### PR TITLE
docs: add /history command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ python tests/test_json_persistence.py
 | `/start` | Rozpocznij korzystanie z bota |
 | `/help` | Pomoc i instrukcje |
 | `/status` | Sprawdź przestrzeń dyskową i statystyki |
+| `/history` | Historia pobrań i statystyki użytkownika |
 | `/cleanup` | Ręczne usunięcie starych plików |
 | `/users` | Zarządzanie autoryzowanymi użytkownikami |
 


### PR DESCRIPTION
Add missing /history command to the Telegram commands table in README.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation to include the `/history` command in the Telegram bot commands table.
> 
> - Adds `/history` entry describing user download history and stats in `README.md`
> - No code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 560418a5f49dd095e64415f7b0ffe395be0e9d52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->