### PR TITLE
Add MTProto large-file upload, free-form URL extraction, medium quality option, H.264 preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ ytdown/
 │       ├── spotify_service.py      # Resolving odcinków Spotify (iTunes/YouTube)
 │       └── transcription_service.py # Artefakty transkrypcji i podsumowań
 ├── setup_config.py                 # Narzędzie konfiguracyjne
-├── tests/                          # Testy (~583 testów)
+├── tests/                          # Testy (~591 testów)
 │   ├── conftest.py                 # Współdzielone fixtures
 │   ├── test_security.py            # Testy bezpieczeństwa
 │   ├── test_security_unit.py       # Testy PIN, blokowania, security reset

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Bot Telegram do pobierania video/audio z YouTube, Vimeo, TikTok, Instagram i Lin
 
 - Python 3.11+
 - ffmpeg (zainstalowany w systemie)
+- deno (wymagany przez yt-dlp do rozwiązywania YouTube JS challenges)
 - Poetry (opcjonalnie, zalecane) lub pip
 
 ### Zależności opcjonalne
@@ -111,6 +112,16 @@ Jeśli chcesz obsługi MTProto lub zdjęć/karuzel z Instagrama, doinstaluj rów
 ```bash
 pip install instaloader
 ```
+
+### Instalacja deno
+
+Deno jest wymagany przez yt-dlp jako JavaScript runtime do rozwiązywania YouTube JS challenges (szyfrowanie podpisów URL i n-parameter). Bez niego część filmów YouTube zwróci błąd "This video is not available".
+
+```bash
+curl -fsSL https://deno.land/install.sh | sh
+```
+
+Po instalacji upewnij się, że `~/.deno/bin` jest w PATH.
 
 ### Instalacja ffmpeg
 
@@ -394,7 +405,7 @@ ytdown/
 │       ├── spotify_service.py      # Resolving odcinków Spotify (iTunes/YouTube)
 │       └── transcription_service.py # Artefakty transkrypcji i podsumowań
 ├── setup_config.py                 # Narzędzie konfiguracyjne
-├── tests/                          # Testy (~575 testów)
+├── tests/                          # Testy (~583 testów)
 │   ├── conftest.py                 # Współdzielone fixtures
 │   ├── test_security.py            # Testy bezpieczeństwa
 │   ├── test_security_unit.py       # Testy PIN, blokowania, security reset
@@ -455,6 +466,7 @@ ytdown/
 - Sama transkrypcja (Whisper) i napisy YouTube działają bez limitu długości
 - Instagram, LinkedIn, TikTok mogą wymagać cookies.txt do pobierania
 - Instagram zdjęcia/karuzele wymagają instaloader z ważną sesją w cookies.txt
+- YouTube wymaga deno jako JS runtime — bez niego część filmów zwróci "This video is not available"
 
 ## Rozwiązywanie problemów
 
@@ -462,6 +474,11 @@ ytdown/
 - Sprawdź czy token jest poprawny
 - Sprawdź połączenie internetowe
 - Sprawdź logi w konsoli
+
+**"This video is not available" dla filmów YouTube:**
+- Upewnij się, że deno jest zainstalowany i dostępny w PATH (`deno --version`)
+- Zaktualizuj yt-dlp do najnowszej wersji (`pip install --upgrade yt-dlp`)
+- YouTube wymaga JS runtime do rozwiązywania challenges — bez deno część filmów nie zadziała
 
 **Błąd transkrypcji:**
 - Sprawdź klucz API Groq

--- a/bot/config.py
+++ b/bot/config.py
@@ -43,6 +43,9 @@ DOWNLOAD_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__f
 # Path to cookies file used by yt-dlp
 COOKIES_FILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "cookies.txt")
 
+# Remote components for yt-dlp YouTube JS challenge solving (signature + n-parameter)
+YTDLP_REMOTE_COMPONENTS = ['ejs:github']
+
 # Path to authorized users file
 AUTHORIZED_USERS_FILE = "authorized_users.json"
 

--- a/bot/downloader_core.py
+++ b/bot/downloader_core.py
@@ -14,7 +14,7 @@ from datetime import datetime
 
 import yt_dlp
 
-from bot.config import COOKIES_FILE
+from bot.config import COOKIES_FILE, YTDLP_REMOTE_COMPONENTS
 from bot.downloader_validation import (
     is_valid_audio_format,
     is_valid_audio_quality,
@@ -48,6 +48,7 @@ def get_basic_ydl_opts(*, include_progress_hooks: bool = False):
     opts = {
         'quiet': True,
         'no_warnings': True,
+        'remote_components': YTDLP_REMOTE_COMPONENTS,
     }
     if include_progress_hooks:
         opts['progress_hooks'] = [progress_hook]
@@ -122,6 +123,7 @@ def download_youtube_video(
             'socket_timeout': 30,
             'retries': 3,
             'fragment_retries': 3,
+            'remote_components': YTDLP_REMOTE_COMPONENTS,
         }
         if os.path.exists(COOKIES_FILE):
             ydl_opts['cookiefile'] = COOKIES_FILE

--- a/bot/downloader_media.py
+++ b/bot/downloader_media.py
@@ -10,7 +10,7 @@ from io import BytesIO
 import requests
 import yt_dlp
 
-from bot.config import COOKIES_FILE
+from bot.config import COOKIES_FILE, YTDLP_REMOTE_COMPONENTS
 from bot.downloader_validation import sanitize_filename
 
 IMAGE_EXTENSIONS = {'jpg', 'jpeg', 'png', 'webp'}
@@ -66,6 +66,7 @@ def _get_instagram_post_info_ytdlp(url: str, *, cookies_file: str | None = COOKI
             'quiet': True,
             'no_warnings': True,
             'ignore_no_formats_error': True,
+            'remote_components': YTDLP_REMOTE_COMPONENTS,
         }
         if cookies_file and os.path.exists(cookies_file):
             ydl_opts['cookiefile'] = cookies_file

--- a/bot/downloader_metadata.py
+++ b/bot/downloader_metadata.py
@@ -7,7 +7,7 @@ import os
 
 import yt_dlp
 
-from bot.config import COOKIES_FILE
+from bot.config import COOKIES_FILE, YTDLP_REMOTE_COMPONENTS
 
 
 def get_video_info(url: str, *, cookies_file: str | None = COOKIES_FILE) -> dict | None:
@@ -18,6 +18,7 @@ def get_video_info(url: str, *, cookies_file: str | None = COOKIES_FILE) -> dict
             'quiet': True,
             'no_warnings': True,
             'noplaylist': True,
+            'remote_components': YTDLP_REMOTE_COMPONENTS,
         }
         if cookies_file and os.path.exists(cookies_file):
             ydl_opts['cookiefile'] = cookies_file

--- a/bot/downloader_playlist.py
+++ b/bot/downloader_playlist.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qs, urlparse
 
 import yt_dlp
 
