### PR TITLE
fix: increase timeouts for long transcriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Bot Telegram do pobierania filmów z YouTube z funkcjami transkrypcji i podsumow
 - Automatyczna transkrypcja audio (Groq API - Whisper Large v3)
 - Generowanie podsumowań transkrypcji (Claude API - Haiku 4.5)
 - Ochrona dostępu kodem PIN
-- Interfejs konsolowy i bot Telegram
+- Interfejs wiersza poleceń (CLI) z pełnym wsparciem dla wyboru formatu, jakości i audio
+- Bot Telegram z interaktywnym menu
 
 ### Bezpieczeństwo
 - Rate limiting - max 10 requestów/minutę per użytkownik
@@ -135,8 +136,37 @@ python main.py
 ```
 
 ### Tryb CLI (interfejs tekstowy)
+
+#### Opcje wiersza poleceń
+
+| Opcja | Opis | Domyślnie |
+|-------|------|-----------|
+| `--cli` | Uruchom w trybie wiersza poleceń (wymagane) | - |
+| `--url <URL>` | URL filmu YouTube | - |
+| `--list-formats` | Wyświetl dostępne formaty bez pobierania | - |
+| `--format <ID>` | Pobierz konkretny format (ID z listy formatów) | najlepsza jakość |
+| `--format auto` | Automatyczny wybór najlepszej jakości | - |
+| `--audio-only` | Pobierz tylko ścieżkę audio | - |
+| `--audio-format <FORMAT>` | Format audio: mp3, m4a, wav, flac, opus, vorbis | mp3 |
+| `--audio-quality <QUALITY>` | Jakość audio (0-9 dla vorbis/opus, 0-330 dla mp3) | 192 |
+
+#### Przykłady użycia
+
 ```bash
-python main.py --cli --url https://youtube.com/watch?v=...
+# Pobierz film w najlepszej jakości
+python main.py --cli --url "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+# Wyświetl dostępne formaty
+python main.py --cli --url "https://www.youtube.com/watch?v=dQw4w9WgXcQ" --list-formats
+
+# Pobierz konkretny format (np. 137 = 1080p)
+python main.py --cli --url "https://www.youtube.com/watch?v=dQw4w9WgXcQ" --format 137
+
+# Pobierz samo audio jako MP3
+python main.py --cli --url "https://www.youtube.com/watch?v=dQw4w9WgXcQ" --audio-only
+
+# Pobierz audio w formacie FLAC z najwyższą jakością
+python main.py --cli --url "https://www.youtube.com/watch?v=dQw4w9WgXcQ" --audio-only --audio-format flac --audio-quality 0
 ```
 
 ### Testy

--- a/bot/telegram_callbacks.py
+++ b/bot/telegram_callbacks.py
@@ -462,7 +462,9 @@ async def download_file(update: Update, context: ContextTypes.DEFAULT_TYPE, type
                         await context.bot.send_message(
                             chat_id=chat_id,
                             text=part,
-                            parse_mode='Markdown'
+                            parse_mode='Markdown',
+                            read_timeout=60,
+                            write_timeout=60,
                         )
 
                     await update_status("Wysyłanie pliku z pełną transkrypcją...")
@@ -472,7 +474,9 @@ async def download_file(update: Update, context: ContextTypes.DEFAULT_TYPE, type
                             chat_id=chat_id,
                             document=f,
                             filename=os.path.basename(transcript_path),
-                            caption=f"Pełna transkrypcja: {title}"
+                            caption=f"Pełna transkrypcja: {title}",
+                            read_timeout=60,
+                            write_timeout=60,
                         )
 
                     # Record transcription+summary in history
@@ -488,7 +492,9 @@ async def download_file(update: Update, context: ContextTypes.DEFAULT_TYPE, type
                         chat_id=chat_id,
                         document=f,
                         filename=os.path.basename(transcript_path),
-                        caption=f"Transkrypcja: {title}"
+                        caption=f"Transkrypcja: {title}",
+                        read_timeout=60,
+                        write_timeout=60,
                     )
 
                 try:
@@ -513,13 +519,17 @@ async def download_file(update: Update, context: ContextTypes.DEFAULT_TYPE, type
                         chat_id=chat_id,
                         audio=f,
                         title=title,
-                        caption=f"{title}"
+                        caption=f"{title}",
+                        read_timeout=60,
+                        write_timeout=60,
                     )
                 else:
                     await context.bot.send_video(
                         chat_id=chat_id,
                         video=f,
-                        caption=f"{title}"
+                        caption=f"{title}",
+                        read_timeout=60,
+                        write_timeout=60,
                     )
 
             os.remove(downloaded_file_path)

--- a/bot/transcription.py
+++ b/bot/transcription.py
@@ -416,7 +416,7 @@ def generate_summary(transcript_text, summary_type):
     }
 
     try:
-        response = requests.post(url, headers=headers, json=data)
+        response = requests.post(url, headers=headers, json=data, timeout=120)
 
         if response.status_code == 200:
             result = response.json()

--- a/main.py
+++ b/main.py
@@ -81,7 +81,14 @@ def main():
     monitor_disk_space()
 
     # Create bot application
-    application = ApplicationBuilder().token(BOT_TOKEN).build()
+    application = (
+        ApplicationBuilder()
+        .token(BOT_TOKEN)
+        .connect_timeout(30)
+        .read_timeout(60)
+        .write_timeout(60)
+        .build()
+    )
 
     # Set bot commands menu
     application.job_queue.run_once(lambda context: set_bot_commands(application), when=1)


### PR DESCRIPTION
## Summary
- Increased Telegram bot timeouts (connect=30s, read/write=60s) to prevent "Timed out" errors when processing ~1 hour videos with transcription + summary
- Added timeout=120s to Claude API call in `generate_summary()` which previously had no timeout
- Added read/write timeouts (60s) to all `send_message`, `send_document`, `send_audio`, `send_video` calls in callback handlers
- Expanded CLI documentation in README with full options table and usage examples

## Test plan
- [ ] Test transcription + detailed summary on a ~1 hour YouTube video
- [ ] Verify no "Timed out" errors during send_document/send_message
- [ ] Verify CLI documentation renders correctly in README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily configuration/documentation changes that adjust network timeouts; functional risk is limited to altering request behavior under slow networks.
> 
> **Overview**
> Reduces timeout failures on long downloads/transcriptions by increasing Telegram client/network timeouts: sets `connect_timeout=30` and `read_timeout`/`write_timeout=60` on the bot `ApplicationBuilder`, and adds 60s read/write timeouts to `send_message`, `send_document`, `send_audio`, and `send_video` calls in `telegram_callbacks`.
> 
> Adds an explicit `timeout=120` to the Claude summarization request in `generate_summary()`, and expands the README’s CLI section with an options table and usage examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbf955abd748e807ec5795d99364b5983b2cf674. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->