### PR TITLE
Add dynamic token limits, README improvements, and test fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,17 +118,6 @@ ADMIN_CHAT_ID=twój_telegram_user_id
 
 **UWAGA**: Plik `api_key.md` jest ignorowany przez git - nie commituj go do repozytorium!
 
-### Opcja 4: Cookies YouTube (wymagane przy blokadzie anty-botowej)
-
-Jeśli YouTube blokuje pobieranie komunikatem "Sign in to confirm you're not a bot", potrzebny jest plik `cookies.txt`:
-
-1. Zainstaluj rozszerzenie **"Get cookies.txt LOCALLY"** w przeglądarce (Chrome/Firefox)
-2. Wejdź na youtube.com (zalogowany na konto Google)
-3. Wyeksportuj cookies do pliku `cookies.txt`
-4. Umieść plik w głównym katalogu projektu (`ytdown/cookies.txt`)
-
-**UWAGA**: Plik `cookies.txt` zawiera dane sesji YouTube — nie udostępniaj go i nie commituj do repozytorium! Jest ignorowany przez git.
-
 ### Opcja 3: Zmienne środowiskowe (najbezpieczniejsze)
 
 **Linux/macOS/WSL:**
@@ -148,6 +137,27 @@ $env:CLAUDE_API_KEY="twój_klucz"
 $env:PIN_CODE="12345678"
 $env:ADMIN_CHAT_ID="twój_telegram_user_id"
 ```
+
+### Jak uzyskać ADMIN_CHAT_ID?
+
+`ADMIN_CHAT_ID` to Twój numeryczny identyfikator użytkownika Telegram. Bot wysyła na ten ID powiadomienia o nieudanych próbach logowania i blokadach. Aby go poznać:
+
+1. Napisz do bota [@userinfobot](https://t.me/userinfobot) na Telegramie
+2. Bot odpowie Twoim ID (np. `123456789`)
+3. Wpisz ten numer jako `ADMIN_CHAT_ID` w konfiguracji
+
+Parametr jest opcjonalny — bez niego bot działa normalnie, ale nie wysyła powiadomień bezpieczeństwa.
+
+### Cookies YouTube (opcjonalne, przy blokadzie anty-botowej)
+
+Jeśli YouTube blokuje pobieranie komunikatem "Sign in to confirm you're not a bot", potrzebny jest plik `cookies.txt`:
+
+1. Zainstaluj rozszerzenie **"Get cookies.txt LOCALLY"** w przeglądarce (Chrome/Firefox)
+2. Wejdź na youtube.com (zalogowany na konto Google)
+3. Wyeksportuj cookies do pliku `cookies.txt`
+4. Umieść plik w głównym katalogu projektu (`ytdown/cookies.txt`)
+
+**UWAGA**: Plik `cookies.txt` zawiera dane sesji YouTube — nie udostępniaj go i nie commituj do repozytorium! Jest ignorowany przez git.
 
 ## Uruchomienie
 
@@ -199,14 +209,15 @@ python main.py --cli --url "https://www.youtube.com/watch?v=dQw4w9WgXcQ" --start
 
 ### Testy
 ```bash
+# Uruchom wszystkie testy
 python -m pytest tests/
-# lub pojedyncze testy:
-python tests/test_security.py
-python tests/test_security_standalone.py
-python tests/test_json_persistence.py
-```
 
-Jeśli używasz testów asynchronicznych, upewnij się, że masz zainstalowany `pytest-asyncio`.
+# Uruchom z widocznym postępem
+python -m pytest tests/ -v
+
+# Uruchom konkretny plik testowy
+python -m pytest tests/test_subtitles.py -v
+```
 
 ## Komendy bota Telegram
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,9 @@ ytdown/
 - Max 20MB dla pojedynczej części transkrypcji (większe pliki są dzielone automatycznie)
 - Max 20MB dla przesyłanych plików audio (limit Telegram Bot API dla pobierania plików przez bota)
 - Telegram limit: 50MB dla plików, 4096 znaków dla wiadomości
-- Max 16384 tokenów dla streszczeń Claude
+- Korekta AI transkrypcji: do ~4.5h materiału audio (powyżej automatycznie pomijana)
+- Podsumowanie AI: do ~14h materiału audio (powyżej automatycznie pomijane)
+- Sama transkrypcja (Whisper) i napisy YouTube działają bez limitu długości
 
 ## Rozwiązywanie problemów
 

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -34,10 +34,16 @@ try:
     from bot.transcription import (
         transcribe_mp3_file,
         generate_summary,
+        estimate_token_count,
+        is_text_too_long_for_correction,
+        is_text_too_long_for_summary,
     )
 except ImportError:
     transcribe_mp3_file = None
     generate_summary = None
+    estimate_token_count = None
+    is_text_too_long_for_correction = None
+    is_text_too_long_for_summary = None
 
 try:
     from bot.downloader import (

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -508,6 +508,7 @@ class TestStatusAndStatsCommands:
         context = _make_context()
 
         monkeypatch.setattr(tc, "authorized_users", {1, 2, 111})
+        monkeypatch.setattr(tc, "ADMIN_CHAT_ID", "111")
 
         _async(tc.users_command(update, context))
 
@@ -673,6 +674,7 @@ class TestUsersCommand:
         context = _make_context()
 
         monkeypatch.setattr(tc, "authorized_users", {user_id, *range(1, 11)})
+        monkeypatch.setattr(tc, "ADMIN_CHAT_ID", "111")
 
         _async(tc.users_command(update, context))
 


### PR DESCRIPTION
## Summary
- **Dynamic token limits**: AI processing (correction/summary) now uses dynamic `max_tokens` based on input length instead of fixed values. Correction skipped for texts >50k tokens (~4.5h speech), summaries skipped for >175k tokens (~14h speech) — graceful fallback sends raw transcript with explanation.
- **README improvements**: Added ADMIN_CHAT_ID setup instructions (via @userinfobot), fixed config section numbering, updated test commands and limitations section with accurate thresholds.
- **Test fix**: Added missing `ADMIN_CHAT_ID` mock in `/users` command tests.

## Changes
- `bot/transcription.py` — token estimation helpers, length guards, dynamic max_tokens and timeouts
- `bot/telegram_callbacks.py` — duration warnings, pre-checks before AI processing
- `bot/__init__.py` — new exports
- `tests/test_transcription.py` — 12 new tests for token limits
- `tests/test_telegram_commands.py` — ADMIN_CHAT_ID mock fix
- `README.md` — ADMIN_CHAT_ID instructions, config section reorder, updated limitations

## Test plan
- [x] All 286 tests pass
- [ ] Verify transcription of long videos gracefully skips correction/summary
- [ ] Verify README renders correctly on GitHub