-from bot.config import COOKIES_FILE
+from bot.config import COOKIES_FILE, YTDLP_REMOTE_COMPONENTS
 
 
 def is_playlist_url(url: str) -> bool:
@@ -67,6 +67,7 @@ def get_playlist_info(url: str, max_items: int = 10) -> dict | None:
             'quiet': True,
             'no_warnings': True,
             'playlistend': max_items,
+            'remote_components': YTDLP_REMOTE_COMPONENTS,
         }
         if os.path.exists(COOKIES_FILE):
             ydl_opts['cookiefile'] = COOKIES_FILE

--- a/bot/downloader_subtitles.py
+++ b/bot/downloader_subtitles.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 import yt_dlp
 
-from bot.config import COOKIES_FILE
+from bot.config import COOKIES_FILE, YTDLP_REMOTE_COMPONENTS
 from bot.downloader_validation import sanitize_filename
 
 
@@ -80,6 +80,7 @@ def download_subtitles(url, lang, output_dir, auto=False, title=""):
             'outtmpl': f"{output_template}.%(ext)s",
             'quiet': True,
             'no_warnings': True,
+            'remote_components': YTDLP_REMOTE_COMPONENTS,
         }
         if os.path.exists(COOKIES_FILE):
             ydl_opts['cookiefile'] = COOKIES_FILE

--- a/bot/downloader_validation.py
+++ b/bot/downloader_validation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 
 FORMAT_ID_PATTERN = re.compile(
-    r"^(?:best|worst|bestvideo|bestaudio|worstaudio|worstvideo)$|^(?:\d+[pP]?)$|^(?:\d+(?:[+x]\d+){0,3})$|^(?:dash-[\da-zA-Z]+)$|^(?:[\da-zA-Z]+-\d+)$"
+    r"^(?:best|worst|bestvideo|bestaudio|worstaudio|worstvideo|medium)$|^(?:\d+[pP]?)$|^(?:\d+(?:[+x]\d+){0,3})$|^(?:dash-[\da-zA-Z]+)$|^(?:[\da-zA-Z]+-\d+)$"
 )
 SUPPORTED_AUDIO_FORMATS = ("mp3", "m4a", "wav", "flac", "ogg", "opus")
 AUDIO_FORMATS = set(SUPPORTED_AUDIO_FORMATS)

--- a/bot/handlers/common_ui.py
+++ b/bot/handlers/common_ui.py
@@ -43,7 +43,8 @@ def build_main_keyboard(platform: str, large_file: bool = False) -> list:
         ]
     else:
         keyboard = [
-            [InlineKeyboardButton("Najlepsza jakość video", callback_data="dl_video_best")],
+            [InlineKeyboardButton("Video — najwyższa (do 4K/2160p)", callback_data="dl_video_best")],
+            [InlineKeyboardButton("Video — średnia (720p HD)", callback_data="dl_video_medium")],
             [InlineKeyboardButton("Audio (MP3)", callback_data="dl_audio_mp3")],
             [InlineKeyboardButton("Audio (M4A)", callback_data="dl_audio_m4a")],
         ]

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -22,7 +22,7 @@ from bot.handlers.common_ui import (
     safe_edit_message,
     send_long_message,
 )
