### PR TITLE
Add X (Twitter) platform support + platform registry refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Media Downloader Telegram Bot
 
-Bot Telegram do pobierania video/audio z YouTube, Vimeo, TikTok, Instagram i LinkedIn z funkcjami transkrypcji i podsumowań AI.
+Bot Telegram do pobierania video/audio z YouTube, Vimeo, TikTok, Instagram, LinkedIn i X z funkcjami transkrypcji i podsumowań AI.
 
 ## Funkcje
 
@@ -26,6 +26,7 @@ Bot Telegram do pobierania video/audio z YouTube, Vimeo, TikTok, Instagram i Lin
 | TikTok | tiktok.com, vm.tiktok.com, m.tiktok.com | Uproszczone menu (krótkie video) |
 | Instagram | instagram.com | Reels i posty video przez yt-dlp. Zdjęcia i karuzele wymagają dodatkowo `instaloader` oraz `cookies.txt` |
 | LinkedIn | linkedin.com | Posty video. Wymaga cookies.txt |
+| X (Twitter) | x.com, twitter.com, mobile.twitter.com | Video z tweetów. Treści oznaczone jako Sensitive wymagają cookies.txt |
 | Spotify | open.spotify.com | Odcinki podcastów. Wymaga SPOTIFY_CLIENT_ID/SECRET. Audio z iTunes lub YouTube |
 
 ### Bezpieczeństwo

--- a/bot/handlers/command_access.py
+++ b/bot/handlers/command_access.py
@@ -29,6 +29,20 @@ from bot.session_context import (
     clear_transient_flow_state as _clear_transient_flow_state,
     get_auth_state as _get_auth_state,
 )
+from bot.platforms import PLATFORMS
+
+
+def _format_supported_platforms_block() -> str:
+    """Return a newline-joined bullet list of platforms for help messages."""
+
+    return "\n".join(f"- {p.display_name} ({p.domains[0]})" for p in PLATFORMS)
+
+
+def _format_cookies_required_names() -> str:
+    """Return a comma-separated list of platforms that typically need cookies.txt."""
+
+    names = [p.display_name for p in PLATFORMS if p.requires_cookies]
+    return ", ".join(names)
 
 
 async def process_youtube_link(update: Update, context: ContextTypes.DEFAULT_TYPE, url):
@@ -218,15 +232,9 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "3. Obsługiwane formaty audio: OGG, MP3, M4A, WAV, FLAC, OPUS\n"
         "4. Obsługiwane formaty video: MP4, MOV, MKV, AVI, WEBM\n\n"
         "🌐 *Obsługiwane platformy:*\n"
-        "- YouTube (youtube.com, youtu.be)\n"
-        "- Vimeo (vimeo.com)\n"
-        "- TikTok (tiktok.com)\n"
-        "- Instagram (instagram.com)\n"
-        "- LinkedIn (linkedin.com)\n"
-        "- Castbox (castbox.fm)\n"
-        "- Spotify podcasty (open.spotify.com/episode)\n\n"
+        f"{_format_supported_platforms_block()}\n\n"
         "🔒 *Platformy wymagające logowania:*\n"
-        "TikTok, Instagram i LinkedIn mogą wymagać pliku cookies.txt\n"
+        f"{_format_cookies_required_names()} mogą wymagać pliku cookies.txt\n"
         "do pobierania treści z ograniczonym dostępem.\n\n"
         "Komendy administracyjne:\n"
         "- /status - sprawdź przestrzeń dyskową\n"
@@ -274,7 +282,7 @@ async def status_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         cookie_size = os.path.getsize(COOKIES_FILE)
         status_msg += f"\n**cookies.txt:** ✅ ({cookie_size} B)\n"
     else:
-        status_msg += "\n**cookies.txt:** ❌ brak (TikTok/Instagram/LinkedIn mogą wymagać)\n"
+        status_msg += f"\n**cookies.txt:** ❌ brak ({_format_cookies_required_names()} mogą wymagać)\n"
 
     await update.message.reply_text(status_msg, parse_mode="Markdown")
 

--- a/bot/handlers/common_ui.py
+++ b/bot/handlers/common_ui.py
@@ -18,9 +18,14 @@ def escape_md(text: str) -> str:
 def build_main_keyboard(platform: str, large_file: bool = False) -> list:
     """Build the main format selection keyboard for a detected platform."""
 
