### PR TITLE
feat: upgrade Claude model to haiku-4-5 and increase max tokens

### DIFF
--- a/youtube_downloader_telegram.py
+++ b/youtube_downloader_telegram.py
@@ -2034,8 +2034,8 @@ def generate_summary(transcript_text, summary_type):
     
     # Przygotuj dane do żądania
     data = {
-        "model": "claude-3-haiku-20240307",
-        "max_tokens": 4096,
+        "model": "claude-haiku-4-5",
+        "max_tokens": 16384,
         "messages": [
             {
                 "role": "user",


### PR DESCRIPTION
## Summary
- Upgrade Claude model from claude-3-haiku-20240307 to claude-haiku-4-5
- Increase max_tokens from 4096 to 16384 for longer summaries

## Test plan
- [ ] Test summary generation with the new model
- [ ] Verify longer transcriptions are summarized correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches summary generation to `claude-haiku-4-5` and raises `max_tokens` to 16384.
> 
> - **AI Summary Generation (`youtube_downloader_telegram.py`)**:
>   - Update `generate_summary` to use model `claude-haiku-4-5` (from `claude-3-haiku-20240307`).
>   - Increase `max_tokens` from `4096` to `16384` for longer outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6dedd8a8f80bf733ad60b51931817bd06fb2c952. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->