-from bot.security_limits import MAX_FILE_SIZE_MB, MAX_PLAYLIST_ITEMS, MAX_PLAYLIST_ITEMS_EXPANDED
+from bot.security_limits import MAX_FILE_SIZE_MB, MAX_PLAYLIST_ITEMS, MAX_PLAYLIST_ITEMS_EXPANDED, TELEGRAM_UPLOAD_LIMIT_MB
 from bot.security_policy import get_media_label, normalize_url
 from bot.session_context import (
     clear_session_context_value as _clear_session_context_value,
@@ -511,34 +511,51 @@ async def download_file(
                 success_recorded = True
                 await update_status("Transkrypcja została wysłana!")
         else:
-            await update_status(f"Pobieranie zakończone ({file_size_mb:.1f} MB).\n\nWysyłanie pliku do Telegram...")
+            use_mtproto = file_size_mb > TELEGRAM_UPLOAD_LIMIT_MB
+            method_label = " (MTProto)" if use_mtproto else ""
+            await update_status(f"Pobieranie zakończone ({file_size_mb:.1f} MB).\n\nWysyłanie pliku do Telegram...{method_label}")
             thumb_path = await asyncio.get_event_loop().run_in_executor(_executor, download_thumbnail, info, chat_download_path, True)
             try:
-                with open(downloaded_file_path, "rb") as file_obj:
-                    thumb_file = open(thumb_path, "rb") if thumb_path else None
-                    try:
-                        if media_type == "audio":
-                            await context.bot.send_audio(
-                                chat_id=chat_id,
-                                audio=file_obj,
-                                title=title,
-                                caption=title,
-                                thumbnail=thumb_file,
-                                read_timeout=60,
-                                write_timeout=60,
-                            )
-                        else:
-                            await context.bot.send_video(
-                                chat_id=chat_id,
-                                video=file_obj,
-                                caption=title,
-                                thumbnail=thumb_file,
-                                read_timeout=60,
-                                write_timeout=60,
-                            )
-                    finally:
-                        if thumb_file:
-                            thumb_file.close()
+                if use_mtproto:
+                    from bot.mtproto import is_mtproto_available, send_audio_mtproto, send_video_mtproto
+
+                    if not is_mtproto_available():
+                        raise RuntimeError(
+                            f"Plik za duży dla Bot API ({file_size_mb:.0f} MB, limit: {TELEGRAM_UPLOAD_LIMIT_MB} MB).\n"
+                            f"Skonfiguruj TELEGRAM_API_ID i TELEGRAM_API_HASH aby wysyłać większe pliki."
+                        )
+                    if media_type == "audio":
+                        ok = await send_audio_mtproto(chat_id, downloaded_file_path, title=title, caption=title, thumb_path=thumb_path)
+                    else:
+                        ok = await send_video_mtproto(chat_id, downloaded_file_path, caption=title, thumb_path=thumb_path)
+                    if not ok:
+                        raise RuntimeError("Wysyłanie pliku przez MTProto nie powiodło się.")
+                else:
+                    with open(downloaded_file_path, "rb") as file_obj:
+                        thumb_file = open(thumb_path, "rb") if thumb_path else None
+                        try:
+                            if media_type == "audio":
+                                await context.bot.send_audio(
+                                    chat_id=chat_id,
+                                    audio=file_obj,
+                                    title=title,
+                                    caption=title,
+                                    thumbnail=thumb_file,
+                                    read_timeout=60,
+                                    write_timeout=60,
+                                )
+                            else:
+                                await context.bot.send_video(
+                                    chat_id=chat_id,
+                                    video=file_obj,
+                                    caption=title,
+                                    thumbnail=thumb_file,
+                                    read_timeout=60,
+                                    write_timeout=60,
+                                )
+                        finally:
+                            if thumb_file:
+                                thumb_file.close()
             finally:
                 if thumb_path and os.path.exists(thumb_path):
                     try:
@@ -610,8 +627,7 @@ async def _download_single_playlist_item(context, chat_id, url, title, media_typ
     file_size_mb = result.file_size_mb
     chat_download_path = os.path.dirname(downloaded_file_path)
 
-    if file_size_mb > 50:
-        raise RuntimeError(f"Plik za duży do wysłania ({file_size_mb:.0f} MB, limit Telegram: 50 MB)")
+    use_mtproto = file_size_mb > TELEGRAM_UPLOAD_LIMIT_MB
 
     loop = asyncio.get_event_loop()
     item_info = await loop.run_in_executor(_executor, get_video_info, url)
@@ -620,31 +636,46 @@ async def _download_single_playlist_item(context, chat_id, url, title, media_typ
         thumb_path = await loop.run_in_executor(_executor, download_thumbnail, item_info, chat_download_path, True)
 
     try:
-        with open(downloaded_file_path, "rb") as file_obj:
-            thumb_file = open(thumb_path, "rb") if thumb_path else None
-            try:
-                if media_type == "audio":
-                    await context.bot.send_audio(
-                        chat_id=chat_id,
-                        audio=file_obj,
-                        title=title,
-                        caption=title[:200],
-                        thumbnail=thumb_file,
-                        read_timeout=120,
-                        write_timeout=120,
-                    )
-                else:
-                    await context.bot.send_video(
-                        chat_id=chat_id,
-                        video=file_obj,
-                        caption=title[:200],
-                        thumbnail=thumb_file,
-                        read_timeout=120,
-                        write_timeout=120,
-                    )
-            finally:
-                if thumb_file:
-                    thumb_file.close()
+        if use_mtproto:
+            from bot.mtproto import is_mtproto_available, send_audio_mtproto, send_video_mtproto
+
+            if not is_mtproto_available():
+                raise RuntimeError(
+                    f"Plik za duży dla Bot API ({file_size_mb:.0f} MB, limit: {TELEGRAM_UPLOAD_LIMIT_MB} MB).\n"
+                    f"Skonfiguruj TELEGRAM_API_ID i TELEGRAM_API_HASH aby wysyłać większe pliki."
+                )
+            if media_type == "audio":
+                ok = await send_audio_mtproto(chat_id, downloaded_file_path, title=title, caption=title[:200], thumb_path=thumb_path)
+            else:
+                ok = await send_video_mtproto(chat_id, downloaded_file_path, caption=title[:200], thumb_path=thumb_path)
+            if not ok:
+                raise RuntimeError("Wysyłanie pliku przez MTProto nie powiodło się.")
+        else:
+            with open(downloaded_file_path, "rb") as file_obj:
+                thumb_file = open(thumb_path, "rb") if thumb_path else None
+                try:
+                    if media_type == "audio":
+                        await context.bot.send_audio(
+                            chat_id=chat_id,
+                            audio=file_obj,
+                            title=title,
+                            caption=title[:200],
+                            thumbnail=thumb_file,
+                            read_timeout=120,
+                            write_timeout=120,
+                        )
+                    else:
+                        await context.bot.send_video(
+                            chat_id=chat_id,
+                            video=file_obj,
+                            caption=title[:200],
+                            thumbnail=thumb_file,
+                            read_timeout=120,
+                            write_timeout=120,
+                        )
+                finally:
+                    if thumb_file:
+                        thumb_file.close()
     finally:
         if thumb_path and os.path.exists(thumb_path):
             try:

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -13,7 +13,7 @@ import yt_dlp
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, InputMediaPhoto, Update
 from telegram.ext import ContextTypes
 
-from bot.config import DOWNLOAD_PATH, get_runtime_value
+from bot.config import DOWNLOAD_PATH, YTDLP_REMOTE_COMPONENTS, get_runtime_value
 from bot.handlers.common_ui import (
     build_main_keyboard,
     escape_md,
@@ -246,6 +246,7 @@ async def _download_and_send_ig_videos(
             "quiet": True,
             "no_warnings": True,
             "noplaylist": True,
+            "remote_components": YTDLP_REMOTE_COMPONENTS,
         }
         if os.path.exists(COOKIES_FILE):
             ydl_opts["cookiefile"] = COOKIES_FILE

--- a/bot/handlers/inbound_media.py
+++ b/bot/handlers/inbound_media.py
@@ -16,7 +16,14 @@ from bot.downloader_metadata import get_video_info
 from bot.downloader_playlist import is_playlist_url, is_pure_playlist_url
 from bot.security_limits import FFMPEG_TIMEOUT, MAX_FILE_SIZE_MB, MAX_PLAYLIST_ITEMS, RATE_LIMIT_REQUESTS, RATE_LIMIT_WINDOW
 from bot.security_pin import get_block_remaining_seconds, is_user_blocked
-from bot.security_policy import detect_platform, estimate_file_size, get_media_label, normalize_url, validate_url
+from bot.security_policy import (
+    detect_platform,
+    estimate_file_size,
+    extract_url_from_text,
+    get_media_label,
+    normalize_url,
+    validate_url,
+)
 from bot.security_throttling import check_rate_limit
 from bot.services.auth_service import store_pending_action
 from bot.services.playlist_service import build_playlist_message, load_playlist
@@ -236,6 +243,12 @@ async def handle_youtube_link(update: Update, context: ContextTypes.DEFAULT_TYPE
             "Spróbuj ponownie za chwilę."
         )
         return
+
+    # Extract the first supported URL if the message contains descriptive text
+    # around the link (e.g. "please download: https://youtu.be/...").
+    extracted_url = extract_url_from_text(message_text)
+    if extracted_url:
+        message_text = extracted_url
 
     if "castbox.fm" in message_text:
         import asyncio
@@ -459,7 +472,9 @@ async def extracted_process_youtube_link(update: Update, context: ContextTypes.D
     estimated_size = estimate_file_size(info)
     size_warning = ""
 
-    if estimated_size and estimated_size > MAX_FILE_SIZE_MB:
+    is_podcast = platform in ("castbox", "spotify")
+    large_file = bool(estimated_size and estimated_size > MAX_FILE_SIZE_MB)
+    if large_file:
         size_warning = (
             f"\n*Uwaga:* Szacowany rozmiar najlepszej jakości: {estimated_size:.1f} MB "
             f"(limit: {MAX_FILE_SIZE_MB} MB)\n"
@@ -471,8 +486,17 @@ async def extracted_process_youtube_link(update: Update, context: ContextTypes.D
     time_range = _get_session_value(context, chat_id, "time_range", user_time_ranges)
     time_range_info = f"\n✂️ Zakres: {time_range['start']} - {time_range['end']}" if time_range else ""
 
+    # Explain what "najwyższa" and "średnia" mean — only relevant when those
+    # labels are shown (non-podcast, non-large-file flow).
+    quality_hint = ""
+    if not is_podcast and not large_file:
+        quality_hint = (
+            "\n_Najwyższa_ = najlepsza dostępna rozdzielczość (do 4K/2160p)."
+            "  _Średnia_ = 720p HD.\n"
+        )
+
     await progress_message.edit_text(
-        f"*{escape_md(title)}*\nCzas trwania: {duration_str}{size_warning}{time_range_info}\n\n"
+        f"*{escape_md(title)}*\nCzas trwania: {duration_str}{size_warning}{time_range_info}{quality_hint}\n"
         f"Wybierz format do pobrania:",
         reply_markup=InlineKeyboardMarkup(keyboard),
         parse_mode="Markdown",

--- a/bot/handlers/media_extras_callbacks.py
+++ b/bot/handlers/media_extras_callbacks.py
@@ -12,7 +12,7 @@ import yt_dlp
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, InputMediaPhoto, Update
 from telegram.ext import ContextTypes
 
-from bot.config import DOWNLOAD_PATH
+from bot.config import DOWNLOAD_PATH, YTDLP_REMOTE_COMPONENTS
 from bot.downloader_media import COOKIES_FILE, download_photo
 from bot.downloader_metadata import get_video_info
 from bot.downloader_validation import sanitize_filename
@@ -181,6 +181,7 @@ async def _download_and_send_ig_videos(
             "quiet": True,
             "no_warnings": True,
             "noplaylist": True,
+            "remote_components": YTDLP_REMOTE_COMPONENTS,
         }
         if os.path.exists(COOKIES_FILE):
             ydl_opts["cookiefile"] = COOKIES_FILE

--- a/bot/handlers/playlist_callbacks.py
+++ b/bot/handlers/playlist_callbacks.py
@@ -13,7 +13,7 @@ from telegram.ext import ContextTypes
 from bot.downloader_media import download_thumbnail
 from bot.downloader_metadata import get_video_info
 from bot.handlers.common_ui import build_main_keyboard, escape_md
-from bot.security_limits import MAX_PLAYLIST_ITEMS, MAX_PLAYLIST_ITEMS_EXPANDED
+from bot.security_limits import MAX_PLAYLIST_ITEMS, MAX_PLAYLIST_ITEMS_EXPANDED, TELEGRAM_UPLOAD_LIMIT_MB
 from bot.security_policy import get_media_label
 from bot.services.playlist_service import (
     build_playlist_message,
@@ -171,8 +171,7 @@ async def _download_single_playlist_item(context, chat_id, url, title, media_typ
     file_size_mb = result.file_size_mb
     chat_download_path = os.path.dirname(downloaded_file_path)
 
-    if file_size_mb > 50:
-        raise RuntimeError(f"Plik za duży do wysłania ({file_size_mb:.0f} MB, limit Telegram: 50 MB)")
+    use_mtproto = file_size_mb > TELEGRAM_UPLOAD_LIMIT_MB
 
     loop = asyncio.get_event_loop()
     item_info = await loop.run_in_executor(_executor, get_video_info, url)
@@ -181,31 +180,46 @@ async def _download_single_playlist_item(context, chat_id, url, title, media_typ
         thumb_path = await loop.run_in_executor(_executor, download_thumbnail, item_info, chat_download_path, True)
 
     try:
-        with open(downloaded_file_path, "rb") as file_obj:
-            thumb_file = open(thumb_path, "rb") if thumb_path else None
-            try:
-                if media_type == "audio":
-                    await context.bot.send_audio(
-                        chat_id=chat_id,
-                        audio=file_obj,
-                        title=title,
-                        caption=title[:200],
-                        thumbnail=thumb_file,
-                        read_timeout=120,
-                        write_timeout=120,
-                    )
-                else:
-                    await context.bot.send_video(
-                        chat_id=chat_id,
-                        video=file_obj,
-                        caption=title[:200],
-                        thumbnail=thumb_file,
-                        read_timeout=120,
-                        write_timeout=120,
-                    )
-            finally:
-                if thumb_file:
-                    thumb_file.close()
+        if use_mtproto:
+            from bot.mtproto import is_mtproto_available, send_audio_mtproto, send_video_mtproto
+
+            if not is_mtproto_available():
+                raise RuntimeError(
+                    f"Plik za duży dla Bot API ({file_size_mb:.0f} MB, limit: {TELEGRAM_UPLOAD_LIMIT_MB} MB).\n"
+                    f"Skonfiguruj TELEGRAM_API_ID i TELEGRAM_API_HASH aby wysyłać większe pliki."
+                )
+            if media_type == "audio":
+                ok = await send_audio_mtproto(chat_id, downloaded_file_path, title=title, caption=title[:200], thumb_path=thumb_path)
+            else:
+                ok = await send_video_mtproto(chat_id, downloaded_file_path, caption=title[:200], thumb_path=thumb_path)
+            if not ok:
+                raise RuntimeError("Wysyłanie pliku przez MTProto nie powiodło się.")
+        else:
+            with open(downloaded_file_path, "rb") as file_obj:
+                thumb_file = open(thumb_path, "rb") if thumb_path else None
+                try:
+                    if media_type == "audio":
+                        await context.bot.send_audio(
+                            chat_id=chat_id,
+                            audio=file_obj,
+                            title=title,
+                            caption=title[:200],
+                            thumbnail=thumb_file,
+                            read_timeout=120,
+                            write_timeout=120,
+                        )
+                    else:
+                        await context.bot.send_video(
+                            chat_id=chat_id,
+                            video=file_obj,
+                            caption=title[:200],
+                            thumbnail=thumb_file,
+                            read_timeout=120,
+                            write_timeout=120,
+                        )
+                finally:
+                    if thumb_file:
+                        thumb_file.close()
     finally:
         if thumb_path and os.path.exists(thumb_path):
             try:

--- a/bot/mtproto.py
+++ b/bot/mtproto.py
@@ -1,8 +1,8 @@
 """
-MTProto file download module using pyrogram.
+MTProto file transfer module using pyrogram.
 
-Provides large file download capability (>20 MB) via Telegram's MTProto
-protocol, bypassing the standard Bot API 20 MB limit on getFile.
+Provides large file download (>20 MB) and upload (>50 MB) capability
+via Telegram's MTProto protocol, bypassing standard Bot API size limits.
 
 Requires: pip install pyrogram
 Configuration: TELEGRAM_API_ID and TELEGRAM_API_HASH in api_key.md or env vars.
@@ -86,4 +86,131 @@ async def download_file_mtproto(bot_token: str, chat_id: int, message_id: int, d
 
     except Exception as e:
         logging.error("MTProto download failed: %s", e)
+        return False
+
+
+def _build_client(chat_id: int, tag: str) -> "Client":
+    """Create a pyrogram Client configured for bot-mode MTProto operations."""
+
+    from pyrogram import Client
+
+    api_id = get_runtime_value("TELEGRAM_API_ID", "")
+    api_hash = get_runtime_value("TELEGRAM_API_HASH", "")
+    session_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "downloads"
+    )
+    os.makedirs(session_dir, exist_ok=True)
+
+    return Client(
+        name=f"bot_{tag}_{chat_id}",
+        api_id=int(api_id),
+        api_hash=api_hash,
+        bot_token=get_runtime_value("TELEGRAM_BOT_TOKEN", ""),
+        workdir=session_dir,
+        in_memory=True,
+    )
+
+
+async def send_audio_mtproto(
+    chat_id: int,
+    file_path: str,
+    title: str | None = None,
+    caption: str | None = None,
+    thumb_path: str | None = None,
+) -> bool:
+    """Send an audio file via MTProto (up to 2 GB).
+
+    Args:
+        chat_id: Destination chat ID.
+        file_path: Local path to the audio file.
+        title: Audio track title shown in the player.
+        caption: Message caption.
+        thumb_path: Optional thumbnail image path.
+
+    Returns:
+        True on success, False on error.
+    """
+
+    try:
+        from pyrogram import Client  # noqa: F401
+    except ImportError:
+        logging.error("pyrogram not installed — cannot send large audio")
+        return False
+
+    api_id = get_runtime_value("TELEGRAM_API_ID", "")
+    api_hash = get_runtime_value("TELEGRAM_API_HASH", "")
+    if not api_id or not api_hash:
+        logging.error("TELEGRAM_API_ID/TELEGRAM_API_HASH not configured")
+        return False
+
+    client = _build_client(chat_id, "send_audio")
+
+    try:
+        async with client:
+            await client.send_audio(
+                chat_id=chat_id,
+                audio=file_path,
+                title=title,
+                caption=caption,
+                thumb=thumb_path,
+            )
+            file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
+            logging.info(
+                "MTProto send_audio OK: %s (%.1f MB) to chat %d",
+                os.path.basename(file_path), file_size_mb, chat_id,
+            )
+            return True
+    except Exception as e:
+        logging.error("MTProto send_audio failed: %s", e)
+        return False
+
+
+async def send_video_mtproto(
+    chat_id: int,
+    file_path: str,
+    caption: str | None = None,
+    thumb_path: str | None = None,
+) -> bool:
+    """Send a video file via MTProto (up to 2 GB).
+
+    Args:
+        chat_id: Destination chat ID.
+        file_path: Local path to the video file.
+        caption: Message caption.
+        thumb_path: Optional thumbnail image path.
+
+    Returns:
+        True on success, False on error.
+    """
+
+    try:
+        from pyrogram import Client  # noqa: F401
+    except ImportError:
+        logging.error("pyrogram not installed — cannot send large video")
+        return False
+
+    api_id = get_runtime_value("TELEGRAM_API_ID", "")
+    api_hash = get_runtime_value("TELEGRAM_API_HASH", "")
+    if not api_id or not api_hash:
+        logging.error("TELEGRAM_API_ID/TELEGRAM_API_HASH not configured")
+        return False
+
+    client = _build_client(chat_id, "send_video")
+
+    try:
+        async with client:
+            await client.send_video(
+                chat_id=chat_id,
+                video=file_path,
+                caption=caption,
+                thumb=thumb_path,
+            )
+            file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
+            logging.info(
+                "MTProto send_video OK: %s (%.1f MB) to chat %d",
+                os.path.basename(file_path), file_size_mb, chat_id,
+            )
+            return True
+    except Exception as e:
+        logging.error("MTProto send_video failed: %s", e)
         return False

--- a/bot/security.py
+++ b/bot/security.py
@@ -30,6 +30,7 @@ from bot.security_policy import (
     ALLOWED_DOMAINS,
     detect_platform,
     estimate_file_size,
+    extract_url_from_text,
     get_media_label,
     normalize_url,
     validate_url,

--- a/bot/security_limits.py
+++ b/bot/security_limits.py
@@ -15,6 +15,10 @@ RATE_LIMIT_WINDOW = 60
 # Maximum file size for download (in MB)
 MAX_FILE_SIZE_MB = 1000
 
+# Telegram Bot API upload limit (in MB) — files larger than this
+# require MTProto (pyrogram) to send
+TELEGRAM_UPLOAD_LIMIT_MB = 50
+
 # Maximum MP3 part size for transcription (in MB)
 MAX_MP3_PART_SIZE_MB = 20
 

--- a/bot/security_policy.py
+++ b/bot/security_policy.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import re
 from urllib.parse import parse_qs, urlparse
+
+# Matches http(s) URLs; trailing punctuation is trimmed after the match.
+_URL_PATTERN = re.compile(r'https?://[^\s<>"\'`]+')
+_URL_TRAILING_PUNCT = '.,;:!?)]}>"\''
 
 _DOMAIN_TO_PLATFORM = {
     'youtube.com': 'youtube',
@@ -88,6 +93,23 @@ def validate_url(url) -> bool:
     if domain.startswith('www.'):
         return domain[4:] in ALLOWED_DOMAINS
     return False
+
+
+def extract_url_from_text(text) -> str | None:
+    """Return the first supported URL found in free-form text, or None.
+
+    Handles messages where the user prefixes the link with descriptive text
+    (e.g. "please download this: https://youtu.be/abc"). Trailing punctuation
+    like '.', ',', ')' is stripped so copy-pasted URLs still validate.
+    """
+
+    if not isinstance(text, str) or not text:
+        return None
+    for match in _URL_PATTERN.finditer(text):
+        candidate = match.group(0).rstrip(_URL_TRAILING_PUNCT)
+        if validate_url(candidate):
+            return candidate
+    return None
 
 
 def detect_platform(url) -> str | None:

--- a/bot/services/download_service.py
+++ b/bot/services/download_service.py
@@ -32,6 +32,12 @@ from bot.security_limits import MAX_FILE_SIZE_MB
 
 ArtifactSuffixes = ('_transcript.md', '_transcript.txt', '_summary.md')
 
+# Prefer H.264/AVC video + m4a audio over AV1/VP9+opus.
+# AV1 has better compression but lower bitrate (smaller files) and worse
+# playback compatibility on older devices/players — users expect mp4 output
+# with the largest practical file size for a given resolution.
+VIDEO_FORMAT_SORT = ['vcodec:h264', 'acodec:m4a', 'res', 'br', 'size']
+
 
 @dataclass
 class DownloadPlan:
@@ -138,18 +144,24 @@ def prepare_download_plan(
     elif media_type == "video":
         if format_choice == "best":
             ydl_opts['format'] = 'bestvideo+bestaudio/best'
+            ydl_opts['format_sort'] = VIDEO_FORMAT_SORT
+            ydl_opts['merge_output_format'] = 'mp4'
         elif format_choice == "medium":
             # Cap at 720p HD for a smaller, faster download while staying watchable.
             ydl_opts['format'] = (
-                'best[height<=720]/bestvideo[height<=720]'
-                '+bestaudio/best[height<=720]'
+                'bestvideo[height<=720]+bestaudio'
+                '/best[height<=720]'
             )
+            ydl_opts['format_sort'] = VIDEO_FORMAT_SORT
+            ydl_opts['merge_output_format'] = 'mp4'
         elif format_choice in ["1080p", "720p", "480p", "360p"]:
             height = format_choice.replace('p', '')
             ydl_opts['format'] = (
-                f'best[height<={height}]/bestvideo[height<={height}]'
-                f'+bestaudio/best[height<={height}]'
+                f'bestvideo[height<={height}]+bestaudio'
+                f'/best[height<={height}]'
             )
+            ydl_opts['format_sort'] = VIDEO_FORMAT_SORT
+            ydl_opts['merge_output_format'] = 'mp4'
         else:
             ydl_opts['format'] = format_choice
 

--- a/bot/services/download_service.py
+++ b/bot/services/download_service.py
@@ -137,7 +137,13 @@ def prepare_download_plan(
             })
     elif media_type == "video":
         if format_choice == "best":
-            ydl_opts['format'] = 'best'
+            ydl_opts['format'] = 'bestvideo+bestaudio/best'
+        elif format_choice == "medium":
+            # Cap at 720p HD for a smaller, faster download while staying watchable.
+            ydl_opts['format'] = (
+                'best[height<=720]/bestvideo[height<=720]'
+                '+bestaudio/best[height<=720]'
+            )
         elif format_choice in ["1080p", "720p", "480p", "360p"]:
             height = format_choice.replace('p', '')
             ydl_opts['format'] = (

--- a/bot/services/download_service.py
+++ b/bot/services/download_service.py
@@ -24,6 +24,7 @@ from typing import Any, Callable
 
 import yt_dlp
 
+from bot.config import YTDLP_REMOTE_COMPONENTS
 from bot.downloader_metadata import COOKIES_FILE, get_video_info
 from bot.downloader_validation import is_valid_audio_quality, sanitize_filename
 from bot.security_limits import MAX_FILE_SIZE_MB
@@ -101,6 +102,7 @@ def prepare_download_plan(
         'throttled_rate': '100K',
         'buffer_size': 1024 * 16,
         'http_chunk_size': 10485760,
+        'remote_components': YTDLP_REMOTE_COMPONENTS,
     }
     if os.path.exists(COOKIES_FILE):
         ydl_opts['cookiefile'] = COOKIES_FILE

--- a/bot/services/spotify_service.py
+++ b/bot/services/spotify_service.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import yt_dlp
 
+from bot.config import YTDLP_REMOTE_COMPONENTS
 from bot.downloader_validation import sanitize_filename
 from bot.spotify import download_direct_audio, resolve_spotify_episode
 
@@ -132,6 +133,7 @@ async def download_resolved_audio(
                 'preferredcodec': audio_format,
                 'preferredquality': '192',
             }],
+            'remote_components': YTDLP_REMOTE_COMPONENTS,
         }
 
         await loop.run_in_executor(

--- a/bot/spotify.py
+++ b/bot/spotify.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse, parse_qs
 import requests
 import yt_dlp
 
-from bot.config import get_runtime_value
+from bot.config import YTDLP_REMOTE_COMPONENTS, get_runtime_value
 
 
 # Spotify API token cache
@@ -234,6 +234,7 @@ def search_youtube_episode(title: str, show_name: str = "",
             'no_warnings': True,
             'extract_flat': True,
             'default_search': 'ytsearch5',
+            'remote_components': YTDLP_REMOTE_COMPONENTS,
         }
 
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/tests/test_download_service.py
+++ b/tests/test_download_service.py
@@ -37,6 +37,46 @@ def test_prepare_download_plan_builds_audio_transcription_plan(monkeypatch, tmp_
     assert plan.ydl_opts["remote_components"] == ["ejs:github"]
 
 
+def test_prepare_download_plan_video_best_uses_bestvideo_bestaudio(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        ds,
+        "get_video_info",
+        lambda url: {"title": "Test Video", "duration": 125},
+    )
+    monkeypatch.setattr(ds.os.path, "exists", lambda path: False)
+
+    plan = ds.prepare_download_plan(
+        url="https://www.youtube.com/watch?v=abc",
+        media_type="video",
+        format_choice="best",
+        chat_download_path=str(tmp_path),
+    )
+
+    assert plan is not None
+    assert plan.ydl_opts["format"] == "bestvideo+bestaudio/best"
+
+
+def test_prepare_download_plan_video_medium_caps_at_720p(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        ds,
+        "get_video_info",
+        lambda url: {"title": "Test Video", "duration": 125},
+    )
+    monkeypatch.setattr(ds.os.path, "exists", lambda path: False)
+
+    plan = ds.prepare_download_plan(
+        url="https://www.youtube.com/watch?v=abc",
+        media_type="video",
+        format_choice="medium",
+        chat_download_path=str(tmp_path),
+    )
+
+    assert plan is not None
+    assert plan.ydl_opts["format"] == (
+        "best[height<=720]/bestvideo[height<=720]+bestaudio/best[height<=720]"
+    )
+
+
 def test_prepare_download_plan_rejects_invalid_audio_quality(monkeypatch, tmp_path):
     monkeypatch.setattr(
         ds,

--- a/tests/test_download_service.py
+++ b/tests/test_download_service.py
@@ -34,6 +34,7 @@ def test_prepare_download_plan_builds_audio_transcription_plan(monkeypatch, tmp_
     assert plan.ydl_opts["format"] == "bestaudio/best"
     assert plan.ydl_opts["postprocessors"][0]["preferredcodec"] == "mp3"
     assert plan.ydl_opts["force_keyframes_at_cuts"] is True
+    assert plan.ydl_opts["remote_components"] == ["ejs:github"]
 
 
 def test_prepare_download_plan_rejects_invalid_audio_quality(monkeypatch, tmp_path):

--- a/tests/test_download_service.py
+++ b/tests/test_download_service.py
@@ -54,6 +54,8 @@ def test_prepare_download_plan_video_best_uses_bestvideo_bestaudio(monkeypatch, 
 
     assert plan is not None
     assert plan.ydl_opts["format"] == "bestvideo+bestaudio/best"
+    assert plan.ydl_opts["format_sort"] == ds.VIDEO_FORMAT_SORT
+    assert plan.ydl_opts["merge_output_format"] == "mp4"
 
 
 def test_prepare_download_plan_video_medium_caps_at_720p(monkeypatch, tmp_path):
@@ -73,8 +75,10 @@ def test_prepare_download_plan_video_medium_caps_at_720p(monkeypatch, tmp_path):
 
     assert plan is not None
     assert plan.ydl_opts["format"] == (
-        "best[height<=720]/bestvideo[height<=720]+bestaudio/best[height<=720]"
+        "bestvideo[height<=720]+bestaudio/best[height<=720]"
     )
+    assert plan.ydl_opts["format_sort"] == ds.VIDEO_FORMAT_SORT
+    assert plan.ydl_opts["merge_output_format"] == "mp4"
 
 
 def test_prepare_download_plan_rejects_invalid_audio_quality(monkeypatch, tmp_path):

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -49,6 +49,7 @@ def test_get_basic_ydl_opts_contains_expected_fields():
     assert opts["quiet"] is True
     assert opts["no_warnings"] is True
     assert "progress_hooks" not in opts
+    assert opts["remote_components"] == ["ejs:github"]
 
 
 def test_get_basic_ydl_opts_can_enable_progress_hooks():
@@ -117,6 +118,7 @@ def test_download_youtube_video_success_audio_only(monkeypatch):
     assert created == ["https://youtube.com/watch?v=test"]
     assert captured["opts"]["format"] == "bestaudio/best"
     assert captured["opts"]["postprocessors"][0]["preferredcodec"] == "mp3"
+    assert captured["opts"]["remote_components"] == ["ejs:github"]
 
 
 def test_download_youtube_video_success_with_format_id(monkeypatch):
@@ -263,6 +265,7 @@ def test_download_youtube_video_sets_download_sections(monkeypatch):
     assert download_youtube_video("https://youtube.com/watch?v=test", time_range_start="0:10", time_range_end="0:20") is True
     assert captured["opts"]["download_sections"] == [{"start_time": 10, "end_time": 20}]
     assert captured["opts"]["force_keyframes_at_cuts"] is True
+    assert captured["opts"]["remote_components"] == ["ejs:github"]
 
 
 def test_download_youtube_video_returns_false_on_exception(monkeypatch):

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -145,6 +145,7 @@ def test_download_youtube_video_success_with_format_id(monkeypatch):
 def test_is_valid_ytdlp_format_id():
     assert is_valid_ytdlp_format_id("best") is True
     assert is_valid_ytdlp_format_id("bestvideo") is True
+    assert is_valid_ytdlp_format_id("medium") is True
     assert is_valid_ytdlp_format_id("1080p") is True
     assert is_valid_ytdlp_format_id("137+140") is True
     assert is_valid_ytdlp_format_id("1080P") is True

--- a/tests/test_mtproto.py
+++ b/tests/test_mtproto.py
@@ -1,12 +1,17 @@
 """
-Unit tests for bot.mtproto — MTProto large file download module.
+Unit tests for bot.mtproto — MTProto large file transfer module.
 """
 
 import asyncio
 import os
 from unittest.mock import patch, AsyncMock, MagicMock
 
-from bot.mtproto import is_mtproto_available, download_file_mtproto
+from bot.mtproto import (
+    is_mtproto_available,
+    download_file_mtproto,
+    send_audio_mtproto,
+    send_video_mtproto,
+)
 
 
 class TestIsMtprotoAvailable:
@@ -83,4 +88,131 @@ class TestDownloadFileMtproto:
         with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
             dest = str(tmp_path / "test.mp3")
             result = asyncio.run(download_file_mtproto("token", 123, 456, dest))
+            assert result is False
+
+
+def _set_mtproto_config(monkeypatch, *, api_id="12345", api_hash="abc123hash", bot_token="tok:en"):
+    """Helper to set MTProto-related config keys."""
+    cfg = __import__('bot.config', fromlist=['CONFIG']).CONFIG
+    monkeypatch.setitem(cfg, 'TELEGRAM_API_ID', api_id)
+    monkeypatch.setitem(cfg, 'TELEGRAM_API_HASH', api_hash)
+    monkeypatch.setitem(cfg, 'TELEGRAM_BOT_TOKEN', bot_token)
+
+
+class TestSendAudioMtproto:
+    """Tests for send_audio_mtproto() upload function."""
+
+    def test_returns_false_when_pyrogram_missing(self, monkeypatch, tmp_path):
+        _set_mtproto_config(monkeypatch)
+        audio_file = tmp_path / "test.mp3"
+        audio_file.write_bytes(b"\x00" * 100)
+        with patch.dict('sys.modules', {'pyrogram': None}):
+            result = asyncio.run(send_audio_mtproto(123, str(audio_file), title="Test"))
+            assert result is False
+
+    def test_returns_false_when_api_id_missing(self, monkeypatch, tmp_path):
+        _set_mtproto_config(monkeypatch, api_id="")
+        audio_file = tmp_path / "test.mp3"
+        audio_file.write_bytes(b"\x00" * 100)
+        mock_pyrogram = MagicMock()
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            result = asyncio.run(send_audio_mtproto(123, str(audio_file), title="Test"))
+            assert result is False
+
+    def test_returns_true_on_success(self, monkeypatch, tmp_path):
+        _set_mtproto_config(monkeypatch)
+        audio_file = tmp_path / "test.mp3"
+        audio_file.write_bytes(b"\x00" * 100)
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client_instance.send_audio = AsyncMock()
+
+        mock_pyrogram = MagicMock()
+        mock_pyrogram.Client.return_value = mock_client_instance
+
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            result = asyncio.run(send_audio_mtproto(123, str(audio_file), title="Test", caption="Cap"))
+            assert result is True
+            mock_client_instance.send_audio.assert_awaited_once()
+            call_kwargs = mock_client_instance.send_audio.await_args.kwargs
+            assert call_kwargs['chat_id'] == 123
+            assert call_kwargs['title'] == "Test"
+            assert call_kwargs['caption'] == "Cap"
+
+    def test_returns_false_on_send_exception(self, monkeypatch, tmp_path):
+        _set_mtproto_config(monkeypatch)
+        audio_file = tmp_path / "test.mp3"
+        audio_file.write_bytes(b"\x00" * 100)
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client_instance.send_audio = AsyncMock(side_effect=RuntimeError("Upload failed"))
+
+        mock_pyrogram = MagicMock()
+        mock_pyrogram.Client.return_value = mock_client_instance
+
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            result = asyncio.run(send_audio_mtproto(123, str(audio_file)))
+            assert result is False
+
+
+class TestSendVideoMtproto:
+    """Tests for send_video_mtproto() upload function."""
+
+    def test_returns_false_when_pyrogram_missing(self, monkeypatch, tmp_path):
+        _set_mtproto_config(monkeypatch)
+        video_file = tmp_path / "test.mp4"
+        video_file.write_bytes(b"\x00" * 100)
+        with patch.dict('sys.modules', {'pyrogram': None}):
+            result = asyncio.run(send_video_mtproto(123, str(video_file)))
+            assert result is False
+
+    def test_returns_false_when_api_hash_missing(self, monkeypatch, tmp_path):
+        _set_mtproto_config(monkeypatch, api_hash="")
+        video_file = tmp_path / "test.mp4"
+        video_file.write_bytes(b"\x00" * 100)
+        mock_pyrogram = MagicMock()
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            result = asyncio.run(send_video_mtproto(123, str(video_file)))
+            assert result is False
+
+    def test_returns_true_on_success(self, monkeypatch, tmp_path):
+        _set_mtproto_config(monkeypatch)
+        video_file = tmp_path / "test.mp4"
+        video_file.write_bytes(b"\x00" * 100)
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client_instance.send_video = AsyncMock()
+
+        mock_pyrogram = MagicMock()
+        mock_pyrogram.Client.return_value = mock_client_instance
+
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            result = asyncio.run(send_video_mtproto(123, str(video_file), caption="My Video"))
+            assert result is True
+            mock_client_instance.send_video.assert_awaited_once()
+            call_kwargs = mock_client_instance.send_video.await_args.kwargs
+            assert call_kwargs['chat_id'] == 123
+            assert call_kwargs['caption'] == "My Video"
+
+    def test_returns_false_on_send_exception(self, monkeypatch, tmp_path):
+        _set_mtproto_config(monkeypatch)
+        video_file = tmp_path / "test.mp4"
+        video_file.write_bytes(b"\x00" * 100)
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client_instance.send_video = AsyncMock(side_effect=RuntimeError("Upload failed"))
+
+        mock_pyrogram = MagicMock()
+        mock_pyrogram.Client.return_value = mock_client_instance
+
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            result = asyncio.run(send_video_mtproto(123, str(video_file)))
             assert result is False

--- a/tests/test_security_unit.py
+++ b/tests/test_security_unit.py
@@ -152,6 +152,52 @@ def test_validate_url_is_backward_compatible_alias():
     assert security.validate_youtube_url is security.validate_url
 
 
+def test_extract_url_from_text_pulls_link_out_of_prose():
+    msg = (
+        "nie mam na kompie służbowym premium - czy mógłbyś mi pobrać "
+        "w wysokiej rozdzielczości ten film i wysłać na wetransfer? "
+        "nie jest to pilne https://www.youtube.com/watch?v=zCq3xb2Hmqs"
+    )
+    assert security.extract_url_from_text(msg) == "https://www.youtube.com/watch?v=zCq3xb2Hmqs"
+
+
+def test_extract_url_from_text_returns_bare_url_unchanged():
+    url = "https://youtu.be/abc123"
+    assert security.extract_url_from_text(url) == url
+
+
+def test_extract_url_from_text_picks_first_supported_platform():
+    msg = "see https://example.com/not-supported and https://vimeo.com/999"
+    assert security.extract_url_from_text(msg) == "https://vimeo.com/999"
+
+
+def test_extract_url_from_text_strips_trailing_punctuation():
+    msg = "Check this (https://www.tiktok.com/@user/video/123)."
+    assert security.extract_url_from_text(msg) == "https://www.tiktok.com/@user/video/123"
+
+
+def test_extract_url_from_text_rejects_messages_without_supported_url():
+    assert security.extract_url_from_text("just some text, no link") is None
+    assert security.extract_url_from_text("https://example.com/only") is None
+    assert security.extract_url_from_text("") is None
+    assert security.extract_url_from_text(None) is None
+
+
+def test_extract_url_from_text_handles_all_supported_platforms():
+    platforms = {
+        "youtube": "https://www.youtube.com/watch?v=abc",
+        "youtu.be": "https://youtu.be/abc",
+        "vimeo": "https://vimeo.com/123",
+        "tiktok": "https://www.tiktok.com/@u/video/1",
+        "instagram": "https://www.instagram.com/p/abc/",
+        "linkedin": "https://www.linkedin.com/posts/abc",
+        "castbox": "https://castbox.fm/episode/abc",
+        "spotify": "https://open.spotify.com/episode/abc",
+    }
+    for _, url in platforms.items():
+        assert security.extract_url_from_text(f"prefix text {url}") == url
+
+
 def test_estimate_file_size_various_inputs():
     info_with_size = {"formats": [{"filesize": 50 * 1024 * 1024}]}
     assert security.estimate_file_size(info_with_size) == 50.0

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -393,6 +393,7 @@ class TestDownloadSubtitles:
         call_args = mock_ytdl_class.call_args[0][0]
         assert call_args['writeautomaticsub'] is True
         assert call_args['writesubtitles'] is False
+        assert call_args['remote_components'] == ['ejs:github']
 
     @patch('bot.downloader_subtitles.yt_dlp.YoutubeDL')
     def test_download_subtitles_not_found(self, mock_ytdl_class, temp_dir):
@@ -440,6 +441,7 @@ class TestDownloadSubtitles:
 
         call_args = mock_ytdl_class.call_args[0][0]
         assert call_args['skip_download'] is True
+        assert call_args['remote_components'] == ['ejs:github']
 
     @patch('bot.downloader_subtitles.yt_dlp.YoutubeDL')
     def test_download_subtitles_srt_format(self, mock_ytdl_class, temp_dir):


### PR DESCRIPTION
## Summary

- Upload files > 50 MB through MTProto (Pyrogram) instead of failing on the Telegram Bot API limit; covers send_audio and send_video paths with new tests.
- Enable yt-dlp remote components so YouTube JS challenges (signature/n-parameter) can be solved when deno is available.
- Accept free-form text containing a URL (e.g. descriptive prose before the link) by extracting the first supported URL across all platforms.
- Add a "Video — średnia (720p HD)" button next to "Video — najwyższa", with an inline hint in the format-picker message.
- Restore expected video file sizes by preferring H.264 + m4a over yt-dlp's default AV1 selection (with mp4 container), with fallback to AV1/VP9 when H.264 is unavailable.

## Test plan

- [ ] `python -m pytest -q` passes locally (591 passed, 2 skipped).
- [ ] Send a YouTube link with descriptive text before the URL — bot extracts the link and proceeds.
- [ ] Pick "Video — najwyższa" on a 1080p YouTube video — output is mp4 (H.264 + m4a), file size matches AVC 1080p.
- [ ] Pick "Video — średnia (720p HD)" on the same video — output is 720p mp4.
- [ ] Trigger a > 50 MB download — file is delivered via MTProto without the Bot API size error.
- [ ] Trigger a YouTube video that requires JS challenge solving — download succeeds with deno installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes download option selection and Telegram delivery paths (Bot API vs MTProto) and alters yt-dlp format selection/remote-component behavior, which can affect media compatibility and runtime dependencies.
> 
> **Overview**
> Improves end-to-end download reliability by routing files **over the Bot API size limit** through MTProto uploads (new `send_audio_mtproto`/`send_video_mtproto`) instead of failing, and centralizes the 50MB threshold via `TELEGRAM_UPLOAD_LIMIT_MB`.
> 
> Updates yt-dlp usage across download/metadata/subtitle/Spotify flows to enable `remote_components` (supporting YouTube JS challenges when `deno` is available), and adjusts video format selection to prefer **`bestvideo+bestaudio` merged to mp4 with H.264+m4a sorting**, plus a new **“medium” (720p cap)** option exposed in the Telegram UI.
> 
> Enhances link intake by extracting the first supported URL from free-form text (`extract_url_from_text`), and documents the new `deno` requirement and related troubleshooting in `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc7a90cfdcd3855a554304fdcd80f975e5b0060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->