-    is_podcast = platform in ("castbox", "spotify")
-    hide_flac = platform in ("tiktok", "castbox", "spotify")
-    hide_time_range = platform in ("tiktok", "castbox", "spotify")
+    from bot.platforms import get_platform
+
+    config = get_platform(platform)
+    if config is None:
+        raise ValueError(f"Unknown platform in session: {platform!r}")
+    is_podcast = config.is_podcast
+    hide_flac = config.hide_flac
+    hide_time_range = config.hide_time_range
 
     if is_podcast:
         return [

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -80,7 +80,16 @@ from bot.handlers.time_range_callbacks import (
     back_to_main_menu,
     show_time_range_options,
 )
+from bot.platforms import get_platform
 
+GENERIC_COOKIES_HINT = (
+    "Ta platforma wymaga zalogowania.\n\n"
+    "Aby pobrać treści z ograniczonym dostępem:\n"
+    "1. Zaloguj się na platformę w przeglądarce\n"
+    "2. Wyeksportuj cookies (rozszerzenie 'Get cookies.txt LOCALLY')\n"
+    "3. Umieść plik cookies.txt w katalogu bota\n"
+    "4. Spróbuj ponownie"
+)
 
 _executor = ThreadPoolExecutor(max_workers=2)
 
@@ -587,14 +596,16 @@ async def download_file(
 
         error_str = str(exc).lower()
         if any(keyword in error_str for keyword in ("login", "sign in", "cookie", "authentication")):
-            await update_status(
-                "Ta platforma wymaga zalogowania.\n\n"
-                "Aby pobrać treści z ograniczonym dostępem:\n"
-                "1. Zaloguj się na platformę w przeglądarce\n"
-                "2. Wyeksportuj cookies (rozszerzenie 'Get cookies.txt LOCALLY')\n"
-                "3. Umieść plik cookies.txt w katalogu bota\n"
-                "4. Spróbuj ponownie"
+            platform_name = _get_session_context_value(
+                context, chat_id, "platform", legacy_key="platform"
             )
+            config = get_platform(platform_name)
+            hint = (
+                config.cookies_hint
+                if config and config.cookies_hint
+                else GENERIC_COOKIES_HINT
+            )
+            await update_status(hint)
         else:
             await update_status("Wystąpił błąd podczas pobierania. Spróbuj ponownie.")
 

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -517,12 +517,13 @@ async def download_file(
             thumb_path = await asyncio.get_event_loop().run_in_executor(_executor, download_thumbnail, info, chat_download_path, True)
             try:
                 if use_mtproto:
-                    from bot.mtproto import is_mtproto_available, send_audio_mtproto, send_video_mtproto
+                    from bot.mtproto import mtproto_unavailability_reason, send_audio_mtproto, send_video_mtproto
 
-                    if not is_mtproto_available():
+                    reason = mtproto_unavailability_reason()
+                    if reason is not None:
                         raise RuntimeError(
                             f"Plik za duży dla Bot API ({file_size_mb:.0f} MB, limit: {TELEGRAM_UPLOAD_LIMIT_MB} MB).\n"
-                            f"Skonfiguruj TELEGRAM_API_ID i TELEGRAM_API_HASH aby wysyłać większe pliki."
+                            f"{reason}"
                         )
                     if media_type == "audio":
                         ok = await send_audio_mtproto(chat_id, downloaded_file_path, title=title, caption=title, thumb_path=thumb_path)

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -51,7 +51,6 @@ from bot.services.download_service import (
 from bot.services.playlist_service import (
     build_playlist_message,
     build_single_video_url,
-    download_playlist_item,
     load_playlist,
     parse_playlist_download_choice,
 )
@@ -609,87 +608,6 @@ async def handle_playlist_callback(update: Update, context: ContextTypes.DEFAULT
 
 async def download_playlist(update: Update, context: ContextTypes.DEFAULT_TYPE, callback_data: str):
     return await _extracted_download_playlist(update, context, callback_data)
-
-
-async def _download_single_playlist_item(context, chat_id, url, title, media_type, format_choice, status_msg):
-    try:
-        result = await download_playlist_item(
-            chat_id=chat_id,
-            url=url,
-            title=title,
-            media_type=media_type,
-            format_choice=format_choice,
-            executor=_executor,
-        )
-    except RuntimeError:
-        raise
-
-    downloaded_file_path = result.file_path
-    file_size_mb = result.file_size_mb
-    chat_download_path = os.path.dirname(downloaded_file_path)
-
-    use_mtproto = file_size_mb > TELEGRAM_UPLOAD_LIMIT_MB
-
-    loop = asyncio.get_event_loop()
-    item_info = await loop.run_in_executor(_executor, get_video_info, url)
-    thumb_path = None
-    if item_info:
-        thumb_path = await loop.run_in_executor(_executor, download_thumbnail, item_info, chat_download_path, True)
-
-    try:
-        if use_mtproto:
-            from bot.mtproto import is_mtproto_available, send_audio_mtproto, send_video_mtproto
-
-            if not is_mtproto_available():
-                raise RuntimeError(
-                    f"Plik za duży dla Bot API ({file_size_mb:.0f} MB, limit: {TELEGRAM_UPLOAD_LIMIT_MB} MB).\n"
-                    f"Skonfiguruj TELEGRAM_API_ID i TELEGRAM_API_HASH aby wysyłać większe pliki."
-                )
-            if media_type == "audio":
-                ok = await send_audio_mtproto(chat_id, downloaded_file_path, title=title, caption=title[:200], thumb_path=thumb_path)
-            else:
-                ok = await send_video_mtproto(chat_id, downloaded_file_path, caption=title[:200], thumb_path=thumb_path)
-            if not ok:
-                raise RuntimeError("Wysyłanie pliku przez MTProto nie powiodło się.")
-        else:
-            with open(downloaded_file_path, "rb") as file_obj:
-                thumb_file = open(thumb_path, "rb") if thumb_path else None
-                try:
-                    if media_type == "audio":
-                        await context.bot.send_audio(
-                            chat_id=chat_id,
-                            audio=file_obj,
-                            title=title,
-                            caption=title[:200],
-                            thumbnail=thumb_file,
-                            read_timeout=120,
-                            write_timeout=120,
-                        )
-                    else:
-                        await context.bot.send_video(
-                            chat_id=chat_id,
-                            video=file_obj,
-                            caption=title[:200],
-                            thumbnail=thumb_file,
-                            read_timeout=120,
-                            write_timeout=120,
-                        )
-                finally:
-                    if thumb_file:
-                        thumb_file.close()
-    finally:
-        if thumb_path and os.path.exists(thumb_path):
-            try:
-                os.remove(thumb_path)
-            except OSError:
-                pass
-        try:
-            os.remove(downloaded_file_path)
-        except OSError:
-            pass
-
-    record_download_for(context, chat_id, title, url, f"{media_type}_{format_choice}", file_size_mb)
-    await status_msg.edit_text(f"[✅] {title}")
 
 
 async def _show_spotify_summary_options(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/bot/handlers/inbound_media.py
+++ b/bot/handlers/inbound_media.py
@@ -182,7 +182,11 @@ async def handle_youtube_link(update: Update, context: ContextTypes.DEFAULT_TYPE
         return
 
     if not _is_authorized(context, user_id):
-        store_pending_action(_get_auth_state(context, chat_id), kind="url", payload=message_text)
+        # Extract URL up-front so that the replay after successful PIN auth
+        # (command_access replays pending_action via process_youtube_link,
+        # which expects a clean URL) gets the same input as the authorized path.
+        pending_payload = extract_url_from_text(message_text) or message_text
+        store_pending_action(_get_auth_state(context, chat_id), kind="url", payload=pending_payload)
         await update.message.reply_text(
             "Wymagane uwierzytelnienie!\n\n"
             "Proszę podaj 8-cyfrowy kod PIN, aby uzyskać dostęp."

--- a/bot/handlers/inbound_media.py
+++ b/bot/handlers/inbound_media.py
@@ -262,16 +262,15 @@ async def handle_youtube_link(update: Update, context: ContextTypes.DEFAULT_TYPE
             message_text = await loop.run_in_executor(executor, normalize_url, message_text)
 
     if not validate_url(message_text):
+        from bot.platforms import PLATFORMS
+
+        platform_lines = "\n".join(
+            f"- {p.display_name} ({p.domains[0]})" for p in PLATFORMS
+        )
         await update.message.reply_text(
             "Nieprawidłowy URL!\n\n"
             "Obsługiwane platformy:\n"
-            "- YouTube (youtube.com, youtu.be)\n"
-            "- Vimeo (vimeo.com)\n"
-            "- TikTok (tiktok.com)\n"
-            "- Instagram (instagram.com)\n"
-            "- LinkedIn (linkedin.com)\n"
-            "- Castbox (castbox.fm)\n"
-            "- Spotify podcasty (open.spotify.com/episode)"
+            f"{platform_lines}"
         )
         return
 
@@ -476,7 +475,10 @@ async def extracted_process_youtube_link(update: Update, context: ContextTypes.D
     estimated_size = estimate_file_size(info)
     size_warning = ""
 
-    is_podcast = platform in ("castbox", "spotify")
+    from bot.platforms import get_platform
+
+    config = get_platform(platform)
+    is_podcast = config.is_podcast if config else False
     large_file = bool(estimated_size and estimated_size > MAX_FILE_SIZE_MB)
     if large_file:
         size_warning = (

--- a/bot/handlers/playlist_callbacks.py
+++ b/bot/handlers/playlist_callbacks.py
@@ -181,12 +181,13 @@ async def _download_single_playlist_item(context, chat_id, url, title, media_typ
 
     try:
         if use_mtproto:
-            from bot.mtproto import is_mtproto_available, send_audio_mtproto, send_video_mtproto
+            from bot.mtproto import mtproto_unavailability_reason, send_audio_mtproto, send_video_mtproto
 
-            if not is_mtproto_available():
+            reason = mtproto_unavailability_reason()
+            if reason is not None:
                 raise RuntimeError(
                     f"Plik za duży dla Bot API ({file_size_mb:.0f} MB, limit: {TELEGRAM_UPLOAD_LIMIT_MB} MB).\n"
-                    f"Skonfiguruj TELEGRAM_API_ID i TELEGRAM_API_HASH aby wysyłać większe pliki."
+                    f"{reason}"
                 )
             if media_type == "audio":
                 ok = await send_audio_mtproto(chat_id, downloaded_file_path, title=title, caption=title[:200], thumb_path=thumb_path)

--- a/bot/handlers/transcription_callbacks.py
+++ b/bot/handlers/transcription_callbacks.py
@@ -43,8 +43,37 @@ _executor = ThreadPoolExecutor(max_workers=2)
 
 
 async def show_summary_options(update: Update, context: ContextTypes.DEFAULT_TYPE, url):
-    """Dependency placeholder overridden by router module during extraction."""
-    raise NotImplementedError
+    """Display the summary-type selection menu before AI transcription + summary."""
+
+    query = update.callback_query
+    chat_id = update.effective_chat.id
+
+    info = get_video_info(url)
+    if not info:
+        media_name = get_media_label(
+            _get_session_context_value(context, chat_id, "platform", legacy_key="platform")
+        )
+        await query.edit_message_text(
+            f"Wystąpił błąd podczas pobierania informacji o {media_name}."
+        )
+        return
+
+    title = info.get("title", "Nieznany tytuł")
+
+    keyboard = [
+        [InlineKeyboardButton("1. Krótkie podsumowanie", callback_data="summary_option_1")],
+        [InlineKeyboardButton("2. Szczegółowe podsumowanie", callback_data="summary_option_2")],
+        [InlineKeyboardButton("3. Podsumowanie w punktach", callback_data="summary_option_3")],
+        [InlineKeyboardButton("4. Podział zadań na osoby", callback_data="summary_option_4")],
+        [InlineKeyboardButton("Powrót", callback_data="back")],
+    ]
+
+    await safe_edit_message(
+        query,
+        f"*{escape_md(title)}*\n\nWybierz rodzaj podsumowania:",
+        reply_markup=InlineKeyboardMarkup(keyboard),
+        parse_mode="Markdown",
+    )
 
 
 async def download_file(update: Update, context: ContextTypes.DEFAULT_TYPE, type, format, url, **kwargs):

--- a/bot/mtproto.py
+++ b/bot/mtproto.py
@@ -15,15 +15,54 @@ import os
 from bot.config import get_runtime_value
 
 
-def is_mtproto_available() -> bool:
-    """Checks if pyrogram is installed and API credentials are configured."""
-    if not get_runtime_value("TELEGRAM_API_ID") or not get_runtime_value("TELEGRAM_API_HASH"):
-        return False
+def mtproto_unavailability_reason() -> str | None:
+    """Return a user-facing explanation of what is missing for MTProto, or None.
+
+    Distinguishes between the three failure modes so callers can give precise
+    guidance instead of always blaming missing API credentials (which used to
+    mislead users who simply had not installed pyrogram).
+    """
+
     try:
         import pyrogram  # noqa: F401
-        return True
+        has_pyrogram = True
     except ImportError:
-        return False
+        has_pyrogram = False
+
+    has_creds = bool(get_runtime_value("TELEGRAM_API_ID")) and bool(
+        get_runtime_value("TELEGRAM_API_HASH")
+    )
+
+    if has_pyrogram and has_creds:
+        return None
+    if not has_pyrogram and not has_creds:
+        return (
+            "Zainstaluj pakiet pyrogram oraz skonfiguruj "
+            "TELEGRAM_API_ID i TELEGRAM_API_HASH."
+        )
+    if not has_pyrogram:
+        return "Zainstaluj pakiet pyrogram, aby wysyłać większe pliki."
+    return "Skonfiguruj TELEGRAM_API_ID i TELEGRAM_API_HASH, aby wysyłać większe pliki."
+
+
+def is_mtproto_available() -> bool:
+    """Checks if pyrogram is installed and API credentials are configured."""
+    return mtproto_unavailability_reason() is None
+
+
+def _parse_api_id(value) -> int | None:
+    """Return TELEGRAM_API_ID as int, or None when the value is invalid.
+
+    Guards pyrogram Client construction: a non-numeric API_ID (e.g. a typo in
+    api_key.md) would otherwise raise ValueError outside the surrounding
+    try/except in send_*_mtproto / download_file_mtproto and crash the handler
+    instead of returning False with a logged reason.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logging.error("TELEGRAM_API_ID is not a valid integer: %r", value)
+        return None
 
 
 async def download_file_mtproto(bot_token: str, chat_id: int, message_id: int, dest_path: str) -> bool:
@@ -53,6 +92,10 @@ async def download_file_mtproto(bot_token: str, chat_id: int, message_id: int, d
         logging.error("TELEGRAM_API_ID/TELEGRAM_API_HASH not configured")
         return False
 
+    api_id_int = _parse_api_id(api_id)
+    if api_id_int is None:
+        return False
+
     # Use in-memory session to avoid session file creation
     session_name = f"bot_download_{chat_id}_{message_id}"
     session_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "downloads")
@@ -60,7 +103,7 @@ async def download_file_mtproto(bot_token: str, chat_id: int, message_id: int, d
 
     client = Client(
         name=session_name,
-        api_id=int(api_id),
+        api_id=api_id_int,
         api_hash=api_hash,
         bot_token=bot_token,
         workdir=session_dir,
@@ -89,13 +132,15 @@ async def download_file_mtproto(bot_token: str, chat_id: int, message_id: int, d
         return False
 
 
-def _build_client(chat_id: int, tag: str) -> "Client":
-    """Create a pyrogram Client configured for bot-mode MTProto operations."""
+def _build_client(chat_id: int, tag: str, api_id: int, api_hash: str) -> "Client":
+    """Create a pyrogram Client configured for bot-mode MTProto operations.
+
+    Callers are expected to have already validated api_id via _parse_api_id so
+    this function never raises for malformed configuration.
+    """
 
     from pyrogram import Client
 
-    api_id = get_runtime_value("TELEGRAM_API_ID", "")
-    api_hash = get_runtime_value("TELEGRAM_API_HASH", "")
     session_dir = os.path.join(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "downloads"
     )
@@ -103,7 +148,7 @@ def _build_client(chat_id: int, tag: str) -> "Client":
 
     return Client(
         name=f"bot_{tag}_{chat_id}",
-        api_id=int(api_id),
+        api_id=api_id,
         api_hash=api_hash,
         bot_token=get_runtime_value("TELEGRAM_BOT_TOKEN", ""),
         workdir=session_dir,
@@ -143,7 +188,11 @@ async def send_audio_mtproto(
         logging.error("TELEGRAM_API_ID/TELEGRAM_API_HASH not configured")
         return False
 
-    client = _build_client(chat_id, "send_audio")
+    api_id_int = _parse_api_id(api_id)
+    if api_id_int is None:
+        return False
+
+    client = _build_client(chat_id, "send_audio", api_id_int, api_hash)
 
     try:
         async with client:
@@ -195,7 +244,11 @@ async def send_video_mtproto(
         logging.error("TELEGRAM_API_ID/TELEGRAM_API_HASH not configured")
         return False
 
-    client = _build_client(chat_id, "send_video")
+    api_id_int = _parse_api_id(api_id)
+    if api_id_int is None:
+        return False
+
+    client = _build_client(chat_id, "send_video", api_id_int, api_hash)
 
     try:
         async with client:

--- a/bot/platforms/__init__.py
+++ b/bot/platforms/__init__.py
@@ -1,1 +1,92 @@
-"""Platform registry package. Contents land in Task 3."""
+"""Platform registry.
+
+Single source of truth for supported platforms. Integration sites import
+``PLATFORMS`` for iteration, ``get_platform`` for name-based lookup, and
+``detect_by_domain`` / ``all_domains`` for URL-based lookup.
+
+Platform modules under this package export a single ``CONFIG`` of type
+:class:`PlatformConfig`. To add a platform:
+
+1. Create ``bot/platforms/<name>.py`` exporting ``CONFIG``.
+2. Add the module to the imports and the ``PLATFORMS`` tuple below.
+"""
+
+from __future__ import annotations
+
+from bot.platforms import (
+    castbox,
+    instagram,
+    linkedin,
+    spotify,
+    tiktok,
+    vimeo,
+    x,
+    youtube,
+)
+from bot.platforms.base import PlatformConfig
+
+__all__ = [
+    "PlatformConfig",
+    "PLATFORMS",
+    "get_platform",
+    "detect_by_domain",
+    "all_domains",
+]
+
+PLATFORMS: tuple[PlatformConfig, ...] = (
+    youtube.CONFIG,
+    vimeo.CONFIG,
+    tiktok.CONFIG,
+    linkedin.CONFIG,
+    x.CONFIG,
+    instagram.CONFIG,
+    castbox.CONFIG,
+    spotify.CONFIG,
+)
+
+
+def _expand_with_www(domains: tuple[str, ...]) -> tuple[str, ...]:
+    """Return domains plus www.-prefixed variants for non-subdomain entries.
+
+    Mirrors the behavior previously inlined in bot/security_policy.py: a
+    domain with exactly one dot (e.g. ``x.com``) also matches ``www.x.com``.
+    Subdomain entries like ``mobile.twitter.com`` are not www-expanded.
+    """
+
+    expanded: list[str] = []
+    for domain in domains:
+        expanded.append(domain)
+        if domain.count(".") == 1:
+            expanded.append(f"www.{domain}")
+    return tuple(expanded)
+
+
+_BY_NAME: dict[str, PlatformConfig] = {p.name: p for p in PLATFORMS}
+_BY_DOMAIN: dict[str, PlatformConfig] = {
+    domain: p
+    for p in PLATFORMS
+    for domain in _expand_with_www(p.domains)
+}
+_ALL_DOMAINS: frozenset[str] = frozenset(_BY_DOMAIN.keys())
+
+
+def get_platform(name: str | None) -> PlatformConfig | None:
+    """Return the PlatformConfig matching ``name`` or None."""
+
+    if not name:
+        return None
+    return _BY_NAME.get(name)
+
+
+def detect_by_domain(host: str | None) -> PlatformConfig | None:
+    """Return the PlatformConfig matching ``host`` (case-insensitive) or None."""
+
+    if not host:
+        return None
+    return _BY_DOMAIN.get(host.lower())
+
+
+def all_domains() -> frozenset[str]:
+    """Return the full set of supported domains (including www. variants)."""
+
+    return _ALL_DOMAINS

--- a/bot/platforms/__init__.py
+++ b/bot/platforms/__init__.py
@@ -1,0 +1,1 @@
+"""Platform registry package. Contents land in Task 3."""

--- a/bot/platforms/base.py
+++ b/bot/platforms/base.py
@@ -1,0 +1,24 @@
+"""PlatformConfig dataclass — data contract for each supported platform."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, kw_only=True)
+class PlatformConfig:
+    """Declarative per-platform configuration.
+
+    Platform modules under bot/platforms/ export exactly one of these as CONFIG.
+    Integration sites read fields via bot.platforms.get_platform(name).
+    """
+
+    name: str
+    display_name: str
+    domains: tuple[str, ...]
+    hide_flac: bool
+    hide_time_range: bool
+    is_podcast: bool
+    media_label: str
+    requires_cookies: bool
+    cookies_hint: str | None = None

--- a/bot/platforms/castbox.py
+++ b/bot/platforms/castbox.py
@@ -1,0 +1,15 @@
+"""Castbox platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="castbox",
+    display_name="Castbox",
+    domains=("castbox.fm",),
+    hide_flac=True,
+    hide_time_range=True,
+    is_podcast=True,
+    media_label="odcinku",
+    requires_cookies=False,
+    cookies_hint=None,
+)

--- a/bot/platforms/instagram.py
+++ b/bot/platforms/instagram.py
@@ -1,0 +1,20 @@
+"""Instagram platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="instagram",
+    display_name="Instagram",
+    domains=("instagram.com",),
+    hide_flac=False,
+    hide_time_range=False,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=True,
+    cookies_hint=(
+        "Instagram blokuje większość postów bez aktywnej sesji. "
+        "Zaloguj się na instagram.com i wyeksportuj cookies rozszerzeniem "
+        "\"Get cookies.txt LOCALLY\". Do zdjęć/karuzel potrzebny jest "
+        "dodatkowo pakiet instaloader."
+    ),
+)

--- a/bot/platforms/linkedin.py
+++ b/bot/platforms/linkedin.py
@@ -1,0 +1,19 @@
+"""LinkedIn platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="linkedin",
+    display_name="LinkedIn",
+    domains=("linkedin.com",),
+    hide_flac=False,
+    hide_time_range=False,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=True,
+    cookies_hint=(
+        "LinkedIn wymaga zalogowania do pobierania video z postów. "
+        "Zaloguj się na linkedin.com i wyeksportuj cookies rozszerzeniem "
+        "\"Get cookies.txt LOCALLY\"."
+    ),
+)

--- a/bot/platforms/spotify.py
+++ b/bot/platforms/spotify.py
@@ -1,0 +1,15 @@
+"""Spotify platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="spotify",
+    display_name="Spotify",
+    domains=("open.spotify.com",),
+    hide_flac=True,
+    hide_time_range=True,
+    is_podcast=True,
+    media_label="odcinku",
+    requires_cookies=False,
+    cookies_hint=None,
+)

--- a/bot/platforms/tiktok.py
+++ b/bot/platforms/tiktok.py
@@ -1,0 +1,19 @@
+"""TikTok platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="tiktok",
+    display_name="TikTok",
+    domains=("tiktok.com", "m.tiktok.com", "vm.tiktok.com"),
+    hide_flac=True,
+    hide_time_range=True,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=True,
+    cookies_hint=(
+        "TikTok często wymaga zalogowania. Zaloguj się na tiktok.com "
+        "w przeglądarce i wyeksportuj cookies rozszerzeniem "
+        "\"Get cookies.txt LOCALLY\"."
+    ),
+)

--- a/bot/platforms/vimeo.py
+++ b/bot/platforms/vimeo.py
@@ -1,0 +1,15 @@
+"""Vimeo platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="vimeo",
+    display_name="Vimeo",
+    domains=("vimeo.com", "player.vimeo.com"),
+    hide_flac=False,
+    hide_time_range=False,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=False,
+    cookies_hint=None,
+)

--- a/bot/platforms/x.py
+++ b/bot/platforms/x.py
@@ -1,0 +1,19 @@
+"""X (Twitter) platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="x",
+    display_name="X",
+    domains=("x.com", "twitter.com", "mobile.twitter.com"),
+    hide_flac=True,
+    hide_time_range=True,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=True,
+    cookies_hint=(
+        "Wiele tweetów (szczególnie oznaczonych jako Sensitive) wymaga "
+        "zalogowania. Zaloguj się na x.com w przeglądarce i wyeksportuj "
+        "cookies rozszerzeniem \"Get cookies.txt LOCALLY\"."
+    ),
+)

--- a/bot/platforms/youtube.py
+++ b/bot/platforms/youtube.py
@@ -1,0 +1,20 @@
+"""YouTube platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="youtube",
+    display_name="YouTube",
+    domains=("youtube.com", "youtu.be", "m.youtube.com", "music.youtube.com"),
+    hide_flac=False,
+    hide_time_range=False,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=False,
+    cookies_hint=(
+        "YouTube czasem blokuje pobieranie komunikatem "
+        "\"Sign in to confirm you're not a bot\". Zaloguj się na YouTube "
+        "w przeglądarce i wyeksportuj cookies rozszerzeniem "
+        "\"Get cookies.txt LOCALLY\"."
+    ),
+)

--- a/bot/security_policy.py
+++ b/bot/security_policy.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import re
 from urllib.parse import parse_qs, urlparse
 
+from bot.platforms import all_domains, detect_by_domain, get_platform
+
 # Matches http(s) URLs; trailing punctuation is trimmed after the match.
 _URL_PATTERN = re.compile(r'https?://[^\s<>"\'`]+')
 _URL_TRAILING_PUNCT = '.,;:!?)]}>"\''
-
-from bot.platforms import all_domains, detect_by_domain, get_platform
 
 # Kept as a module attribute for backward compatibility with external code
 # (tests, downstream imports). Prefer bot.platforms.all_domains() in new code.

--- a/bot/security_policy.py
+++ b/bot/security_policy.py
@@ -95,20 +95,43 @@ def validate_url(url) -> bool:
     return False
 
 
+def _offline_redirect_target(url: str) -> str | None:
+    """Resolve supported redirect URLs without network I/O.
+
+    Mirrors the offline branch of normalize_url so extract_url_from_text can
+    recognize Castbox share links (d.castbox.fm?link=...) as supported. Network
+    resolution (HEAD on castbox.fm/ch/...) stays in normalize_url, which runs
+    in an executor off the event loop.
+    """
+
+    try:
+        parsed = urlparse(url)
+        if parsed.netloc.lower() == 'd.castbox.fm':
+            link_param = parse_qs(parsed.query).get('link', [None])[0]
+            if link_param and 'castbox.fm' in link_param:
+                return link_param
+    except Exception:
+        pass
+    return None
+
+
 def extract_url_from_text(text) -> str | None:
     """Return the first supported URL found in free-form text, or None.
 
     Handles messages where the user prefixes the link with descriptive text
     (e.g. "please download this: https://youtu.be/abc"). Trailing punctuation
     like '.', ',', ')' is stripped so copy-pasted URLs still validate.
+    Redirect links resolvable without network I/O (e.g. d.castbox.fm share
+    URLs) are resolved up-front so the returned candidate passes validate_url.
     """
 
     if not isinstance(text, str) or not text:
         return None
     for match in _URL_PATTERN.finditer(text):
         candidate = match.group(0).rstrip(_URL_TRAILING_PUNCT)
-        if validate_url(candidate):
-            return candidate
+        resolved = _offline_redirect_target(candidate) or candidate
+        if validate_url(resolved):
+            return resolved
     return None
 
 

--- a/bot/security_policy.py
+++ b/bot/security_policy.py
@@ -9,26 +9,11 @@ from urllib.parse import parse_qs, urlparse
 _URL_PATTERN = re.compile(r'https?://[^\s<>"\'`]+')
 _URL_TRAILING_PUNCT = '.,;:!?)]}>"\''
 
-_DOMAIN_TO_PLATFORM = {
-    'youtube.com': 'youtube',
-    'youtu.be': 'youtube',
-    'm.youtube.com': 'youtube',
-    'music.youtube.com': 'youtube',
-    'vimeo.com': 'vimeo',
-    'player.vimeo.com': 'vimeo',
-    'tiktok.com': 'tiktok',
-    'm.tiktok.com': 'tiktok',
-    'vm.tiktok.com': 'tiktok',
-    'instagram.com': 'instagram',
-    'linkedin.com': 'linkedin',
-    'castbox.fm': 'castbox',
-    'open.spotify.com': 'spotify',
-}
+from bot.platforms import all_domains, detect_by_domain, get_platform
 
-ALLOWED_DOMAINS = sorted(
-    set(_DOMAIN_TO_PLATFORM.keys())
-    | {f'www.{domain}' for domain in _DOMAIN_TO_PLATFORM if domain.count('.') == 1}
-)
+# Kept as a module attribute for backward compatibility with external code
+# (tests, downstream imports). Prefer bot.platforms.all_domains() in new code.
+ALLOWED_DOMAINS = sorted(all_domains())
 
 
 def _normalize_domain(url: str) -> str | None:
@@ -77,9 +62,10 @@ def normalize_url(url: str, _depth: int = 0) -> str:
 def get_media_label(platform: str | None) -> str:
     """Return Polish locative noun for media type."""
 
-    if platform in ('castbox', 'spotify'):
-        return 'odcinku'
-    return 'filmie'
+    config = get_platform(platform)
+    if config is None:
+        return "filmie"
+    return config.media_label
 
 
 def validate_url(url) -> bool:
@@ -142,8 +128,10 @@ def detect_platform(url) -> str | None:
     if domain is None:
         return None
 
-    bare = domain[4:] if domain.startswith('www.') else domain
-    return _DOMAIN_TO_PLATFORM.get(bare) or _DOMAIN_TO_PLATFORM.get(domain)
+    config = detect_by_domain(domain)
+    if config is None and domain.startswith("www."):
+        config = detect_by_domain(domain[4:])
+    return config.name if config else None
 
 
 def estimate_file_size(info):

--- a/bot/services/auth_service.py
+++ b/bot/services/auth_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable
 
+from bot.platforms import PLATFORMS
 from bot.security_limits import BLOCK_TIME, MAX_ATTEMPTS
 from bot.security_pin import (
     clear_failed_attempts,
@@ -18,6 +19,12 @@ from bot.security_pin import (
     is_user_blocked,
     register_pin_failure,
 )
+
+
+def _platforms_inline_list() -> str:
+    """Return comma-separated display names for inline sentences."""
+
+    return ", ".join(p.display_name for p in PLATFORMS)
 
 
 @dataclass
@@ -100,7 +107,7 @@ def handle_start(
         return StartResult(
             message=(
                 f"Witaj, {user_name}!\n\n"
-                "Jesteś już zalogowany. Wyślij link (YouTube, Vimeo, TikTok, Instagram, LinkedIn, Castbox, Spotify) "
+                f"Jesteś już zalogowany. Wyślij link ({_platforms_inline_list()}) "
                 "aby pobrać film lub audio."
             )
         )
@@ -178,7 +185,7 @@ def handle_pin_input(
             handled=True,
             message=(
                 "PIN poprawny! Możesz teraz korzystać z bota.\n\n"
-                "Wyślij link (YouTube, Vimeo, TikTok, Instagram, LinkedIn, Castbox, Spotify) "
+                f"Wyślij link ({_platforms_inline_list()}) "
                 "aby pobrać film lub audio."
             ),
             delete_message=True,

--- a/docs/superpowers/plans/2026-04-23-x-platform-support.md
+++ b/docs/superpowers/plans/2026-04-23-x-platform-support.md
@@ -1,0 +1,1350 @@
+# X (Twitter) Platform Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add X (x.com, twitter.com, mobile.twitter.com) as a supported download platform while introducing a central `bot/platforms/` registry that eliminates scattered string checks for TikTok/Vimeo/LinkedIn.
+
+**Architecture:** Data-only `PlatformConfig` dataclass per platform + central registry with name/domain lookups. Integration sites (security_policy, common_ui, inbound_media, command_access, auth_service, download_callbacks) read from the registry instead of hardcoding platform names. Instagram, Castbox, Spotify, and YouTube get registry entries but their custom flows stay untouched.
+
+**Tech Stack:** Python 3.11+, `dataclasses`, `pytest`, yt-dlp ≥ 2024.12.6.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-x-platform-support-design.md`
+
+**Scope note:** During plan authoring, discovered a 6th integration point (`bot/services/auth_service.py` with two hardcoded platform-list strings) in addition to the 5 named in the spec. This plan includes it as Task 8.
+
+---
+
+## File Structure
+
+### Created
+
+| Path | Responsibility |
+|---|---|
+| `bot/platforms/__init__.py` | Registry: `PLATFORMS`, `get_platform`, `detect_by_domain`, `all_domains`, `_expand_with_www` |
+| `bot/platforms/base.py` | `PlatformConfig` dataclass (frozen, kw_only) |
+| `bot/platforms/youtube.py` | YouTube CONFIG (data only) |
+| `bot/platforms/vimeo.py` | Vimeo CONFIG |
+| `bot/platforms/tiktok.py` | TikTok CONFIG |
+| `bot/platforms/linkedin.py` | LinkedIn CONFIG |
+| `bot/platforms/x.py` | X CONFIG (new platform) |
+| `bot/platforms/instagram.py` | Instagram CONFIG |
+| `bot/platforms/castbox.py` | Castbox CONFIG |
+| `bot/platforms/spotify.py` | Spotify CONFIG |
+| `tests/test_platforms.py` | Registry integrity, lookup functions, per-platform regressions |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `bot/security_policy.py` | Replace `_DOMAIN_TO_PLATFORM`/`ALLOWED_DOMAINS`/`get_media_label` with registry delegation |
+| `bot/handlers/common_ui.py` | `build_main_keyboard` reads flags via `get_platform(name)` |
+| `bot/handlers/inbound_media.py` | Generate "Obsługiwane platformy" list from `PLATFORMS` |
+| `bot/handlers/command_access.py` | Generate `/start` platform list and `/status` cookies hint from registry |
+| `bot/services/auth_service.py` | Generate two PIN-flow platform-list strings from registry |
+| `bot/handlers/download_callbacks.py` | Add `cookies_hint` lookup; extract `GENERIC_COOKIES_HINT` constant |
+| `tests/test_security_policy.py` | Extend `detect_platform`/`validate_url` parametrizations with X |
+| `tests/test_command_access_handlers.py` | Relax assertions on the hardcoded 7-platform list so X inclusion passes |
+| `README.md` | Add X row to supported-platforms table |
+
+---
+
+### Task 1: PlatformConfig dataclass (TDD)
+
+**Files:**
+- Create: `bot/platforms/base.py`
+- Create: `bot/platforms/__init__.py` (empty module marker; real registry lands in Task 3)
+- Test: `tests/test_platforms.py`
+
+- [ ] **Step 1: Create empty `bot/platforms/__init__.py` so the package is importable**
+
+```python
+"""Platform registry package. Contents land in Task 3."""
+```
+
+- [ ] **Step 2: Write the failing test for `PlatformConfig`**
+
+Create `tests/test_platforms.py` with the following content:
+
+```python
+"""Tests for bot/platforms/ registry and per-platform CONFIG modules."""
+
+import dataclasses
+
+import pytest
+
+from bot.platforms.base import PlatformConfig
+
+
+def test_platform_config_is_frozen_and_kw_only():
+    config = PlatformConfig(
+        name="test",
+        display_name="Test",
+        domains=("test.com",),
+        hide_flac=False,
+        hide_time_range=False,
+        is_podcast=False,
+        media_label="filmie",
+        requires_cookies=False,
+    )
+    assert dataclasses.is_dataclass(config)
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        config.name = "mutated"  # type: ignore[misc]
+
+
+def test_platform_config_defaults_cookies_hint_to_none():
+    config = PlatformConfig(
+        name="test",
+        display_name="Test",
+        domains=("test.com",),
+        hide_flac=False,
+        hide_time_range=False,
+        is_podcast=False,
+        media_label="filmie",
+        requires_cookies=False,
+    )
+    assert config.cookies_hint is None
+
+
+def test_platform_config_requires_keyword_arguments():
+    with pytest.raises(TypeError):
+        PlatformConfig(  # type: ignore[call-arg]
+            "test", "Test", ("test.com",), False, False, False, "filmie", False
+        )
+
+
+def test_platform_config_equality_on_same_fields():
+    a = PlatformConfig(
+        name="test",
+        display_name="Test",
+        domains=("test.com",),
+        hide_flac=False,
+        hide_time_range=False,
+        is_podcast=False,
+        media_label="filmie",
+        requires_cookies=False,
+    )
+    b = PlatformConfig(
+        name="test",
+        display_name="Test",
+        domains=("test.com",),
+        hide_flac=False,
+        hide_time_range=False,
+        is_podcast=False,
+        media_label="filmie",
+        requires_cookies=False,
+    )
+    assert a == b
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `source venv/bin/activate && pytest tests/test_platforms.py -v`
+Expected: FAIL with `ImportError: No module named 'bot.platforms.base'`
+
+- [ ] **Step 4: Implement `PlatformConfig`**
+
+Create `bot/platforms/base.py`:
+
+```python
+"""PlatformConfig dataclass — data contract for each supported platform."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, kw_only=True)
+class PlatformConfig:
+    """Declarative per-platform configuration.
+
+    Platform modules under bot/platforms/ export exactly one of these as CONFIG.
+    Integration sites read fields via bot.platforms.get_platform(name).
+    """
+
+    name: str
+    display_name: str
+    domains: tuple[str, ...]
+    hide_flac: bool
+    hide_time_range: bool
+    is_podcast: bool
+    media_label: str
+    requires_cookies: bool
+    cookies_hint: str | None = None
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_platforms.py -v`
+Expected: 4 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bot/platforms/__init__.py bot/platforms/base.py tests/test_platforms.py
+git commit -m "Add PlatformConfig dataclass for platform registry"
+```
+
+---
+
+### Task 2: Per-platform CONFIG modules (bulk)
+
+**Files:**
+- Create: `bot/platforms/youtube.py`
+- Create: `bot/platforms/vimeo.py`
+- Create: `bot/platforms/tiktok.py`
+- Create: `bot/platforms/linkedin.py`
+- Create: `bot/platforms/x.py`
+- Create: `bot/platforms/instagram.py`
+- Create: `bot/platforms/castbox.py`
+- Create: `bot/platforms/spotify.py`
+
+These are pure data files with no logic. The registry in Task 3 will import them; the tests in Task 3 verify them.
+
+- [ ] **Step 1: Create `bot/platforms/youtube.py`**
+
+```python
+"""YouTube platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="youtube",
+    display_name="YouTube",
+    domains=("youtube.com", "youtu.be", "m.youtube.com", "music.youtube.com"),
+    hide_flac=False,
+    hide_time_range=False,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=False,
+    cookies_hint=(
+        "YouTube czasem blokuje pobieranie komunikatem "
+        "\"Sign in to confirm you're not a bot\". Zaloguj się na YouTube "
+        "w przeglądarce i wyeksportuj cookies rozszerzeniem "
+        "\"Get cookies.txt LOCALLY\"."
+    ),
+)
+```
+
+- [ ] **Step 2: Create `bot/platforms/vimeo.py`**
+
+```python
+"""Vimeo platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="vimeo",
+    display_name="Vimeo",
+    domains=("vimeo.com", "player.vimeo.com"),
+    hide_flac=False,
+    hide_time_range=False,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=False,
+    cookies_hint=None,
+)
+```
+
+- [ ] **Step 3: Create `bot/platforms/tiktok.py`**
+
+```python
+"""TikTok platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="tiktok",
+    display_name="TikTok",
+    domains=("tiktok.com", "m.tiktok.com", "vm.tiktok.com"),
+    hide_flac=True,
+    hide_time_range=True,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=True,
+    cookies_hint=(
+        "TikTok często wymaga zalogowania. Zaloguj się na tiktok.com "
+        "w przeglądarce i wyeksportuj cookies rozszerzeniem "
+        "\"Get cookies.txt LOCALLY\"."
+    ),
+)
+```
+
+- [ ] **Step 4: Create `bot/platforms/linkedin.py`**
+
+```python
+"""LinkedIn platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="linkedin",
+    display_name="LinkedIn",
+    domains=("linkedin.com",),
+    hide_flac=False,
+    hide_time_range=False,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=True,
+    cookies_hint=(
+        "LinkedIn wymaga zalogowania do pobierania video z postów. "
+        "Zaloguj się na linkedin.com i wyeksportuj cookies rozszerzeniem "
+        "\"Get cookies.txt LOCALLY\"."
+    ),
+)
+```
+
+- [ ] **Step 5: Create `bot/platforms/x.py`**
+
+```python
+"""X (Twitter) platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="x",
+    display_name="X",
+    domains=("x.com", "twitter.com", "mobile.twitter.com"),
+    hide_flac=True,
+    hide_time_range=True,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=True,
+    cookies_hint=(
+        "Wiele tweetów (szczególnie oznaczonych jako Sensitive) wymaga "
+        "zalogowania. Zaloguj się na x.com w przeglądarce i wyeksportuj "
+        "cookies rozszerzeniem \"Get cookies.txt LOCALLY\"."
+    ),
+)
+```
+
+- [ ] **Step 6: Create `bot/platforms/instagram.py`**
+
+```python
+"""Instagram platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="instagram",
+    display_name="Instagram",
+    domains=("instagram.com",),
+    hide_flac=False,
+    hide_time_range=False,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=True,
+    cookies_hint=(
+        "Instagram blokuje większość postów bez aktywnej sesji. "
+        "Zaloguj się na instagram.com i wyeksportuj cookies rozszerzeniem "
+        "\"Get cookies.txt LOCALLY\". Do zdjęć/karuzel potrzebny jest "
+        "dodatkowo pakiet instaloader."
+    ),
+)
+```
+
+- [ ] **Step 7: Create `bot/platforms/castbox.py`**
+
+```python
+"""Castbox platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="castbox",
+    display_name="Castbox",
+    domains=("castbox.fm",),
+    hide_flac=True,
+    hide_time_range=True,
+    is_podcast=True,
+    media_label="odcinku",
+    requires_cookies=False,
+    cookies_hint=None,
+)
+```
+
+- [ ] **Step 8: Create `bot/platforms/spotify.py`**
+
+```python
+"""Spotify platform config."""
+
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="spotify",
+    display_name="Spotify",
+    domains=("open.spotify.com",),
+    hide_flac=True,
+    hide_time_range=True,
+    is_podcast=True,
+    media_label="odcinku",
+    requires_cookies=False,
+    cookies_hint=None,
+)
+```
+
+- [ ] **Step 9: Verify all modules import cleanly**
+
+Run:
+```bash
+python -c "
+from bot.platforms import youtube, vimeo, tiktok, linkedin, x, instagram, castbox, spotify
+for m in (youtube, vimeo, tiktok, linkedin, x, instagram, castbox, spotify):
+    print(f'{m.__name__}: {m.CONFIG.name}')
+"
+```
+Expected: eight lines listing each module and its platform name.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add bot/platforms/
+git commit -m "Add per-platform CONFIG modules"
+```
+
+---
+
+### Task 3: Registry (`bot/platforms/__init__.py`) with tests
+
+**Files:**
+- Modify: `bot/platforms/__init__.py`
+- Modify: `tests/test_platforms.py`
+
+- [ ] **Step 1: Append registry tests to `tests/test_platforms.py`**
+
+Add to the bottom of the existing `tests/test_platforms.py`:
+
+```python
+# Registry tests start here
+
+
+import bot.platforms as platforms_pkg
+
+
+def test_platforms_registry_is_non_empty_tuple():
+    assert isinstance(platforms_pkg.PLATFORMS, tuple)
+    assert len(platforms_pkg.PLATFORMS) == 8
+
+
+def test_all_platforms_have_unique_names():
+    names = [p.name for p in platforms_pkg.PLATFORMS]
+    assert len(names) == len(set(names))
+
+
+def test_no_overlapping_domains_across_platforms():
+    seen: dict[str, str] = {}
+    for p in platforms_pkg.PLATFORMS:
+        for domain in p.domains:
+            assert domain not in seen, (
+                f"Domain {domain!r} used by both "
+                f"{seen.get(domain)!r} and {p.name!r}"
+            )
+            seen[domain] = p.name
+
+
+@pytest.mark.parametrize(
+    "host, expected_name",
+    [
+        ("youtube.com", "youtube"),
+        ("youtu.be", "youtube"),
+        ("m.youtube.com", "youtube"),
+        ("music.youtube.com", "youtube"),
+        ("www.youtube.com", "youtube"),
+        ("vimeo.com", "vimeo"),
+        ("www.vimeo.com", "vimeo"),
+        ("player.vimeo.com", "vimeo"),
+        ("tiktok.com", "tiktok"),
+        ("www.tiktok.com", "tiktok"),
+        ("m.tiktok.com", "tiktok"),
+        ("vm.tiktok.com", "tiktok"),
+        ("linkedin.com", "linkedin"),
+        ("www.linkedin.com", "linkedin"),
+        ("x.com", "x"),
+        ("www.x.com", "x"),
+        ("twitter.com", "x"),
+        ("www.twitter.com", "x"),
+        ("mobile.twitter.com", "x"),
+        ("instagram.com", "instagram"),
+        ("www.instagram.com", "instagram"),
+        ("castbox.fm", "castbox"),
+        ("www.castbox.fm", "castbox"),
+        ("open.spotify.com", "spotify"),
+    ],
+)
+def test_detect_by_domain_matches_known_hosts(host, expected_name):
+    config = platforms_pkg.detect_by_domain(host)
+    assert config is not None
+    assert config.name == expected_name
+
+
+def test_detect_by_domain_returns_none_for_unknown_host():
+    assert platforms_pkg.detect_by_domain("example.com") is None
+    assert platforms_pkg.detect_by_domain("") is None
+
+
+def test_detect_by_domain_is_case_insensitive():
+    assert platforms_pkg.detect_by_domain("X.COM").name == "x"
+    assert platforms_pkg.detect_by_domain("WwW.YouTube.Com").name == "youtube"
+
+
+def test_get_platform_returns_config_for_known_names():
+    for p in platforms_pkg.PLATFORMS:
+        assert platforms_pkg.get_platform(p.name) is p
+
+
+def test_get_platform_returns_none_for_unknown():
+    assert platforms_pkg.get_platform("facebook") is None
+    assert platforms_pkg.get_platform("") is None
+
+
+def test_all_domains_includes_www_variants_for_bare_domains():
+    domains = platforms_pkg.all_domains()
+    assert "x.com" in domains
+    assert "www.x.com" in domains
+    assert "mobile.twitter.com" in domains
+    # Subdomain entries should NOT be www-expanded
+    assert "www.mobile.twitter.com" not in domains
+    assert "www.m.youtube.com" not in domains
+
+
+def test_x_platform_has_tiktok_style_menu_flags():
+    x_config = platforms_pkg.get_platform("x")
+    assert x_config is not None
+    assert x_config.hide_flac is True
+    assert x_config.hide_time_range is True
+    assert x_config.is_podcast is False
+
+
+def test_cookies_hint_set_for_platforms_requiring_cookies_except_podcasts():
+    for p in platforms_pkg.PLATFORMS:
+        if p.is_podcast:
+            assert p.cookies_hint is None, (
+                f"Podcast platform {p.name!r} should not have cookies_hint"
+            )
+            continue
+        if p.requires_cookies:
+            assert p.cookies_hint is not None, (
+                f"Platform {p.name!r} marked requires_cookies but has no hint"
+            )
+```
+
+- [ ] **Step 2: Run registry tests to verify they fail**
+
+Run: `pytest tests/test_platforms.py -v`
+Expected: all registry tests FAIL (module `bot.platforms` has no `PLATFORMS` / `get_platform` / etc.)
+
+- [ ] **Step 3: Implement the registry**
+
+Replace content of `bot/platforms/__init__.py` with:
+
+```python
+"""Platform registry.
+
+Single source of truth for supported platforms. Integration sites import
+``PLATFORMS`` for iteration, ``get_platform`` for name-based lookup, and
+``detect_by_domain`` / ``all_domains`` for URL-based lookup.
+
+Platform modules under this package export a single ``CONFIG`` of type
+:class:`PlatformConfig`. To add a platform:
+
+1. Create ``bot/platforms/<name>.py`` exporting ``CONFIG``.
+2. Add the module to the imports and the ``PLATFORMS`` tuple below.
+"""
+
+from __future__ import annotations
+
+from bot.platforms import (
+    castbox,
+    instagram,
+    linkedin,
+    spotify,
+    tiktok,
+    vimeo,
+    x,
+    youtube,
+)
+from bot.platforms.base import PlatformConfig
+
+__all__ = [
+    "PlatformConfig",
+    "PLATFORMS",
+    "get_platform",
+    "detect_by_domain",
+    "all_domains",
+]
+
+PLATFORMS: tuple[PlatformConfig, ...] = (
+    youtube.CONFIG,
+    vimeo.CONFIG,
+    tiktok.CONFIG,
+    linkedin.CONFIG,
+    x.CONFIG,
+    instagram.CONFIG,
+    castbox.CONFIG,
+    spotify.CONFIG,
+)
+
+
+def _expand_with_www(domains: tuple[str, ...]) -> tuple[str, ...]:
+    """Return domains plus www.-prefixed variants for non-subdomain entries.
+
+    Mirrors the behavior previously inlined in bot/security_policy.py: a
+    domain with exactly one dot (e.g. ``x.com``) also matches ``www.x.com``.
+    Subdomain entries like ``mobile.twitter.com`` are not www-expanded.
+    """
+
+    expanded: list[str] = []
+    for domain in domains:
+        expanded.append(domain)
+        if domain.count(".") == 1:
+            expanded.append(f"www.{domain}")
+    return tuple(expanded)
+
+
+_BY_NAME: dict[str, PlatformConfig] = {p.name: p for p in PLATFORMS}
+_BY_DOMAIN: dict[str, PlatformConfig] = {
+    domain: p
+    for p in PLATFORMS
+    for domain in _expand_with_www(p.domains)
+}
+_ALL_DOMAINS: frozenset[str] = frozenset(_BY_DOMAIN.keys())
+
+
+def get_platform(name: str | None) -> PlatformConfig | None:
+    """Return the PlatformConfig matching ``name`` or None."""
+
+    if not name:
+        return None
+    return _BY_NAME.get(name)
+
+
+def detect_by_domain(host: str | None) -> PlatformConfig | None:
+    """Return the PlatformConfig matching ``host`` (case-insensitive) or None."""
+
+    if not host:
+        return None
+    return _BY_DOMAIN.get(host.lower())
+
+
+def all_domains() -> frozenset[str]:
+    """Return the full set of supported domains (including www. variants)."""
+
+    return _ALL_DOMAINS
+```
+
+- [ ] **Step 4: Run all platform tests**
+
+Run: `pytest tests/test_platforms.py -v`
+Expected: all tests pass (data class tests from Task 1 + registry tests from Task 3)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bot/platforms/__init__.py tests/test_platforms.py
+git commit -m "Add platform registry with name and domain lookups"
+```
+
+---
+
+### Task 4: Refactor `bot/security_policy.py` to use the registry
+
+**Files:**
+- Modify: `bot/security_policy.py`
+- Test: `tests/test_security_policy.py` (should still pass, not modified in this task)
+
+- [ ] **Step 1: Run the existing security_policy tests (baseline)**
+
+Run: `pytest tests/test_security_policy.py -v`
+Expected: all tests pass (this is the pre-refactor baseline)
+
+- [ ] **Step 2: Replace the domain map and helpers with registry delegation**
+
+In `bot/security_policy.py`, replace the block from line 12 to line 31 (the
+`_DOMAIN_TO_PLATFORM` dict and `ALLOWED_DOMAINS` sorted set) with:
+
+```python
+from bot.platforms import all_domains, detect_by_domain, get_platform
+
+# Kept as a module attribute for backward compatibility with external code
+# (tests, downstream imports). Prefer bot.platforms.all_domains() in new code.
+ALLOWED_DOMAINS = sorted(all_domains())
+```
+
+- [ ] **Step 3: Refactor `get_media_label` (lines 77-82)**
+
+Replace the existing function body with:
+
+```python
+def get_media_label(platform: str | None) -> str:
+    """Return Polish locative noun for media type."""
+
+    config = get_platform(platform)
+    if config is None:
+        return "filmie"
+    return config.media_label
+```
+
+- [ ] **Step 4: Refactor `detect_platform` (lines 138-146)**
+
+Replace the existing function body with:
+
+```python
+def detect_platform(url) -> str | None:
+    """Detect source platform name from URL."""
+
+    domain = _normalize_domain(url)
+    if domain is None:
+        return None
+
+    config = detect_by_domain(domain)
+    if config is None and domain.startswith("www."):
+        config = detect_by_domain(domain[4:])
+    return config.name if config else None
+```
+
+- [ ] **Step 5: Run security_policy tests**
+
+Run: `pytest tests/test_security_policy.py -v`
+Expected: all tests still pass
+
+- [ ] **Step 6: Run the full test suite to catch regressions elsewhere**
+
+Run: `pytest -x`
+Expected: all tests pass (X is not yet integrated into UI sites; we are only testing the registry plumbing)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add bot/security_policy.py
+git commit -m "Delegate platform detection to bot/platforms registry"
+```
+
+---
+
+### Task 5: Refactor `bot/handlers/common_ui.py`
+
+**Files:**
+- Modify: `bot/handlers/common_ui.py`
+
+- [ ] **Step 1: Add a test for the refactor behavior**
+
+Append to `tests/test_platforms.py`:
+
+```python
+def test_build_main_keyboard_reads_flags_from_registry():
+    from bot.handlers.common_ui import build_main_keyboard
+
+    # TikTok → hide FLAC and time-range
+    tiktok_keyboard = build_main_keyboard("tiktok")
+    flat_callbacks = [
+        btn.callback_data
+        for row in tiktok_keyboard
+        for btn in row
+    ]
+    assert "dl_audio_flac" not in flat_callbacks
+    assert "time_range" not in flat_callbacks
+
+    # YouTube → FLAC and time-range present
+    yt_keyboard = build_main_keyboard("youtube")
+    flat_callbacks = [
+        btn.callback_data
+        for row in yt_keyboard
+        for btn in row
+    ]
+    assert "dl_audio_flac" in flat_callbacks
+    assert "time_range" in flat_callbacks
+
+    # X → same shape as TikTok
+    x_keyboard = build_main_keyboard("x")
+    flat_callbacks = [
+        btn.callback_data
+        for row in x_keyboard
+        for btn in row
+    ]
+    assert "dl_audio_flac" not in flat_callbacks
+    assert "time_range" not in flat_callbacks
+
+
+def test_build_main_keyboard_raises_on_unknown_platform():
+    from bot.handlers.common_ui import build_main_keyboard
+
+    with pytest.raises(ValueError, match="Unknown platform"):
+        build_main_keyboard("facebook")
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `pytest tests/test_platforms.py -v -k "build_main_keyboard"`
+Expected: `test_build_main_keyboard_raises_on_unknown_platform` FAILS (current
+code returns a keyboard for any string); the TikTok/YouTube checks likely pass
+by coincidence but will confirm the refactor preserves behavior.
+
+- [ ] **Step 3: Refactor `build_main_keyboard`**
+
+In `bot/handlers/common_ui.py`, replace lines 18-23 with:
+
+```python
+def build_main_keyboard(platform: str, large_file: bool = False) -> list:
+    """Build the main format selection keyboard for a detected platform."""
+
+    from bot.platforms import get_platform
+
+    config = get_platform(platform)
+    if config is None:
+        raise ValueError(f"Unknown platform in session: {platform!r}")
+    is_podcast = config.is_podcast
+    hide_flac = config.hide_flac
+    hide_time_range = config.hide_time_range
+```
+
+(The rest of the function body — `if is_podcast:` onwards — stays unchanged.)
+
+- [ ] **Step 4: Run the new tests**
+
+Run: `pytest tests/test_platforms.py -v -k "build_main_keyboard"`
+Expected: both tests pass
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `pytest -x`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bot/handlers/common_ui.py tests/test_platforms.py
+git commit -m "Read keyboard flags from platform registry"
+```
+
+---
+
+### Task 6: Refactor `bot/handlers/inbound_media.py` supported-platforms message
+
+**Files:**
+- Modify: `bot/handlers/inbound_media.py`
+
+- [ ] **Step 1: Replace the hardcoded list with a registry-driven formatter**
+
+In `bot/handlers/inbound_media.py`, replace lines 264-275 (the `if not validate_url(...)` block with its `reply_text(...)` containing the hardcoded list) with:
+
+```python
+    if not validate_url(message_text):
+        from bot.platforms import PLATFORMS
+
+        platform_lines = "\n".join(
+            f"- {p.display_name} ({p.domains[0]})" for p in PLATFORMS
+        )
+        await update.message.reply_text(
+            "Nieprawidłowy URL!\n\n"
+            "Obsługiwane platformy:\n"
+            f"{platform_lines}"
+        )
+        return
+```
+
+- [ ] **Step 2: Verify smoke test**
+
+Run:
+```bash
+python -c "
+from bot.platforms import PLATFORMS
+for p in PLATFORMS:
+    print(f'- {p.display_name} ({p.domains[0]})')
+"
+```
+Expected output includes `- X (x.com)` among 8 lines.
+
+- [ ] **Step 3: Run relevant test files**
+
+Run: `pytest tests/test_inbound_media_handlers.py -v`
+Expected: all pass (the existing test only checks for "Nieprawidłowy URL"
+substring, which is preserved).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bot/handlers/inbound_media.py
+git commit -m "Generate supported-platforms message from registry"
+```
+
+---
+
+### Task 7: Refactor `bot/handlers/command_access.py`
+
+**Files:**
+- Modify: `bot/handlers/command_access.py`
+
+- [ ] **Step 1: Inspect the current `/help` message**
+
+Run: `grep -n "Obsługiwane platformy\|TikTok, Instagram" bot/handlers/command_access.py`
+Expected: matches around lines 220 (the `/help` platform list) and 229 (the
+"TikTok, Instagram i LinkedIn" cookies hint) and 277 (the `/status` cookies
+hint).
+
+- [ ] **Step 2: Add the helper functions at module top (after imports)**
+
+Find the import block at the top of `bot/handlers/command_access.py` and add immediately after it:
+
+```python
+from bot.platforms import PLATFORMS
+
+
+def _format_supported_platforms_block() -> str:
+    """Return a newline-joined bullet list of platforms for help messages."""
+
+    return "\n".join(f"- {p.display_name} ({p.domains[0]})" for p in PLATFORMS)
+
+
+def _format_cookies_required_names() -> str:
+    """Return a comma-separated list of platforms that typically need cookies.txt."""
+
+    names = [p.display_name for p in PLATFORMS if p.requires_cookies]
+    return ", ".join(names)
+```
+
+- [ ] **Step 3: Replace the `/help` platform list and cookies hint**
+
+In `bot/handlers/command_access.py`, replace the block from line 220 to 230
+(the hardcoded platform bullets + "TikTok, Instagram i LinkedIn" hint) with:
+
+```python
+        "🌐 *Obsługiwane platformy:*\n"
+        f"{_format_supported_platforms_block()}\n\n"
+        "🔒 *Platformy wymagające logowania:*\n"
+        f"{_format_cookies_required_names()} mogą wymagać pliku cookies.txt\n"
+        "do pobierania treści z ograniczonym dostępem.\n\n"
+        "Komendy administracyjne:\n"
+        "- /status - sprawdź przestrzeń dyskową\n"
+        "- /cleanup - usuń stare pliki (>24h)",
+```
+
+- [ ] **Step 4: Replace the `/status` cookies hint**
+
+In the same file, replace line 277:
+
+```python
+        status_msg += f"\n**cookies.txt:** ❌ brak ({_format_cookies_required_names()} mogą wymagać)\n"
+```
+
+- [ ] **Step 5: Smoke test**
+
+Run:
+```bash
+python -c "
+from bot.handlers.command_access import _format_supported_platforms_block, _format_cookies_required_names
+print(_format_supported_platforms_block())
+print('---')
+print(_format_cookies_required_names())
+"
+```
+Expected: 8-line bullet list including X; cookies list includes YouTube,
+TikTok, LinkedIn, X, Instagram.
+
+- [ ] **Step 6: Run command_access tests**
+
+Run: `pytest tests/test_command_access_handlers.py -v`
+Expected: all tests pass (or fail only on hardcoded 7-platform list
+assertions, which Task 11 will address).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add bot/handlers/command_access.py
+git commit -m "Generate /help and /status platform lists from registry"
+```
+
+---
+
+### Task 8: Refactor `bot/services/auth_service.py`
+
+**Files:**
+- Modify: `bot/services/auth_service.py`
+
+- [ ] **Step 1: Locate the two hardcoded strings**
+
+Run: `grep -n "YouTube, Vimeo, TikTok" bot/services/auth_service.py`
+Expected: matches around lines 103 and 181.
+
+- [ ] **Step 2: Add a helper near the top of `auth_service.py` (after existing imports)**
+
+```python
+from bot.platforms import PLATFORMS
+
+
+def _platforms_inline_list() -> str:
+    """Return comma-separated display names for inline sentences."""
+
+    return ", ".join(p.display_name for p in PLATFORMS)
+```
+
+- [ ] **Step 3: Replace both hardcoded strings**
+
+Line 103:
+```python
+                f"Jesteś już zalogowany. Wyślij link ({_platforms_inline_list()}) "
+```
+
+Line 181:
+```python
+                f"Wyślij link ({_platforms_inline_list()}) "
+```
+
+- [ ] **Step 4: Smoke test**
+
+Run:
+```bash
+python -c "from bot.services.auth_service import _platforms_inline_list; print(_platforms_inline_list())"
+```
+Expected: `YouTube, Vimeo, TikTok, LinkedIn, X, Instagram, Castbox, Spotify`
+
+- [ ] **Step 5: Run auth_service tests**
+
+Run: `pytest tests/test_auth_service.py -v`
+Expected: all tests pass (or fail only on hardcoded 7-platform list
+assertions, which Task 11 will address).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bot/services/auth_service.py
+git commit -m "Generate auth-flow platform lists from registry"
+```
+
+---
+
+### Task 9: Per-platform `cookies_hint` in `bot/handlers/download_callbacks.py`
+
+**Files:**
+- Modify: `bot/handlers/download_callbacks.py`
+
+- [ ] **Step 1: Locate the auth-error block**
+
+Run: `grep -n "Ta platforma wymaga zalogowania\|login.*sign in.*cookie" bot/handlers/download_callbacks.py`
+Expected: matches around lines 589-597.
+
+- [ ] **Step 2: Extract the existing message into a module-level constant**
+
+At the top of `bot/handlers/download_callbacks.py`, ensure these imports are
+present (add if missing):
+
+```python
+from bot.platforms import get_platform
+from bot.session_context import get_session_context_value as _get_session_context_value
+```
+
+(The file already imports `_get_session_context_value` — verify with
+`grep -n "_get_session_context_value" bot/handlers/download_callbacks.py`.
+Only add the `get_platform` import.)
+
+Then add a module-level constant near the top of the file:
+
+```python
+GENERIC_COOKIES_HINT = (
+    "Ta platforma wymaga zalogowania.\n\n"
+    "Aby pobrać treści z ograniczonym dostępem:\n"
+    "1. Zaloguj się na platformę w przeglądarce\n"
+    "2. Wyeksportuj cookies (rozszerzenie 'Get cookies.txt LOCALLY')\n"
+    "3. Umieść plik cookies.txt w katalogu bota\n"
+    "4. Spróbuj ponownie"
+)
+```
+
+- [ ] **Step 3: Replace the keyword-match block (lines 588-597)**
+
+Replace:
+```python
+        error_str = str(exc).lower()
+        if any(keyword in error_str for keyword in ("login", "sign in", "cookie", "authentication")):
+            await update_status(
+                "Ta platforma wymaga zalogowania.\n\n"
+                "Aby pobrać treści z ograniczonym dostępem:\n"
+                "1. Zaloguj się na platformę w przeglądarce\n"
+                "2. Wyeksportuj cookies (rozszerzenie 'Get cookies.txt LOCALLY')\n"
+                "3. Umieść plik cookies.txt w katalogu bota\n"
+                "4. Spróbuj ponownie"
+            )
+        else:
+            await update_status("Wystąpił błąd podczas pobierania. Spróbuj ponownie.")
+```
+
+With:
+```python
+        error_str = str(exc).lower()
+        if any(keyword in error_str for keyword in ("login", "sign in", "cookie", "authentication")):
+            platform_name = _get_session_context_value(
+                context, chat_id, "platform", legacy_key="platform"
+            )
+            config = get_platform(platform_name)
+            hint = (
+                config.cookies_hint
+                if config and config.cookies_hint
+                else GENERIC_COOKIES_HINT
+            )
+            await update_status(hint)
+        else:
+            await update_status("Wystąpił błąd podczas pobierania. Spróbuj ponownie.")
+```
+
+(The `chat_id` variable is already in scope from the surrounding download
+handler — the same handler earlier calls `record_download_for(context, chat_id, ...)`.)
+
+- [ ] **Step 4: Add tests for the new behavior**
+
+Append to `tests/test_platforms.py`:
+
+```python
+def test_download_callbacks_has_generic_cookies_hint_constant():
+    """The generic fallback hint must stay available for unknown platforms."""
+
+    from bot.handlers.download_callbacks import GENERIC_COOKIES_HINT
+
+    assert isinstance(GENERIC_COOKIES_HINT, str)
+    assert "cookies.txt" in GENERIC_COOKIES_HINT
+
+
+def test_x_platform_cookies_hint_mentions_x():
+    """Regression: X's per-platform hint should reference X-specific guidance."""
+
+    config = platforms_pkg.get_platform("x")
+    assert config is not None
+    assert config.cookies_hint is not None
+    lowered = config.cookies_hint.lower()
+    assert "x.com" in lowered or "sensitive" in lowered
+
+
+def test_get_platform_fallback_behavior_for_auth_error_path():
+    """get_platform(None) returns None so the caller falls back to GENERIC."""
+
+    assert platforms_pkg.get_platform(None) is None
+    assert platforms_pkg.get_platform("unknown-platform") is None
+```
+
+- [ ] **Step 5: Run the new tests**
+
+Run: `pytest tests/test_platforms.py -v -k "cookies_hint or generic_cookies or fallback"`
+Expected: 3 passed
+
+- [ ] **Step 6: Run the full download_callbacks test file**
+
+Run: `pytest tests/test_callback_download_handlers.py -v`
+Expected: all tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add bot/handlers/download_callbacks.py tests/test_platforms.py
+git commit -m "Surface per-platform cookies hint on auth errors"
+```
+
+---
+
+### Task 10: Extend `tests/test_security_policy.py` for X
+
+**Files:**
+- Modify: `tests/test_security_policy.py`
+
+- [ ] **Step 1: Add X cases to existing tests**
+
+In `tests/test_security_policy.py`, extend the existing tests:
+
+Replace `test_validate_url_accepts_supported_https_domains` with:
+
+```python
+def test_validate_url_accepts_supported_https_domains():
+    assert validate_url("https://www.youtube.com/watch?v=abc") is True
+    assert validate_url("https://open.spotify.com/episode/abc") is True
+    assert validate_url("https://castbox.fm/episode/test") is True
+    assert validate_url("https://x.com/i/status/123456789") is True
+    assert validate_url("https://twitter.com/user/status/123456789") is True
+    assert validate_url("https://mobile.twitter.com/user/status/123") is True
+```
+
+Replace `test_detect_platform_maps_supported_domains` with:
+
+```python
+def test_detect_platform_maps_supported_domains():
+    assert detect_platform("https://youtu.be/abc") == "youtube"
+    assert detect_platform("https://www.instagram.com/reel/abc") == "instagram"
+    assert detect_platform("https://open.spotify.com/episode/abc") == "spotify"
+    assert detect_platform("https://x.com/i/status/123") == "x"
+    assert detect_platform("https://www.x.com/i/status/123") == "x"
+    assert detect_platform("https://twitter.com/u/status/123") == "x"
+    assert detect_platform("https://mobile.twitter.com/u/status/123") == "x"
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `pytest tests/test_security_policy.py -v`
+Expected: all pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_security_policy.py
+git commit -m "Cover X domains in security_policy tests"
+```
+
+---
+
+### Task 11: Update hardcoded 7-platform assertions in existing tests
+
+**Files:**
+- Modify: `tests/test_command_access_handlers.py`
+- Modify: `tests/test_auth_service.py` (if it asserts platform list strings)
+
+- [ ] **Step 1: Find hardcoded 7-platform strings in tests**
+
+Run: `grep -rn "YouTube, Vimeo, TikTok, Instagram, LinkedIn, Castbox, Spotify" tests/`
+Expected: matches in `tests/test_command_access_handlers.py` around lines 43
+and 86; possibly `tests/test_auth_service.py`.
+
+- [ ] **Step 2: Update each assertion**
+
+For every match, change the assertion pattern from exact substring equality
+to a looser check that tolerates additional platforms. Example — if the
+test currently has:
+
+```python
+assert "Wyślij link (YouTube, Vimeo, TikTok, Instagram, LinkedIn, Castbox, Spotify) aby pobrać" in message
+```
+
+Change to:
+
+```python
+assert "Wyślij link (" in message
+assert "YouTube" in message
+assert "X" in message
+assert ") aby pobrać" in message
+```
+
+Apply the same transformation to every match found in Step 1.
+
+- [ ] **Step 3: Run the affected tests**
+
+Run:
+```bash
+pytest tests/test_command_access_handlers.py tests/test_auth_service.py -v
+```
+Expected: all pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_command_access_handlers.py tests/test_auth_service.py
+git commit -m "Relax test assertions for registry-driven platform lists"
+```
+
+---
+
+### Task 12: Update README supported-platforms table
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Locate the supported-platforms table**
+
+Run: `grep -n "Obsługiwane platformy\|| Platforma" README.md | head -5`
+Expected: matches around line 22.
+
+- [ ] **Step 2: Add an X row**
+
+In the `### Obsługiwane platformy` table (around line 22), add a new row for
+X. Order-wise, place it after LinkedIn so the table matches `PLATFORMS` tuple
+order from the registry:
+
+```markdown
+| X (Twitter) | x.com, twitter.com, mobile.twitter.com | Video z tweetów. Treści oznaczone jako Sensitive wymagają cookies.txt |
+```
+
+Also update the introductory paragraph on line 3 if it enumerates supported
+platforms by name, adding "X" alongside "YouTube, Vimeo, TikTok, Instagram,
+LinkedIn".
+
+- [ ] **Step 3: Visual diff check**
+
+Run: `git diff README.md`
+Expected: only the platform table (and possibly the intro sentence) changed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "Document X platform support in README"
+```
+
+---
+
+### Task 13: Full test suite + smoke test
+
+**Files:** none modified
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `source venv/bin/activate && pytest`
+Expected: every test passes, no skips attributable to this work.
+
+- [ ] **Step 2: Import-time smoke test**
+
+Run:
+```bash
+python -c "
+from bot.platforms import PLATFORMS, get_platform, detect_by_domain, all_domains
+assert len(PLATFORMS) == 8
+assert get_platform('x').name == 'x'
+assert detect_by_domain('x.com').name == 'x'
+assert detect_by_domain('www.twitter.com').name == 'x'
+assert 'x.com' in all_domains()
+print('Registry smoke test OK')
+"
+```
+Expected: `Registry smoke test OK`
+
+- [ ] **Step 3: Manual CLI smoke test against X**
+
+Run (requires network):
+```bash
+source venv/bin/activate
+python main.py --cli --url "https://x.com/i/status/2047124368623534362" --list-formats
+```
+Expected: either a list of formats from yt-dlp (public video), or a clean
+error message (if tweet requires auth). **Not expected:** Python traceback
+from registry lookup.
+
+- [ ] **Step 4: (Optional) Manual bot smoke test**
+
+Start the bot (`python main.py`) and in Telegram send:
+```
+https://x.com/i/status/2047124368623534362
+```
+Expected: menu appears with Video/Audio buttons, NO FLAC, NO time-range
+button; selecting Video → MP4 download; on auth error, the message mentions
+"Sensitive" and "x.com".
+
+- [ ] **Step 5: Final commit if any cleanup was needed**
+
+```bash
+git status
+# If clean, nothing to do.
+# If there are fixups, commit them with a descriptive message.
+```
+
+---
+
+## Rollback Notes
+
+If the refactor breaks an existing platform flow in production, rollback is
+safe at any task boundary — commits are sequential and each task leaves the
+codebase in a working state. The risk points are Tasks 4 (security_policy) and
+5 (common_ui) which change the dispatch path; Tasks 6-8 only change UI text;
+Task 9 only affects error-handling text. If needed, revert the specific task's
+commit rather than the whole series.
+
+## Out-of-Scope Reminders
+
+Do not, during this implementation:
+
+- Move Instagram photo/carousel handling into `bot/platforms/instagram.py` (that's Phase 2).
+- Move Spotify/Castbox iTunes resolution (Phase 3).
+- Add time-range support for X (explicit design decision — mirror TikTok).
+- Pre-flight cookies check for X links (explicit design decision — lazy check).
+- Change session schema — platform stays as string name in session.

--- a/docs/superpowers/specs/2026-04-23-x-platform-support-design.md
+++ b/docs/superpowers/specs/2026-04-23-x-platform-support-design.md
@@ -1,0 +1,345 @@
+# X (Twitter) Platform Support — Design
+
+**Status:** Approved for implementation
+**Date:** 2026-04-23
+**Scope:** Phase 1 of platform-registry refactor + X integration
+
+## Problem
+
+The project supports YouTube, Vimeo, TikTok, Instagram, LinkedIn, Castbox, and
+Spotify. It does not accept URLs from X (formerly Twitter). Adding X is the
+trigger for a broader cleanup: today, "what each platform does" is expressed
+through `if platform == "..."` string checks scattered across at least four
+files (`security_policy.py`, `common_ui.py`, `inbound_media.py`,
+`command_access.py`) and hardcoded lists of platform names in two more
+(`telegram_callbacks.py`, `command_access.py`). Every new platform grows that
+surface.
+
+This spec introduces a `bot/platforms/` registry that centralizes per-platform
+configuration, adds X as a first-class platform, and migrates the "simple
+video" platforms (TikTok, Vimeo, LinkedIn) onto the new registry. Platforms
+with unique logic (Instagram, Castbox, Spotify, YouTube) get registry entries
+but keep their current code paths — they are explicitly out of scope for the
+migration in this phase.
+
+## Scope Decisions
+
+All decisions made during brainstorming, preserved here so implementation can
+verify intent without re-deriving it.
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Content types supported | Video only (single tweet) | Matches user's immediate need; mirrors TikTok scope. Images, carousels, and threads deferred to future phases. |
+| Cookies handling | Lazy — attempt, explain on failure | Consistent with Instagram/LinkedIn. No pre-flight checks. |
+| Menu layout for X | Mirror TikTok: hide FLAC and time-range | X videos are typically short. Long-form X Premium videos are rare and can be addressed later if needed. |
+| Refactor scope | Phase 1: registry + simple-video platforms migrated; others get registry entries only | Full refactor of Instagram/podcasts/YouTube in one spec is too risky; each gets its own phase. |
+| Per-platform cookies hints | Yes, `cookies_hint` field on `PlatformConfig` | User chose platform-specific messages over one generic fallback. |
+| Platform in session | String name, not full config | Backward-compatible with current session shape; lookup on use. |
+
+## Architecture
+
+### New package: `bot/platforms/`
+
+```
+bot/platforms/
+├── __init__.py      # registry + public lookup API
+├── base.py          # PlatformConfig dataclass
+├── youtube.py       # CONFIG only (no migration in Phase 1)
+├── vimeo.py         # CONFIG — simple-video, migrated
+├── tiktok.py        # CONFIG — simple-video, migrated
+├── linkedin.py      # CONFIG — simple-video, migrated
+├── x.py             # CONFIG — simple-video, NEW
+├── instagram.py     # CONFIG only (no migration in Phase 1)
+├── castbox.py       # CONFIG only (no migration in Phase 1)
+└── spotify.py       # CONFIG only (no migration in Phase 1)
+```
+
+Each platform module exports exactly one symbol: `CONFIG: PlatformConfig`.
+Platform modules contain **data only** — no logic, no side effects on import.
+Future phases will move platform-specific functions (e.g., `get_instagram_post_info`)
+into their respective modules.
+
+### `bot/platforms/base.py`
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True, kw_only=True)
+class PlatformConfig:
+    name: str                    # stable identifier in code, e.g. "x", "tiktok"
+    display_name: str            # shown in UI, e.g. "X", "TikTok"
+    domains: tuple[str, ...]     # e.g. ("x.com", "twitter.com", "mobile.twitter.com")
+    hide_flac: bool              # remove FLAC option from audio menu
+    hide_time_range: bool        # remove "✂️ Zakres czasowy" button
+    is_podcast: bool             # use podcast menu variant instead of video/audio
+    media_label: str             # "filmie" | "odcinku" — for error phrasing
+    requires_cookies: bool       # included in "X, Y, Z may need cookies.txt" message
+    cookies_hint: str | None = None  # per-platform auth-error hint; None falls back to generic
+```
+
+Using `kw_only=True` + `frozen=True` enforces explicit construction and
+immutability. All nine fields required per platform except `cookies_hint`.
+
+### `bot/platforms/__init__.py`
+
+```python
+from bot.platforms import youtube, vimeo, tiktok, linkedin, x, instagram, castbox, spotify
+from bot.platforms.base import PlatformConfig
+
+PLATFORMS: tuple[PlatformConfig, ...] = (
+    youtube.CONFIG, vimeo.CONFIG, tiktok.CONFIG, linkedin.CONFIG,
+    x.CONFIG, instagram.CONFIG, castbox.CONFIG, spotify.CONFIG,
+)
+
+_BY_NAME: dict[str, PlatformConfig] = {p.name: p for p in PLATFORMS}
+_BY_DOMAIN: dict[str, PlatformConfig] = {
+    domain: p
+    for p in PLATFORMS
+    for domain in _expand_with_www(p.domains)
+}
+
+def get_platform(name: str) -> PlatformConfig | None:
+    return _BY_NAME.get(name)
+
+def detect_by_domain(host: str) -> PlatformConfig | None:
+    return _BY_DOMAIN.get(host.lower())
+
+def all_domains() -> frozenset[str]:
+    return frozenset(_BY_DOMAIN.keys())
+```
+
+`_expand_with_www` mirrors the existing behavior in `security_policy.py:28-31`:
+for any non-subdomain entry (one dot, e.g., `x.com`), also register `www.x.com`.
+Subdomain entries (`mobile.twitter.com`) are not expanded.
+
+### Example platform modules
+
+```python
+# bot/platforms/x.py
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="x",
+    display_name="X",
+    domains=("x.com", "twitter.com", "mobile.twitter.com"),
+    hide_flac=True,
+    hide_time_range=True,
+    is_podcast=False,
+    media_label="filmie",
+    requires_cookies=True,
+    cookies_hint=(
+        "Wiele tweetów (szczególnie oznaczonych jako Sensitive) wymaga "
+        "zalogowania. Zaloguj się na x.com w przeglądarce i wyeksportuj "
+        "cookies rozszerzeniem 'Get cookies.txt LOCALLY'."
+    ),
+)
+```
+
+```python
+# bot/platforms/spotify.py
+from bot.platforms.base import PlatformConfig
+
+CONFIG = PlatformConfig(
+    name="spotify",
+    display_name="Spotify",
+    domains=("open.spotify.com",),
+    hide_flac=True,
+    hide_time_range=True,
+    is_podcast=True,
+    media_label="odcinku",
+    requires_cookies=False,
+    cookies_hint=None,
+)
+```
+
+## Integration Points (5 files)
+
+### `bot/security_policy.py`
+
+- Replace inline `_DOMAIN_TO_PLATFORM` dict with `from bot.platforms import detect_by_domain, all_domains, get_platform`.
+- `ALLOWED_DOMAINS` → `all_domains()`.
+- `detect_platform(url) -> str | None` — keep signature for backward compatibility, implement as `detect_by_domain(host).name if match else None`.
+- `get_media_label(platform: str | None) -> str` — look up via `get_platform(platform)`, fall back to `"filmie"` if unknown.
+- `normalize_url` (Castbox redirect handling) stays untouched — it is URL logic, not registry data.
+
+### `bot/handlers/common_ui.py`
+
+`build_main_keyboard(platform: str, ...)`:
+
+```python
+config = get_platform(platform)
+if config is None:
+    raise ValueError(f"Unknown platform in session: {platform!r}")
+is_podcast = config.is_podcast
+hide_flac = config.hide_flac
+hide_time_range = config.hide_time_range
+```
+
+Raising is appropriate here because an unknown platform name in the session
+indicates a programming bug (writing to session but not registering the
+platform), not a user-facing condition.
+
+### `bot/handlers/inbound_media.py`
+
+- The "Obsługiwane platformy:" message (the reply sent when `validate_url`
+  rejects a URL; currently a hardcoded list around line 267) is generated by
+  iterating `PLATFORMS` and formatting `"- {display_name} ({first_domain})"`.
+  Ordering follows declaration order in `PLATFORMS`.
+- Special branches (`if platform == "instagram"`, `if platform == "castbox"`,
+  `if platform == "spotify"`) stay exactly as they are — Phase 1 does not touch
+  them. The `platform` variable at line 357 still comes from
+  `detect_platform(url)`, now backed by the registry.
+
+### `bot/handlers/command_access.py`
+
+Two hardcoded strings ("TikTok, Instagram i LinkedIn mogą wymagać cookies")
+replaced by dynamic generation:
+
+```python
+requires_cookies_names = [
+    p.display_name for p in PLATFORMS if p.requires_cookies
+]
+cookies_msg = f"{', '.join(requires_cookies_names)} mogą wymagać cookies.txt"
+```
+
+### `bot/handlers/download_callbacks.py`
+
+This file has no `if platform == "..."` check today — Phase 1 **adds** a new
+platform lookup (does not refactor an existing one). At the keyword-based
+auth-error detection block (currently around line 589):
+
+```python
+if any(keyword in error_str for keyword in ("login", "sign in", "cookie", "authentication")):
+    platform_name = session_context.get("platform")  # read from current session
+    config = get_platform(platform_name) if platform_name else None
+    hint = config.cookies_hint if config and config.cookies_hint else GENERIC_COOKIES_HINT
+    # ... send message with `hint` substituted
+```
+
+`GENERIC_COOKIES_HINT` is the **existing fallback text extracted verbatim into
+a module-level constant** — no wording change, no translation change. The new
+code only inserts the platform-specific `cookies_hint` when available;
+platforms without one (or unknown platform in session) see the same message
+they see today.
+
+## Data Flow
+
+1. User sends URL → `inbound_media.handle_url`
+2. `normalize_url(url)` — resolves Castbox redirects, unchanged
+3. `validate_url(url)` — checks `parsed.netloc` against `all_domains()`
+4. `detect_platform(url)` → returns `"x"` (or other name); stored in session as string
+5. Existing branching in `inbound_media.py` dispatches podcast/Instagram/default flows
+6. `build_main_keyboard("x")` — reads flags from `get_platform("x")`, renders menu without FLAC and without time-range buttons
+7. User picks format → `execute_download_plan` runs yt-dlp (no platform-specific logic in the download pipeline)
+8. On auth failure → error handler looks up `get_platform(session.platform).cookies_hint` and surfaces it; successful downloads follow the standard upload path
+
+The download pipeline itself (`bot/services/download_service.py`) remains
+platform-agnostic. yt-dlp's Twitter extractor handles X URLs natively; the
+existing `yt-dlp>=2024.12.6` pin in `requirements.txt` is sufficient.
+
+## Error Handling
+
+| Scenario | Behavior |
+|---|---|
+| URL matches no domain | Existing "supported platforms" message, now generated from registry |
+| yt-dlp auth error (login/sign-in/cookie keywords) | Per-platform `cookies_hint` if set, else `GENERIC_COOKIES_HINT` |
+| X "Sensitive media" without cookies | Surfaces as auth error → handled by above case (no separate code path) |
+| yt-dlp extractor broken / schema change | Propagate original yt-dlp error, no platform-specific wrapping |
+| Missing `platform` in session (defensive) | Fall back to generic hint, log warning |
+| `get_platform(name)` returns None for a name from session | Raise — programming bug, not user-facing |
+
+No pre-flight cookies check for X. Consistent with all other platforms.
+
+## Testing Strategy
+
+### New: `tests/test_platforms.py`
+
+- `test_all_platforms_have_unique_names`
+- `test_no_overlapping_domains`
+- `test_detect_by_domain_matches_known_hosts` (parametrized over every
+  `(domain, platform.name)` pair, plus `www.` variants where applicable)
+- `test_detect_by_domain_returns_none_for_unknown`
+- `test_get_platform_returns_config_for_known_names`
+- `test_all_domains_includes_www_variants_for_bare_domains`
+- `test_x_platform_has_tiktok_style_menu_flags` — regression for the
+  hide_flac/hide_time_range decision
+- `test_cookies_hint_set_for_platforms_requiring_cookies_except_podcasts`
+
+### Updated: `tests/test_security_policy.py`
+
+- Extend parametrization of `detect_platform` with `x.com`, `twitter.com`,
+  `mobile.twitter.com`, and their `www.` variants where applicable
+- Happy-path `validate_url` for `https://x.com/i/status/{id}` and
+  `https://twitter.com/{user}/status/{id}`
+- Any assertions that hardcode the old `_DOMAIN_TO_PLATFORM` dict are rewritten
+  to iterate the registry
+
+### Updated: `tests/test_inbound_media_handlers.py`
+
+- Assertions on the "supported platforms" message relaxed from exact string
+  match to containment checks (must include each platform's `display_name`)
+
+### Optional integration: `tests/test_telegram_integration.py`
+
+One scenario: simulate user sending `https://x.com/i/status/{id}` and assert
+`session.platform == "x"` and the rendered keyboard contains neither FLAC nor
+time-range buttons. Skipped if it becomes fragile to session-store changes.
+
+### Out of scope for tests
+
+- Actual network fetches from X (non-deterministic, requires credentials)
+- yt-dlp's own Twitter extractor (covered upstream)
+
+## What Is Not Changing in Phase 1
+
+- `bot/services/download_service.py` — platform-agnostic, no changes
+- `bot/handlers/inbound_media.py` special branches for Instagram/Spotify/Castbox
+- `bot/telegram_callbacks.py:144` Spotify-specific callback
+- `bot/downloader_media.py` Instagram post/photo helpers
+- `bot/spotify.py`, `bot/mtproto.py`, transcription pipeline
+- CLI (`bot/cli.py`) — inherits registry via `validate_url`, no explicit changes
+- `cookies.txt` handling, session store schema, authorization flow
+
+## Future Phases (Out of Scope)
+
+- **Phase 2 — Instagram:** Move `downloader_media.get_instagram_post_info`,
+  `is_photo_entry`, carousel keyboard into `bot/platforms/instagram.py`
+- **Phase 3 — Podcasts:** Move Spotify/Castbox iTunes resolution and
+  podcast-specific callbacks into `bot/platforms/{spotify,castbox}.py`
+- **Phase 4 — YouTube:** Move YouTube-specific format-sort heuristics and
+  subtitles handling into `bot/platforms/youtube.py`
+
+Each future phase gets its own spec.
+
+## Risk Assessment
+
+- **Regression in simple-video platforms (TikTok/Vimeo/LinkedIn):** Mitigated
+  by keeping `detect_platform(url) -> str` signature stable and by the existing
+  test suite in `test_security_policy.py` (extended, not replaced).
+- **Session schema drift:** None — session still stores `platform: str`.
+- **Import cycles:** `bot/platforms/` imports nothing from `bot/handlers/` or
+  `bot/services/`. The reverse dependency is the only direction.
+- **Docstring rot in platform files:** Deliberate — platform modules are data
+  only. No logic, no docstrings to drift.
+
+## Acceptance Criteria
+
+Implementation is complete when:
+
+1. `bot/platforms/` exists with all 8 platforms defined
+2. The 5 integration-point files read from the registry. Specifically:
+   `security_policy.py` has no inline `_DOMAIN_TO_PLATFORM`, `common_ui.py` has
+   no `platform in ("tiktok", ...)` tuple, `command_access.py` has no hardcoded
+   "TikTok, Instagram i LinkedIn" string, `inbound_media.py` generates its
+   supported-platforms list from `PLATFORMS`, `download_callbacks.py` looks up
+   `cookies_hint` via `get_platform`. Remaining `if platform == "..."` branches
+   in `inbound_media.py` (Instagram/Castbox/Spotify special flows) and
+   `telegram_callbacks.py:144` (Spotify callback) are custom logic paths, not
+   data queries, and are permitted to stay in Phase 1.
+3. `tests/test_platforms.py` exists and passes
+4. `tests/test_security_policy.py` extended with X and passes
+5. Sending `https://x.com/i/status/2047124368623534362` to the bot produces
+   the TikTok-style menu (no FLAC, no time-range) and a successful download
+   for public video tweets
+6. README's platforms table updated with an X row
+7. Full test suite passes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Core runtime dependencies
 yt-dlp>=2024.12.6
 mutagen>=1.47.0
-python-telegram-bot>=21.0
+python-telegram-bot[job-queue]>=21.0
 requests>=2.31.0
 python-dotenv>=1.0.0
 Pillow>=10.0.0

--- a/tests/test_command_access_handlers.py
+++ b/tests/test_command_access_handlers.py
@@ -38,11 +38,12 @@ class TestStart:
         _async(tc.start(update, context))
 
         assert "awaiting_pin" not in context.user_data
-        update.message.reply_text.assert_awaited_once_with(
-            "Witaj, User!\n\n"
-            "Jesteś już zalogowany. Wyślij link (YouTube, Vimeo, TikTok, Instagram, LinkedIn, Castbox, Spotify) "
-            "aby pobrać film lub audio."
-        )
+        update.message.reply_text.assert_awaited_once()
+        message = update.message.reply_text.await_args.args[0]
+        assert "Wyślij link (" in message
+        assert "YouTube" in message
+        assert "X" in message
+        assert ") aby pobrać" in message
 
     def test_start_blocked_until_expiration(self, monkeypatch):
         update = _make_update(user_id=111)
@@ -81,11 +82,12 @@ class TestHandlePin:
         assert "awaiting_pin" not in context.user_data
         assert "pending_url" not in context.user_data
         assert called["url"] == "https://youtube.com/watch?v=abc"
-        update.message.reply_text.assert_awaited_once_with(
-            "PIN poprawny! Możesz teraz korzystać z bota.\n\n"
-            "Wyślij link (YouTube, Vimeo, TikTok, Instagram, LinkedIn, Castbox, Spotify) "
-            "aby pobrać film lub audio."
-        )
+        update.message.reply_text.assert_awaited_once()
+        message = update.message.reply_text.await_args.args[0]
+        assert "Wyślij link (" in message
+        assert "YouTube" in message
+        assert "X" in message
+        assert ") aby pobrać" in message
 
     def test_handle_pin_uses_runtime_authorized_store(self, monkeypatch):
         update = _make_update(text="12345678", user_id=222, chat_id=222)

--- a/tests/test_inbound_media_handlers.py
+++ b/tests/test_inbound_media_handlers.py
@@ -28,6 +28,24 @@ class TestHandleYoutubeLink:
         assert context.user_data["awaiting_pin"] is True
         update.message.reply_text.assert_awaited_once()
 
+    def test_handle_youtube_link_extracts_url_before_storing_pending(self, monkeypatch):
+        # Regression: if the unauthorized user sends a URL wrapped in descriptive
+        # text, the pending_action must store the clean URL so that the post-auth
+        # replay in command_access (which bypasses extract_url_from_text) works.
+        update = _make_update(
+            text="prosze pobierz https://youtube.com/watch?v=wrapped dzieki",
+            user_id=444,
+        )
+        context = _make_context()
+
+        _set_authorized_users(monkeypatch, set())
+        monkeypatch.setattr(tc, "handle_pin", AsyncMock(return_value=False))
+
+        _async(tc.handle_youtube_link(update, context))
+
+        assert context.user_data["pending_url"] == "https://youtube.com/watch?v=wrapped"
+        assert context.user_data["awaiting_pin"] is True
+
     def test_handle_youtube_link_sets_time_range_for_active_session(self, monkeypatch):
         update = _make_update(text="0:10-0:20", user_id=333, chat_id=333)
         context = _make_context()

--- a/tests/test_mtproto.py
+++ b/tests/test_mtproto.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, AsyncMock, MagicMock
 
 from bot.mtproto import (
     is_mtproto_available,
+    mtproto_unavailability_reason,
     download_file_mtproto,
     send_audio_mtproto,
     send_video_mtproto,
@@ -48,6 +49,46 @@ class TestIsMtprotoAvailable:
             assert is_mtproto_available() is True
 
 
+class TestMtprotoUnavailabilityReason:
+    """Verifies that the user-facing hint reflects the actual missing piece."""
+
+    def _set_creds(self, monkeypatch, *, api_id, api_hash):
+        cfg = __import__('bot.config', fromlist=['CONFIG']).CONFIG
+        monkeypatch.setitem(cfg, 'TELEGRAM_API_ID', api_id)
+        monkeypatch.setitem(cfg, 'TELEGRAM_API_HASH', api_hash)
+
+    def test_returns_none_when_fully_configured(self, monkeypatch):
+        self._set_creds(monkeypatch, api_id='12345', api_hash='abc')
+        mock_pyrogram = MagicMock()
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            assert mtproto_unavailability_reason() is None
+
+    def test_mentions_only_pyrogram_when_creds_present(self, monkeypatch):
+        self._set_creds(monkeypatch, api_id='12345', api_hash='abc')
+        with patch.dict('sys.modules', {'pyrogram': None}):
+            reason = mtproto_unavailability_reason()
+            assert reason is not None
+            assert 'pyrogram' in reason.lower()
+            assert 'TELEGRAM_API_ID' not in reason
+
+    def test_mentions_only_creds_when_pyrogram_present(self, monkeypatch):
+        self._set_creds(monkeypatch, api_id='', api_hash='abc')
+        mock_pyrogram = MagicMock()
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            reason = mtproto_unavailability_reason()
+            assert reason is not None
+            assert 'TELEGRAM_API_ID' in reason
+            assert 'pyrogram' not in reason.lower()
+
+    def test_mentions_both_when_nothing_is_set(self, monkeypatch):
+        self._set_creds(monkeypatch, api_id='', api_hash='')
+        with patch.dict('sys.modules', {'pyrogram': None}):
+            reason = mtproto_unavailability_reason()
+            assert reason is not None
+            assert 'pyrogram' in reason.lower()
+            assert 'TELEGRAM_API_ID' in reason
+
+
 class TestDownloadFileMtproto:
     """Tests for download_file_mtproto() error handling."""
 
@@ -63,6 +104,18 @@ class TestDownloadFileMtproto:
     def test_returns_false_when_api_id_missing(self, monkeypatch):
         monkeypatch.setitem(__import__('bot.config', fromlist=['CONFIG']).CONFIG,
                             'TELEGRAM_API_ID', '')
+        monkeypatch.setitem(__import__('bot.config', fromlist=['CONFIG']).CONFIG,
+                            'TELEGRAM_API_HASH', 'abc123hash')
+        mock_pyrogram = MagicMock()
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            result = asyncio.run(download_file_mtproto("token", 123, 456, "/tmp/test.mp3"))
+            assert result is False
+
+    def test_returns_false_when_api_id_not_numeric(self, monkeypatch):
+        # Regression: a non-numeric TELEGRAM_API_ID must be rejected cleanly
+        # instead of raising ValueError during Client construction.
+        monkeypatch.setitem(__import__('bot.config', fromlist=['CONFIG']).CONFIG,
+                            'TELEGRAM_API_ID', 'not-a-number')
         monkeypatch.setitem(__import__('bot.config', fromlist=['CONFIG']).CONFIG,
                             'TELEGRAM_API_HASH', 'abc123hash')
         mock_pyrogram = MagicMock()
@@ -112,6 +165,17 @@ class TestSendAudioMtproto:
 
     def test_returns_false_when_api_id_missing(self, monkeypatch, tmp_path):
         _set_mtproto_config(monkeypatch, api_id="")
+        audio_file = tmp_path / "test.mp3"
+        audio_file.write_bytes(b"\x00" * 100)
+        mock_pyrogram = MagicMock()
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            result = asyncio.run(send_audio_mtproto(123, str(audio_file), title="Test"))
+            assert result is False
+
+    def test_returns_false_when_api_id_not_numeric(self, monkeypatch, tmp_path):
+        # Regression: non-numeric TELEGRAM_API_ID used to raise ValueError inside
+        # _build_client, outside the try/except around async with client.
+        _set_mtproto_config(monkeypatch, api_id="oops")
         audio_file = tmp_path / "test.mp3"
         audio_file.write_bytes(b"\x00" * 100)
         mock_pyrogram = MagicMock()
@@ -172,6 +236,17 @@ class TestSendVideoMtproto:
 
     def test_returns_false_when_api_hash_missing(self, monkeypatch, tmp_path):
         _set_mtproto_config(monkeypatch, api_hash="")
+        video_file = tmp_path / "test.mp4"
+        video_file.write_bytes(b"\x00" * 100)
+        mock_pyrogram = MagicMock()
+        with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+            result = asyncio.run(send_video_mtproto(123, str(video_file)))
+            assert result is False
+
+    def test_returns_false_when_api_id_not_numeric(self, monkeypatch, tmp_path):
+        # Regression: non-numeric TELEGRAM_API_ID used to raise ValueError inside
+        # _build_client, outside the try/except around async with client.
+        _set_mtproto_config(monkeypatch, api_id="bogus")
         video_file = tmp_path / "test.mp4"
         video_file.write_bytes(b"\x00" * 100)
         mock_pyrogram = MagicMock()

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -1,0 +1,69 @@
+"""Tests for bot/platforms/ registry and per-platform CONFIG modules."""
+
+import dataclasses
+
+import pytest
+
+from bot.platforms.base import PlatformConfig
+
+
+def test_platform_config_is_frozen_and_kw_only():
+    config = PlatformConfig(
+        name="test",
+        display_name="Test",
+        domains=("test.com",),
+        hide_flac=False,
+        hide_time_range=False,
+        is_podcast=False,
+        media_label="filmie",
+        requires_cookies=False,
+    )
+    assert dataclasses.is_dataclass(config)
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        config.name = "mutated"  # type: ignore[misc]
+
+
+def test_platform_config_defaults_cookies_hint_to_none():
+    config = PlatformConfig(
+        name="test",
+        display_name="Test",
+        domains=("test.com",),
+        hide_flac=False,
+        hide_time_range=False,
+        is_podcast=False,
+        media_label="filmie",
+        requires_cookies=False,
+    )
+    assert config.cookies_hint is None
+
+
+def test_platform_config_requires_keyword_arguments():
+    with pytest.raises(TypeError):
+        PlatformConfig(  # type: ignore[call-arg]
+            "test", "Test", ("test.com",), False, False, False, "filmie", False
+        )
+
+
+def test_platform_config_equality_on_same_fields():
+    a = PlatformConfig(
+        name="test",
+        display_name="Test",
+        domains=("test.com",),
+        hide_flac=False,
+        hide_time_range=False,
+        is_podcast=False,
+        media_label="filmie",
+        requires_cookies=False,
+    )
+    b = PlatformConfig(
+        name="test",
+        display_name="Test",
+        domains=("test.com",),
+        hide_flac=False,
+        hide_time_range=False,
+        is_podcast=False,
+        media_label="filmie",
+        requires_cookies=False,
+    )
+    assert a == b

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -180,3 +180,44 @@ def test_cookies_hint_set_for_platforms_requiring_cookies_except_podcasts():
             assert p.cookies_hint is not None, (
                 f"Platform {p.name!r} marked requires_cookies but has no hint"
             )
+
+
+def test_build_main_keyboard_reads_flags_from_registry():
+    from bot.handlers.common_ui import build_main_keyboard
+
+    # TikTok → hide FLAC and time-range
+    tiktok_keyboard = build_main_keyboard("tiktok")
+    flat_callbacks = [
+        btn.callback_data
+        for row in tiktok_keyboard
+        for btn in row
+    ]
+    assert "dl_audio_flac" not in flat_callbacks
+    assert "time_range" not in flat_callbacks
+
+    # YouTube → FLAC and time-range present
+    yt_keyboard = build_main_keyboard("youtube")
+    flat_callbacks = [
+        btn.callback_data
+        for row in yt_keyboard
+        for btn in row
+    ]
+    assert "dl_audio_flac" in flat_callbacks
+    assert "time_range" in flat_callbacks
+
+    # X → same shape as TikTok
+    x_keyboard = build_main_keyboard("x")
+    flat_callbacks = [
+        btn.callback_data
+        for row in x_keyboard
+        for btn in row
+    ]
+    assert "dl_audio_flac" not in flat_callbacks
+    assert "time_range" not in flat_callbacks
+
+
+def test_build_main_keyboard_raises_on_unknown_platform():
+    from bot.handlers.common_ui import build_main_keyboard
+
+    with pytest.raises(ValueError, match="Unknown platform"):
+        build_main_keyboard("facebook")

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -67,3 +67,116 @@ def test_platform_config_equality_on_same_fields():
         requires_cookies=False,
     )
     assert a == b
+
+
+# Registry tests start here
+
+
+import bot.platforms as platforms_pkg
+
+
+def test_platforms_registry_is_non_empty_tuple():
+    assert isinstance(platforms_pkg.PLATFORMS, tuple)
+    assert len(platforms_pkg.PLATFORMS) == 8
+
+
+def test_all_platforms_have_unique_names():
+    names = [p.name for p in platforms_pkg.PLATFORMS]
+    assert len(names) == len(set(names))
+
+
+def test_no_overlapping_domains_across_platforms():
+    seen: dict[str, str] = {}
+    for p in platforms_pkg.PLATFORMS:
+        for domain in p.domains:
+            assert domain not in seen, (
+                f"Domain {domain!r} used by both "
+                f"{seen.get(domain)!r} and {p.name!r}"
+            )
+            seen[domain] = p.name
+
+
+@pytest.mark.parametrize(
+    "host, expected_name",
+    [
+        ("youtube.com", "youtube"),
+        ("youtu.be", "youtube"),
+        ("m.youtube.com", "youtube"),
+        ("music.youtube.com", "youtube"),
+        ("www.youtube.com", "youtube"),
+        ("vimeo.com", "vimeo"),
+        ("www.vimeo.com", "vimeo"),
+        ("player.vimeo.com", "vimeo"),
+        ("tiktok.com", "tiktok"),
+        ("www.tiktok.com", "tiktok"),
+        ("m.tiktok.com", "tiktok"),
+        ("vm.tiktok.com", "tiktok"),
+        ("linkedin.com", "linkedin"),
+        ("www.linkedin.com", "linkedin"),
+        ("x.com", "x"),
+        ("www.x.com", "x"),
+        ("twitter.com", "x"),
+        ("www.twitter.com", "x"),
+        ("mobile.twitter.com", "x"),
+        ("instagram.com", "instagram"),
+        ("www.instagram.com", "instagram"),
+        ("castbox.fm", "castbox"),
+        ("www.castbox.fm", "castbox"),
+        ("open.spotify.com", "spotify"),
+    ],
+)
+def test_detect_by_domain_matches_known_hosts(host, expected_name):
+    config = platforms_pkg.detect_by_domain(host)
+    assert config is not None
+    assert config.name == expected_name
+
+
+def test_detect_by_domain_returns_none_for_unknown_host():
+    assert platforms_pkg.detect_by_domain("example.com") is None
+    assert platforms_pkg.detect_by_domain("") is None
+
+
+def test_detect_by_domain_is_case_insensitive():
+    assert platforms_pkg.detect_by_domain("X.COM").name == "x"
+    assert platforms_pkg.detect_by_domain("WwW.YouTube.Com").name == "youtube"
+
+
+def test_get_platform_returns_config_for_known_names():
+    for p in platforms_pkg.PLATFORMS:
+        assert platforms_pkg.get_platform(p.name) is p
+
+
+def test_get_platform_returns_none_for_unknown():
+    assert platforms_pkg.get_platform("facebook") is None
+    assert platforms_pkg.get_platform("") is None
+
+
+def test_all_domains_includes_www_variants_for_bare_domains():
+    domains = platforms_pkg.all_domains()
+    assert "x.com" in domains
+    assert "www.x.com" in domains
+    assert "mobile.twitter.com" in domains
+    # Subdomain entries should NOT be www-expanded
+    assert "www.mobile.twitter.com" not in domains
+    assert "www.m.youtube.com" not in domains
+
+
+def test_x_platform_has_tiktok_style_menu_flags():
+    x_config = platforms_pkg.get_platform("x")
+    assert x_config is not None
+    assert x_config.hide_flac is True
+    assert x_config.hide_time_range is True
+    assert x_config.is_podcast is False
+
+
+def test_cookies_hint_set_for_platforms_requiring_cookies_except_podcasts():
+    for p in platforms_pkg.PLATFORMS:
+        if p.is_podcast:
+            assert p.cookies_hint is None, (
+                f"Podcast platform {p.name!r} should not have cookies_hint"
+            )
+            continue
+        if p.requires_cookies:
+            assert p.cookies_hint is not None, (
+                f"Platform {p.name!r} marked requires_cookies but has no hint"
+            )

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -221,3 +221,29 @@ def test_build_main_keyboard_raises_on_unknown_platform():
 
     with pytest.raises(ValueError, match="Unknown platform"):
         build_main_keyboard("facebook")
+
+
+def test_download_callbacks_has_generic_cookies_hint_constant():
+    """The generic fallback hint must stay available for unknown platforms."""
+
+    from bot.handlers.download_callbacks import GENERIC_COOKIES_HINT
+
+    assert isinstance(GENERIC_COOKIES_HINT, str)
+    assert "cookies.txt" in GENERIC_COOKIES_HINT
+
+
+def test_x_platform_cookies_hint_mentions_x():
+    """Regression: X's per-platform hint should reference X-specific guidance."""
+
+    config = platforms_pkg.get_platform("x")
+    assert config is not None
+    assert config.cookies_hint is not None
+    lowered = config.cookies_hint.lower()
+    assert "x.com" in lowered or "sensitive" in lowered
+
+
+def test_get_platform_fallback_behavior_for_auth_error_path():
+    """get_platform(None) returns None so the caller falls back to GENERIC."""
+
+    assert platforms_pkg.get_platform(None) is None
+    assert platforms_pkg.get_platform("unknown-platform") is None

--- a/tests/test_security_policy.py
+++ b/tests/test_security_policy.py
@@ -13,6 +13,9 @@ def test_validate_url_accepts_supported_https_domains():
     assert validate_url("https://www.youtube.com/watch?v=abc") is True
     assert validate_url("https://open.spotify.com/episode/abc") is True
     assert validate_url("https://castbox.fm/episode/test") is True
+    assert validate_url("https://x.com/i/status/123456789") is True
+    assert validate_url("https://twitter.com/user/status/123456789") is True
+    assert validate_url("https://mobile.twitter.com/user/status/123") is True
 
 
 def test_validate_url_rejects_invalid_or_unsupported_urls():
@@ -25,6 +28,10 @@ def test_detect_platform_maps_supported_domains():
     assert detect_platform("https://youtu.be/abc") == "youtube"
     assert detect_platform("https://www.instagram.com/reel/abc") == "instagram"
     assert detect_platform("https://open.spotify.com/episode/abc") == "spotify"
+    assert detect_platform("https://x.com/i/status/123") == "x"
+    assert detect_platform("https://www.x.com/i/status/123") == "x"
+    assert detect_platform("https://twitter.com/u/status/123") == "x"
+    assert detect_platform("https://mobile.twitter.com/u/status/123") == "x"
 
 
 def test_get_media_label_distinguishes_podcast_like_platforms():

--- a/tests/test_security_unit.py
+++ b/tests/test_security_unit.py
@@ -183,6 +183,19 @@ def test_extract_url_from_text_rejects_messages_without_supported_url():
     assert security.extract_url_from_text(None) is None
 
 
+def test_extract_url_from_text_resolves_castbox_share_redirect():
+    # d.castbox.fm is the share/redirect host; validate_url rejects it, so the
+    # extractor must unwrap the inner ?link= target before validating.
+    share_url = (
+        "https://d.castbox.fm/ch/1234?link="
+        "https://castbox.fm/episode/Some-Episode-id12345"
+    )
+    expected = "https://castbox.fm/episode/Some-Episode-id12345"
+
+    assert security.extract_url_from_text(share_url) == expected
+    assert security.extract_url_from_text(f"posłuchaj: {share_url} dzięki") == expected
+
+
 def test_extract_url_from_text_handles_all_supported_platforms():
     platforms = {
         "youtube": "https://www.youtube.com/watch?v=abc",


### PR DESCRIPTION
## Summary
- Adds X (x.com, twitter.com, mobile.twitter.com) as a supported download platform — TikTok-style menu (no FLAC, no time range), lazy cookies handling
- Introduces `bot/platforms/` registry with `PlatformConfig` dataclass as single source of truth for per-platform flags, domains, display names, and per-platform cookies hints
- Refactors 6 integration sites (`security_policy`, `common_ui`, `inbound_media`, `command_access`, `auth_service`, `download_callbacks`) to read from the registry instead of hardcoded platform-string checks
- Restores `show_summary_options` implementation that had become a `NotImplementedError` placeholder during an earlier extraction refactor (pre-existing bug surfaced during Telegram smoke test)
- Also includes pre-PR commits: prose-wrapper URL extraction, MTProto hardening, dead-code removal, python-telegram-bot[job-queue] dependency

## Architecture
- 8 per-platform modules under `bot/platforms/` export pure-data `CONFIG: PlatformConfig`
- Registry `__init__.py` builds O(1) name and domain lookups once at import time, supports `www.` expansion for bare domains, case-insensitive
- Spec: `docs/superpowers/specs/2026-04-23-x-platform-support-design.md`
- Plan: `docs/superpowers/plans/2026-04-23-x-platform-support.md`
- Phased — Phase 1 only migrates simple-video platforms (TikTok, Vimeo, LinkedIn, X). Instagram/Spotify/Castbox/YouTube get registry entries but their custom flows remain in place for future phases

## Test plan
- [x] `pytest` — 642 passed, 2 skipped (Poetry not installed), 2 pre-existing flakes in `test_mtproto.py` (pyrogram + Python 3.13 `asyncio.get_event_loop()`, unrelated)
- [x] `tests/test_platforms.py` — new file, 43 tests covering registry integrity, lookups, www-expansion, X-specific flags, cookies-hint invariants
- [x] CLI smoke test against `https://x.com/i/status/2047124368623534362` — yt-dlp Twitter extractor returns full format list (audio HLS 32k/64k/128k + video 480p/720p/1080p in HLS and HTTP variants), no traceback
- [x] Telegram bot smoke test — X URL produces TikTok-style menu (no FLAC, no time range), `Transkrypcja + Podsumowanie` correctly shows the 4-option summary menu after the placeholder fix