### PR TITLE
Fix subtitle callback parsing, admin notifications, and history records

### DIFF
--- a/bot/security.py
+++ b/bot/security.py
@@ -206,11 +206,13 @@ def register_pin_failure(
     block_map: DefaultDict[int, float] | None = None,
     max_attempts: int = MAX_ATTEMPTS,
     block_time: int = BLOCK_TIME,
-) -> int:
+) -> tuple[int, int]:
     """
     Increments failed PIN attempts and optionally sets block time.
 
-    Returns remaining attempts until block (0 when blocked now).
+    Returns:
+        tuple: (remaining_attempts, actual_attempt_number).
+            remaining is 0 when blocked.
     """
 
     attempts_map = _as_attempt_map(attempts)
@@ -226,13 +228,13 @@ def register_pin_failure(
             "User %s BLOCKED after %d failed PIN attempts",
             user_id, current_attempt,
         )
-        return 0
+        return (0, current_attempt)
 
     logging.warning(
         "Failed PIN attempt for user %s (attempt %d/%d)",
         user_id, current_attempt, max_attempts,
     )
-    return max_attempts - current_attempt
+    return (max_attempts - current_attempt, current_attempt)
 
 
 def validate_youtube_url(url):

--- a/bot/telegram_commands.py
+++ b/bot/telegram_commands.py
@@ -243,7 +243,7 @@ async def handle_pin(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     await process_audio_file(update, context, pending_audio)
             else:
                 # Increment failed attempts counter
-                remaining_attempts = register_pin_failure(
+                remaining_attempts, attempt_count = register_pin_failure(
                     user_id,
                     attempts=failed_attempts,
                     block_map=block_until,
@@ -251,8 +251,6 @@ async def handle_pin(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     block_time=BLOCK_TIME,
                 )
 
-                # Determine attempt count for notification
-                attempt_count = MAX_ATTEMPTS - remaining_attempts
                 blocked = remaining_attempts == 0
 
                 # Notify admin (non-blocking)

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -14,6 +14,7 @@ from bot.downloader import (
     download_subtitles,
     parse_subtitle_file,
 )
+from bot.telegram_callbacks import _parse_subtitle_callback
 
 
 # --- get_available_subtitles tests ---
@@ -448,3 +449,47 @@ class TestDownloadSubtitles:
             title="Test"
         )
         assert result == sub_file
+
+
+# --- _parse_subtitle_callback tests ---
+
+
+class TestParseSubtitleCallback:
+    """Tests for _parse_subtitle_callback() — callback data parsing."""
+
+    def test_manual_lang_no_summary(self):
+        assert _parse_subtitle_callback("sub_lang_en") == ("en", False, False)
+
+    def test_manual_lang_with_summary(self):
+        assert _parse_subtitle_callback("sub_lang_en_sum") == ("en", False, True)
+
+    def test_auto_lang_no_summary(self):
+        assert _parse_subtitle_callback("sub_auto_pl") == ("pl", True, False)
+
+    def test_auto_lang_with_summary(self):
+        assert _parse_subtitle_callback("sub_auto_pl_sum") == ("pl", True, True)
+
+    def test_lang_ending_in_s_no_summary(self):
+        """Spanish (es) must work without summary — was broken by '_s' suffix."""
+        assert _parse_subtitle_callback("sub_lang_es") == ("es", False, False)
+
+    def test_lang_ending_in_s_with_summary(self):
+        """Spanish (es) must work with summary."""
+        assert _parse_subtitle_callback("sub_lang_es_sum") == ("es", False, True)
+
+    def test_auto_lang_ending_in_s_no_summary(self):
+        """Auto Malay (ms) without summary."""
+        assert _parse_subtitle_callback("sub_auto_ms") == ("ms", True, False)
+
+    def test_auto_lang_ending_in_s_with_summary(self):
+        """Auto Bosnian (bs) with summary."""
+        assert _parse_subtitle_callback("sub_auto_bs_sum") == ("bs", True, True)
+
+    def test_invalid_prefix(self):
+        assert _parse_subtitle_callback("sub_unknown_en") is None
+
+    def test_empty_lang(self):
+        assert _parse_subtitle_callback("sub_lang_") is None
+
+    def test_empty_lang_with_summary(self):
+        assert _parse_subtitle_callback("sub_lang__sum") is None

--- a/tests/test_telegram_callbacks.py
+++ b/tests/test_telegram_callbacks.py
@@ -184,9 +184,9 @@ def test_handle_callback_sub_src_ai_starts_download(monkeypatch):
 
 
 def test_handle_callback_sub_src_ai_s_shows_summary_options(monkeypatch):
-    """sub_src_ai_s callback shows summary options."""
+    """sub_src_ai_sum callback shows summary options."""
     tc.user_urls[333] = "https://www.youtube.com/watch?v=abc"
-    update = _make_update("sub_src_ai_s", chat_id=333)
+    update = _make_update("sub_src_ai_sum", chat_id=333)
     context = _make_context()
 
     shown = {}


### PR DESCRIPTION
## Summary
- **Subtitle callback parsing**: Change suffix from `_s` to `_sum` to fix ambiguity with language codes ending in 's' (es, ms, bs, is). These languages were completely non-functional.
- **Admin notification accuracy**: `register_pin_failure` now returns `(remaining, actual_attempt)` tuple so admin notifications show the real attempt count even after repeated blocks.
- **Duplicate history prevention**: `download_file` tracks `success_recorded` flag to prevent false failure records when exceptions occur after success was already logged.
- **Subtitle file cleanup**: Raw VTT/SRT files now cleaned up in the summary download path (was missing).
- **11 new tests** for `_parse_subtitle_callback` covering language codes ending in 's'.

## Test plan
- [x] All 298 tests pass
- [x] Verified `_parse_subtitle_callback("sub_lang_es")` returns correct result
- [x] Verified `register_pin_failure` returns actual attempt count after re-block

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to callback parsing and bookkeeping (PIN attempt counts and history recording) with added test coverage; minimal impact on core download/transcription behavior.
> 
> **Overview**
> Fixes subtitle callback parsing by changing the summary suffix from `_s` to `_sum`, updating routing/parsing so language codes ending in `s` (e.g. `es`, `ms`, `bs`) no longer collide and break subtitle selection.
> 
> Improves PIN failure tracking by having `register_pin_failure` return `(remaining_attempts, actual_attempt_number)`, and updates the PIN handler to use the real attempt count in admin notifications.
> 
> Prevents duplicate/incorrect download history entries by guarding success vs failure recording in `download_file`, and adds cleanup of raw downloaded subtitle files after sending results. Tests are updated/added to cover the new callback parsing and PIN failure return semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d87e1d10b29c3dddbdbac1b348344e77e9bc5be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->