### PR TITLE
Audio upload support and transcription improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Bot Telegram do pobierania filmów z YouTube z funkcjami transkrypcji i podsumow
 - Ekstrakcja ścieżek audio (MP3, M4A, FLAC, WAV, Opus)
 - Automatyczna transkrypcja audio (Groq API - Whisper Large v3)
 - Generowanie podsumowań transkrypcji (Claude API - Haiku 4.5)
+- **Transkrypcja przesłanych plików audio** — wiadomości głosowe, pliki audio i dokumenty audio (np. notatki głosowe z WhatsApp)
 - Ochrona dostępu kodem PIN
 - Interfejs wiersza poleceń (CLI) z pełnym wsparciem dla wyboru formatu, jakości i audio
 - Bot Telegram z interaktywnym menu
@@ -191,12 +192,19 @@ python tests/test_json_persistence.py
 
 ## Używanie bota
 
+### Pobieranie z YouTube
 1. Znajdź swojego bota na Telegramie
 2. Wyślij `/start`
 3. Wprowadź 8-cyfrowy kod PIN
 4. Wyślij link do filmu YouTube
 5. Wybierz format i jakość
 6. Opcjonalnie: wybierz transkrypcję lub streszczenie
+
+### Transkrypcja plików audio
+1. Wyślij wiadomość głosową, plik audio lub dokument audio (np. notatkę głosową z WhatsApp)
+2. Wybierz opcję: "Transkrypcja" lub "Transkrypcja + Podsumowanie"
+3. Obsługiwane formaty: OGG, OPUS, MP3, M4A, WAV, FLAC, WebM
+4. Limit rozmiaru: 20 MB (ograniczenie Telegram Bot API)
 
 ## Typy streszczeń
 
@@ -230,7 +238,6 @@ ytdown/
 ├── api_key.md                      # Konfiguracja (ignorowany przez git)
 ├── authorized_users.json           # Lista autoryzowanych użytkowników (ignorowany)
 ├── README.md                       # Ten plik
