### PR TITLE
Feature: Time range downloads, history tracking, and CI improvements

### DIFF
--- a/bot/telegram_callbacks.py
+++ b/bot/telegram_callbacks.py
@@ -256,6 +256,16 @@ async def download_file(update: Update, context: ContextTypes.DEFAULT_TYPE, type
 
             if selected_format and selected_format.get('filesize'):
                 size_mb = selected_format['filesize'] / (1024 * 1024)
+
+                # Adjust size estimate for time range (proportional to duration)
+                if time_range and duration > 0:
+                    start_sec = time_range.get('start_sec', 0)
+                    end_sec = time_range.get('end_sec', duration)
+                    range_duration = end_sec - start_sec
+                    if range_duration > 0:
+                        size_mb = size_mb * (range_duration / duration)
+                        logging.info(f"Adjusted size estimate for time range: {size_mb:.1f} MB (original: {selected_format['filesize'] / (1024 * 1024):.1f} MB)")
+
                 if size_mb > MAX_FILE_SIZE_MB:
                     await update_status(
                         f"Wybrany format jest zbyt duży!\n\n"


### PR DESCRIPTION
## Summary

- **Time range selection**: Users can now select specific time ranges for video/audio downloads (e.g., first 5 minutes, custom range)
- **Download history**: Added `/history` command to track and re-download previous files
- **File size fix**: Adjusted file size validation to account for time range selection (proportional estimate)
- **Performance**: Added yt-dlp download speed optimizations and detailed progress updates
- **CI/CD**: Added GitHub Actions workflow with pytest integration
- **Code quality**: Thread safety improvements, test cleanup, and Python 3.12+ requirement

## Test plan

- [ ] Test time range download with a long video (verify partial download works)
- [ ] Test `/history` command shows previous downloads
- [ ] Verify file size check allows partial downloads that would exceed limit as full video
- [ ] Run `pytest` to verify all tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines pre-download file size validation to account for selected time ranges.
> 
> - In `download_file`, computes proportional `size_mb` using `range_duration / duration` when a `time_range` is set and logs the adjusted estimate
> - Prevents rejecting partial downloads that would exceed the limit only at full duration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e2f65bd087711710bdcc6cb4ee2cb2b71da69b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->