-├── SECURITY_NOTES.md               # Uwagi bezpieczeństwa
 └── downloads/                      # Pobrane pliki (ignorowany)
     └── [chat_id]/                  # Pliki per użytkownik
 ```
@@ -244,11 +251,10 @@ ytdown/
 - Blokada po złym PIN
 - Autoryzacja zapisywana w JSON
 
-Szczegóły w pliku [SECURITY_NOTES.md](SECURITY_NOTES.md)
-
 ## Ograniczenia
 
 - Max 20MB dla pojedynczej części transkrypcji (większe pliki są dzielone automatycznie)
+- Max 20MB dla przesyłanych plików audio (limit Telegram Bot API dla pobierania plików przez bota)
 - Telegram limit: 50MB dla plików, 4096 znaków dla wiadomości
 - Max 16384 tokenów dla streszczeń Claude
 

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -62,6 +62,7 @@ try:
         handle_youtube_link,
         handle_pin,
         process_youtube_link,
+        handle_audio_upload,
     )
 except ImportError:
     start = None
@@ -72,6 +73,7 @@ except ImportError:
     handle_youtube_link = None
     handle_pin = None
     process_youtube_link = None
+    handle_audio_upload = None
 
 try:
     from bot.telegram_callbacks import (
@@ -80,6 +82,8 @@ try:
         handle_formats_list,
         show_summary_options,
         back_to_main_menu,
+        transcribe_audio_file,
+        show_audio_summary_options,
     )
 except ImportError:
     handle_callback = None
@@ -87,6 +91,8 @@ except ImportError:
     handle_formats_list = None
     show_summary_options = None
     back_to_main_menu = None
+    transcribe_audio_file = None
+    show_audio_summary_options = None
 
 __all__ = [
     # Config
@@ -125,10 +131,13 @@ __all__ = [
     'handle_youtube_link',
     'handle_pin',
     'process_youtube_link',
+    'handle_audio_upload',
     # Telegram callbacks
     'handle_callback',
     'download_file',
     'handle_formats_list',
     'show_summary_options',
     'back_to_main_menu',
+    'transcribe_audio_file',
+    'show_audio_summary_options',
 ]

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -84,6 +84,7 @@ try:
         back_to_main_menu,
         transcribe_audio_file,
         show_audio_summary_options,
+        show_language_selection,
     )
 except ImportError:
     handle_callback = None
@@ -93,6 +94,7 @@ except ImportError:
     back_to_main_menu = None
     transcribe_audio_file = None
     show_audio_summary_options = None
+    show_language_selection = None
 
 __all__ = [
     # Config
@@ -140,4 +142,5 @@ __all__ = [
     'back_to_main_menu',
     'transcribe_audio_file',
     'show_audio_summary_options',
+    'show_language_selection',
 ]

--- a/bot/telegram_callbacks.py
+++ b/bot/telegram_callbacks.py
@@ -547,11 +547,12 @@ async def download_file(update: Update, context: ContextTypes.DEFAULT_TYPE, type
                             display_text = '\n'.join(lines[i:])
                             break
 
-                # Send transcript as message(s) in chat
-                await send_long_message(
-                    context.bot, chat_id, display_text,
-                    header=f"*Transkrypcja: {title}*\n\n"
-                )
+                # Send transcript in chat if short enough, otherwise file only
+                if len(display_text) <= 30000:
+                    await send_long_message(
+                        context.bot, chat_id, display_text,
+                        header=f"*Transkrypcja: {title}*\n\n"
+                    )
 
                 # Send file as attachment
                 with open(transcript_path, 'rb') as f:
@@ -559,7 +560,8 @@ async def download_file(update: Update, context: ContextTypes.DEFAULT_TYPE, type
                         chat_id=chat_id,
                         document=f,
                         filename=os.path.basename(transcript_path),
-                        caption=f"Transkrypcja: {title}",
+                        caption=f"Transkrypcja: {title}" if len(display_text) <= 30000
+                            else f"Transkrypcja: {title} ({len(display_text):,} znaków — tylko plik)",
                         read_timeout=60,
                         write_timeout=60,
                     )
@@ -968,11 +970,12 @@ async def transcribe_audio_file(update: Update, context: ContextTypes.DEFAULT_TY
                     display_text = '\n'.join(lines[i:])
                     break
 
-        # Send transcript as message(s) in chat
-        await send_long_message(
-            context.bot, chat_id, display_text,
-            header=f"*Transkrypcja: {title}*\n\n"
-        )
+        # Send transcript in chat if short enough, otherwise file only
+        if len(display_text) <= 30000:
+            await send_long_message(
+                context.bot, chat_id, display_text,
+                header=f"*Transkrypcja: {title}*\n\n"
+            )
 
         # Send file as attachment
         with open(transcript_path, 'rb') as f:
@@ -980,7 +983,8 @@ async def transcribe_audio_file(update: Update, context: ContextTypes.DEFAULT_TY
                 chat_id=chat_id,
                 document=f,
                 filename=os.path.basename(transcript_path),
-                caption=f"Transkrypcja: {title}",
+                caption=f"Transkrypcja: {title}" if len(display_text) <= 30000
+                    else f"Transkrypcja: {title} ({len(display_text):,} znaków — tylko plik)",
                 read_timeout=60,
                 write_timeout=60,
             )

--- a/bot/telegram_callbacks.py
+++ b/bot/telegram_callbacks.py
@@ -119,6 +119,20 @@ async def handle_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
     data = query.data
 
     chat_id = update.effective_chat.id
+
+    # Audio upload callbacks — handled before URL check because
+    # audio uploads don't require a YouTube URL in the session
+    if data == "audio_transcribe":
+        await transcribe_audio_file(update, context)
+        return
+    elif data == "audio_transcribe_summary":
+        await show_audio_summary_options(update, context)
+        return
+    elif data.startswith("audio_summary_option_"):
+        option = int(data.split('_')[-1])
+        await transcribe_audio_file(update, context, summary=True, summary_type=option)
+        return
+
     url = user_urls.get(chat_id)
 
     if not url:
@@ -755,3 +769,212 @@ async def apply_time_range_preset(update: Update, context: ContextTypes.DEFAULT_
     }
 
     await back_to_main_menu(update, context, url)
+
+
+async def transcribe_audio_file(update: Update, context: ContextTypes.DEFAULT_TYPE, summary=False, summary_type=None):
+    """
+    Transcribes an uploaded audio file (MP3 path stored in user_data).
+
+    Reuses the existing transcription pipeline from transcribe_mp3_file().
+    """
+    query = update.callback_query
+    chat_id = update.effective_chat.id
+
+    mp3_path = context.user_data.get('audio_file_path')
+    title = context.user_data.get('audio_file_title', 'Plik audio')
+
+    if not mp3_path or not os.path.exists(mp3_path):
+        await query.edit_message_text("Plik audio nie został znaleziony. Wyślij go ponownie.")
+        return
+
+    async def update_status(text):
+        await safe_edit_message(query, text)
+
+    chat_download_path = os.path.join(DOWNLOAD_PATH, str(chat_id))
+    file_size_mb = os.path.getsize(mp3_path) / (1024 * 1024)
+
+    await update_status("Rozpoczynanie transkrypcji audio...\nTo może potrwać kilka minut.")
+
+    if not CONFIG["GROQ_API_KEY"]:
+        await update_status(
+            "Błąd: Brak klucza API do transkrypcji w pliku konfiguracyjnym.\n"
+            f"Dodaj klucz GROQ_API_KEY w pliku {CONFIG_FILE_PATH}."
+        )
+        return
+
+    # Progress callback for transcription status updates
+    current_status = {"text": ""}
+
+    def progress_callback(status_text):
+        current_status["text"] = status_text
+
+    async def run_transcription_with_progress():
+        loop = asyncio.get_event_loop()
+        future = loop.run_in_executor(
+            _executor,
+            lambda: transcribe_mp3_file(mp3_path, chat_download_path, progress_callback)
+        )
+
+        last_status = ""
+        while not future.done():
+            if current_status["text"] and current_status["text"] != last_status:
+                last_status = current_status["text"]
+                await update_status(f"Transkrypcja w toku...\n\n{last_status}")
+            await asyncio.sleep(2)
+
+        return await future
+
+    transcript_path = await run_transcription_with_progress()
+
+    if not transcript_path or not os.path.exists(transcript_path):
+        await update_status("Wystąpił błąd podczas transkrypcji.")
+        return
+
+    if summary:
+        if not CONFIG["CLAUDE_API_KEY"]:
+            await update_status(
+                "Błąd: Brak klucza API Claude w pliku konfiguracyjnym.\n"
+                f"Dodaj klucz CLAUDE_API_KEY w pliku {CONFIG_FILE_PATH}."
+            )
+            return
+
+        await update_status("Transkrypcja zakończona.\n\nGeneruję podsumowanie AI...\nTo może potrwać około minuty.")
+
+        with open(transcript_path, 'r', encoding='utf-8') as f:
+            transcript_text = f.read()
+
+        # Strip markdown header if present
+        if transcript_text.startswith('# '):
+            lines = transcript_text.split('\n')
+            for i in range(1, len(lines)):
+                if lines[i].strip():
+                    transcript_text = '\n'.join(lines[i:])
+                    break
+            else:
+                logging.warning("Transcription contains only header, using original text")
+
+        loop = asyncio.get_event_loop()
+        summary_text = await loop.run_in_executor(
+            _executor,
+            lambda: generate_summary(transcript_text, summary_type)
+        )
+
+        if not summary_text:
+            await update_status("Wystąpił błąd podczas generowania podsumowania.")
+            return
+
+        await update_status("Podsumowanie wygenerowane.\n\nWysyłanie wyników...")
+
+        # Save summary file
+        safe_title = "".join(c if c.isalnum() or c in ' -_' else '_' for c in title)[:80]
+        summary_path = os.path.join(chat_download_path, f"{safe_title}_summary.md")
+        with open(summary_path, 'w', encoding='utf-8') as f:
+            summary_types = {
+                1: "Krótkie podsumowanie",
+                2: "Szczegółowe podsumowanie",
+                3: "Podsumowanie w punktach",
+                4: "Podział zadań na osoby"
+            }
+            summary_type_name = summary_types.get(summary_type, "Podsumowanie")
+            f.write(f"# {title} - {summary_type_name}\n\n")
+            f.write(summary_text)
+
+        # Send summary as message(s)
+        with open(summary_path, 'r', encoding='utf-8') as f:
+            summary_content = f.read()
+            if summary_content.startswith('#'):
+                summary_lines = summary_content.split('\n')
+                summary_content = '\n'.join(summary_lines[2:]) if len(summary_lines) > 2 else '\n'.join(summary_lines[1:])
+
+            summary_types = {
+                1: "Krótkie podsumowanie",
+                2: "Szczegółowe podsumowanie",
+                3: "Podsumowanie w punktach",
+                4: "Podział zadań na osoby"
+            }
+            summary_type_name = summary_types.get(summary_type, "Podsumowanie")
+
+            max_length = 4000
+            message_parts = []
+            current_part = f"*{title} - {summary_type_name}*\n\n"
+
+            for line in summary_content.split('\n'):
+                if len(current_part) + len(line) + 2 > max_length:
+                    message_parts.append(current_part)
+                    current_part = line + '\n'
+                else:
+                    current_part += line + '\n'
+
+            if current_part:
+                message_parts.append(current_part)
+
+            for part in message_parts:
+                await context.bot.send_message(
+                    chat_id=chat_id,
+                    text=part,
+                    parse_mode='Markdown',
+                    read_timeout=60,
+                    write_timeout=60,
+                )
+
+            await update_status("Wysyłanie pliku z pełną transkrypcją...")
+
+            with open(transcript_path, 'rb') as f:
+                await context.bot.send_document(
+                    chat_id=chat_id,
+                    document=f,
+                    filename=os.path.basename(transcript_path),
+                    caption=f"Pełna transkrypcja: {title}",
+                    read_timeout=60,
+                    write_timeout=60,
+                )
+
+            add_download_record(chat_id, title, "audio_upload", f"audio_upload_transcription_summary_{summary_type}", file_size_mb, None)
+            await update_status("Transkrypcja i podsumowanie zostały wysłane!")
+
+    else:
+        await update_status("Transkrypcja zakończona.\n\nWysyłanie pliku...")
+
+        with open(transcript_path, 'rb') as f:
+            await context.bot.send_document(
+                chat_id=chat_id,
+                document=f,
+                filename=os.path.basename(transcript_path),
+                caption=f"Transkrypcja: {title}",
+                read_timeout=60,
+                write_timeout=60,
+            )
+
+        # Clean up source MP3 and chunk transcripts
+        try:
+            os.remove(mp3_path)
+            for fname in os.listdir(chat_download_path):
+                if fname.endswith("_transcript.txt") and "_part" in fname:
+                    os.remove(os.path.join(chat_download_path, fname))
+        except Exception as e:
+            logging.error(f"Error deleting audio files: {e}")
+
+        add_download_record(chat_id, title, "audio_upload", "audio_upload_transcription", file_size_mb, None)
+        await update_status("Transkrypcja została wysłana!")
+
+
+async def show_audio_summary_options(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Displays summary type selection for uploaded audio files."""
+    query = update.callback_query
+    title = context.user_data.get('audio_file_title', 'Plik audio')
+
+    keyboard = [
+        [InlineKeyboardButton("1. Krótkie podsumowanie", callback_data="audio_summary_option_1")],
+        [InlineKeyboardButton("2. Szczegółowe podsumowanie", callback_data="audio_summary_option_2")],
+        [InlineKeyboardButton("3. Podsumowanie w punktach", callback_data="audio_summary_option_3")],
+        [InlineKeyboardButton("4. Podział zadań na osoby", callback_data="audio_summary_option_4")],
+    ]
+
+    reply_markup = InlineKeyboardMarkup(keyboard)
+
+    await safe_edit_message(
+        query,
+        f"*{title}*\n\nWybierz rodzaj podsumowania:",
+        reply_markup=reply_markup,
+        parse_mode='Markdown'
+    )

--- a/bot/transcription.py
+++ b/bot/transcription.py
@@ -164,13 +164,15 @@ def split_mp3(file_path, output_dir, max_size_mb=MAX_MP3_PART_SIZE_MB):
     return output_files
 
 
-def transcribe_audio(file_path, api_key):
+def transcribe_audio(file_path, api_key, language=None, prompt=None):
     """
     Transcribes audio file using Groq API.
 
     Args:
         file_path: Path to audio file
         api_key: Groq API key
+        language: ISO 639-1 language code (e.g. "pl", "en") for better accuracy
+        prompt: Context text to guide Whisper (e.g. tail of previous chunk)
 
     Returns:
         str: Transcription text or empty string on error
@@ -207,6 +209,11 @@ def transcribe_audio(file_path, api_key):
                 "response_format": "text"
             }
 
+            if language:
+                data["language"] = language
+            if prompt:
+                data["prompt"] = prompt
+
             response = requests.post(url, headers=headers, files=files, data=data, timeout=300)
 
             if response.status_code == 200:
@@ -242,14 +249,16 @@ def get_part_number(filename):
     return 0
 
 
-def transcribe_mp3_file(file_path, output_dir, progress_callback=None):
+def transcribe_mp3_file(file_path, output_dir, progress_callback=None, language=None):
     """
     Transcribes MP3 file, splitting into smaller parts if necessary.
+    Uses cross-chunk context (prompt) and optional Claude post-processing.
 
     Args:
         file_path: Path to MP3 file
         output_dir: Output directory for transcription
-        progress_callback: Optional async callback function(status_text) for progress updates
+        progress_callback: Optional callback function(status_text) for progress updates
+        language: ISO 639-1 language code ("pl", "en") or None for auto-detect
 
     Returns:
         str or None: Path to transcription file or None on error
@@ -277,6 +286,7 @@ def transcribe_mp3_file(file_path, output_dir, progress_callback=None):
     total_parts = len(part_files)
     total_characters = 0
     start_time = time_module.time()
+    previous_text = ""
     logging.info(f"Found {total_parts} part files to transcribe.")
 
     base_name = os.path.splitext(os.path.basename(file_path))[0]
@@ -305,12 +315,16 @@ def transcribe_mp3_file(file_path, output_dir, progress_callback=None):
                 f"Pozostały czas: ~{eta_str}"
             )
 
-        transcription = transcribe_audio(part_path, api_key)
+        # Pass tail of previous chunk as prompt for cross-chunk context
+        chunk_prompt = previous_text[-500:] if previous_text else None
+
+        transcription = transcribe_audio(part_path, api_key, language=language, prompt=chunk_prompt)
 
         if transcription:
             logging.info(f"Part {i+1}: transcription has {len(transcription)} characters")
             transcriptions.append(transcription)
             total_characters += len(transcription)
+            previous_text = transcription
         else:
             logging.warning(f"Part {i+1}: transcription is empty!")
             transcriptions.append("[No transcription for this part]")
@@ -357,6 +371,17 @@ def transcribe_mp3_file(file_path, output_dir, progress_callback=None):
 
         return transcript_md_path
 
+    # Post-process transcript with Claude to fix typos and incomplete words
+    if get_claude_api_key():
+        if progress_callback:
+            progress_callback("Korekta transkrypcji przez AI...")
+        corrected = post_process_transcript(combined_text)
+        if corrected:
+            combined_text = corrected
+            logging.info(f"Post-processed transcript: {len(combined_text)} characters")
+    else:
+        logging.info("Skipping post-processing: no Claude API key configured")
+
     transcript_md_path = os.path.join(output_dir, f"{base_name}_transcript.md")
     with open(transcript_md_path, "w", encoding="utf-8") as f:
         f.write(f"# {base_name} Transcript\n\n")
@@ -370,6 +395,75 @@ def transcribe_mp3_file(file_path, output_dir, progress_callback=None):
         logging.error(f"Error removing temporary directory: {e}")
 
     return transcript_md_path
+
+
+def post_process_transcript(text):
+    """
+    Cleans up raw Whisper transcription using Claude API.
+
+    Fixes typos, incomplete words, and punctuation errors while
+    preserving the original meaning and structure of the text.
+
+    Args:
+        text: Raw transcription text
+
+    Returns:
+        str or None: Corrected text, or None on error
+    """
+    api_key = get_claude_api_key()
+    if not api_key:
+        return None
+
+    url = "https://api.anthropic.com/v1/messages"
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json"
+    }
+
+    data = {
+        "model": "claude-haiku-4-5",
+        "max_tokens": 32768,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "You are a transcription proofreader. Fix the following audio transcript:\n"
+                    "- Fix typos and spelling errors\n"
+                    "- Complete truncated or incomplete words\n"
+                    "- Fix punctuation\n"
+                    "- Do NOT change the meaning or structure\n"
+                    "- Do NOT add new content or commentary\n"
+                    "- Do NOT add any headers, labels or prefixes\n"
+                    "- Preserve the original language of the text\n"
+                    "- Return ONLY the corrected text, nothing else\n\n"
+                    f"{text}"
+                )
+            }
+        ]
+    }
+
+    try:
+        response = requests.post(url, headers=headers, json=data, timeout=180)
+
+        if response.status_code == 200:
+            result = response.json()
+            corrected = ""
+            if "content" in result:
+                for item in result["content"]:
+                    if item.get("type") == "text":
+                        corrected += item.get("text", "")
+            if corrected.strip():
+                return corrected.strip()
+            logging.warning("Post-processing returned empty result, using original text")
+            return None
+        else:
+            logging.error(f"Claude API error during post-processing: {response.status_code}")
+            logging.error(response.text)
+            return None
+    except Exception as e:
+        logging.error(f"Error during transcript post-processing: {e}")
+        return None
 
 
 def generate_summary(transcript_text, summary_type):

--- a/bot/transcription.py
+++ b/bot/transcription.py
@@ -205,7 +205,7 @@ def transcribe_audio(file_path, api_key, language=None, prompt=None):
                 "file": (filename, audio_file.read(), "audio/mpeg")
             }
             data = {
-                "model": "whisper-large-v3",
+                "model": "whisper-large-v3-turbo",
                 "response_format": "text"
             }
 

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ from bot.telegram_commands import (
     cleanup_command,
     users_command,
     handle_youtube_link,
+    handle_audio_upload,
 )
 from bot.telegram_callbacks import handle_callback
 
@@ -103,6 +104,21 @@ def main():
 
     # Handler for text messages (including PIN and links)
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_youtube_link))
+
+    # Handlers for audio uploads (voice messages, audio files, audio documents)
+    application.add_handler(MessageHandler(filters.VOICE, handle_audio_upload))
+    application.add_handler(MessageHandler(filters.AUDIO, handle_audio_upload))
+    audio_doc_filter = (
+        filters.Document.MimeType("audio/ogg")
+        | filters.Document.MimeType("audio/mpeg")
+        | filters.Document.MimeType("audio/mp4")
+        | filters.Document.MimeType("audio/x-m4a")
+        | filters.Document.MimeType("audio/wav")
+        | filters.Document.MimeType("audio/flac")
+        | filters.Document.MimeType("audio/opus")
+        | filters.Document.MimeType("audio/webm")
+    )
+    application.add_handler(MessageHandler(audio_doc_filter, handle_audio_upload))
 
     application.add_handler(CallbackQueryHandler(handle_callback))
 


### PR DESCRIPTION
## Summary
- **Audio file uploads**: Users can send voice messages, audio files, and forwarded WhatsApp voice notes directly to the bot for transcription and summarization (OGG, MP3, M4A, WAV, FLAC, OPUS, WebM)
- **Transcription quality improvements**: Language selection (PL/EN), cross-chunk context via Whisper prompt parameter, Claude-based post-processing to fix typos and incomplete words
- **Inline transcript display**: Transcriptions are shown directly in the Telegram chat (up to 30k chars), with file attachment always included
- **Whisper model upgrade**: Switched from `whisper-large-v3` to `whisper-large-v3-turbo` (~3x cheaper, faster)
- **Long message fix**: `send_long_message()` now handles lines >4000 chars by splitting at sentence boundaries

## Test plan
- [x] Existing tests pass (57/58, 1 pre-existing async test issue)
- [ ] Send a Telegram voice message → should offer transcription options
- [ ] Send an MP3 file as audio → should offer transcription options
- [ ] Forward a WhatsApp voice note → should offer transcription options
- [ ] Test PIN flow: send audio while unauthenticated → enter PIN → audio should process
- [ ] Test language selection (PL/EN) before transcription
- [ ] Test transcription + summary flow end-to-end
- [ ] Verify long transcripts (>30k chars) are sent as file-only
- [ ] Verify short transcripts are displayed inline in chat

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new file ingestion/conversion paths (`ffmpeg` subprocess, Telegram file downloads) and modifies the core transcription flow, which can impact reliability and resource usage despite limited security exposure.
> 
> **Overview**
> Adds an **audio-upload transcription flow**: the bot now accepts voice messages/audio files/audio documents, downloads and (if needed) converts them to MP3 via `ffmpeg`, enforces Telegram’s ~20MB bot download limit, then offers transcription or transcription+summary options via new callback paths.
> 
> Improves the **transcription pipeline** for both YouTube and uploaded audio by adding PL/EN language selection, passing cross-chunk context via Whisper `prompt`, switching Groq to `whisper-large-v3-turbo`, and optionally post-processing the combined transcript with Claude to fix typos/punctuation. Output sending is updated to reliably split long messages (`send_long_message`) and to inline-display transcripts up to ~30k chars while always attaching the transcript file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72fafd394253b733247fb952027c60ec2eb8a50d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->