### PR TITLE
Add /stop cancel command + 7z archive download mode

### DIFF
--- a/bot/archive.py
+++ b/bot/archive.py
@@ -1,0 +1,56 @@
+"""Low-level wrapper around the system 7z binary.
+
+This module knows nothing about Telegram, sessions, or downloads. It only
+shells out to 7z, normalizes its output, and exposes a few naming/sizing
+helpers used by bot.services.archive_service.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import unicodedata
+from datetime import datetime
+from pathlib import Path
+
+from bot.security_limits import BOTAPI_VOLUME_SIZE_MB, MTPROTO_VOLUME_SIZE_MB
+
+
+def volume_size_for(use_mtproto: bool) -> int:
+    """Volume size for 7z multi-volume archives, in MiB.
+
+    MTProto allows ~2 GB per message, Bot API caps at 50 MB; we leave a
+    margin in both cases so the resulting volume always slots in.
+    """
+
+    return MTPROTO_VOLUME_SIZE_MB if use_mtproto else BOTAPI_VOLUME_SIZE_MB
+
+
+def transliterate_to_ascii(text: str) -> str:
+    """Best-effort ASCII transliteration of Polish/diacritic characters.
+
+    NFKD decomposes characters like 'ą' into 'a' + combining ogonek, and
+    we drop the combining marks. The handful of Polish letters that NFKD
+    does not decompose (notably 'ł' / 'Ł') are mapped explicitly.
+    Used for naming 7z volumes shipped to a Windows host.
+    """
+
+    explicit_map = {
+        "ł": "l",
+        "Ł": "L",
+    }
+    translated = "".join(explicit_map.get(ch, ch) for ch in text)
+    decomposed = unicodedata.normalize("NFKD", translated)
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+
+
+def compute_archive_basename(slug: str, ts: datetime) -> str:
+    """Deterministic prefix for archive volumes: <slug>_<YYYYMMDD-HHMMSS>."""
+
+    return f"{slug}_{ts.strftime('%Y%m%d-%H%M%S')}"
+
+
+def is_7z_available() -> bool:
+    """Return True when the 7z binary is present in PATH."""
+
+    return shutil.which("7z") is not None

--- a/bot/archive.py
+++ b/bot/archive.py
@@ -14,9 +14,12 @@ import unicodedata
 from collections.abc import Callable, Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Awaitable
+from typing import TYPE_CHECKING, Awaitable
 
 from bot.security_limits import BOTAPI_VOLUME_SIZE_MB, MTPROTO_VOLUME_SIZE_MB
+
+if TYPE_CHECKING:
+    from bot.jobs import JobCancellation
 
 
 def volume_size_for(use_mtproto: bool) -> int:
@@ -65,11 +68,16 @@ async def pack_to_volumes(
     volume_size_mb: int,
     *,
     progress_cb: Callable[[str], Awaitable[None]] | None = None,
+    cancellation: "JobCancellation | None" = None,
 ) -> list[Path]:
     """Pack ``sources`` into a 7z multi-volume archive at ``dest_basename``.
 
+    When ``cancellation`` is provided, the spawned 7z process is attached
+    to it so a /stop signal can terminate it. On cancellation the partial
+    .7z.NNN volumes are removed and RuntimeError("cancelled") is raised.
+
     Resulting volumes are named ``<dest_basename>.7z.001``, ``.002`` etc.
-    Returns the sorted list of created volume paths.
+    Returns the sorted list of created volume paths on success.
 
     The 7z process is invoked with ``-t7z -v<size>m -mx0 -mmt=on`` because:
     - the inputs are already-compressed media (mp3/mp4/m4a), so further
@@ -79,6 +87,7 @@ async def pack_to_volumes(
     Raises:
         ValueError: when ``sources`` is empty.
         RuntimeError: when 7z exits with a non-zero status.
+        RuntimeError("cancelled"): when the job is cancelled via ``cancellation``.
     """
 
     if not sources:
@@ -86,12 +95,7 @@ async def pack_to_volumes(
 
     archive_path = dest_basename.with_suffix(".7z")
     args = [
-        "7z",
-        "a",
-        "-t7z",
-        f"-v{volume_size_mb}m",
-        "-mx0",
-        "-mmt=on",
+        "7z", "a", "-t7z", f"-v{volume_size_mb}m", "-mx0", "-mmt=on",
         str(archive_path),
         *[str(src) for src in sources],
     ]
@@ -102,14 +106,27 @@ async def pack_to_volumes(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
+    if cancellation is not None:
+        cancellation.process = process
 
-    if progress_cb is not None:
-        await _stream_7z_progress(process, progress_cb)
+    try:
+        if progress_cb is not None:
+            await _stream_7z_progress(process, progress_cb, cancellation)
 
-    stdout, stderr = await process.communicate()
-    if process.returncode != 0:
-        err = stderr.decode("utf-8", errors="replace")[:200]
-        raise RuntimeError(f"7z failed (exit {process.returncode}): {err}")
+        # If user cancelled before/during stdout streaming, terminate now.
+        if cancellation is not None and cancellation.event.is_set():
+            await _terminate_with_grace(process)
+            _remove_partial_volumes(dest_basename)
+            raise RuntimeError("cancelled")
+
+        stdout, stderr = await process.communicate()
+        if process.returncode != 0:
+            err = stderr.decode("utf-8", errors="replace")[:200]
+            raise RuntimeError(f"7z failed (exit {process.returncode}): {err}")
+    except asyncio.CancelledError:
+        await _terminate_with_grace(process)
+        _remove_partial_volumes(dest_basename)
+        raise
 
     parent = dest_basename.parent
     prefix = f"{archive_path.name}."
@@ -121,11 +138,55 @@ async def pack_to_volumes(
     return volumes
 
 
+async def _terminate_with_grace(process: asyncio.subprocess.Process) -> None:
+    """SIGTERM → grace period → SIGKILL fallback for a 7z subprocess.
+
+    Uses JOB_TERMINATE_GRACE_SEC from security_limits so the grace
+    window stays consistent with cancel_async in JobRegistry.
+    ProcessLookupError is swallowed — the process may have already exited.
+    """
+
+    from bot.security_limits import JOB_TERMINATE_GRACE_SEC
+
+    try:
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=JOB_TERMINATE_GRACE_SEC)
+        except asyncio.TimeoutError:
+            logging.warning("7z SIGTERM grace expired, sending SIGKILL")
+            process.kill()
+            await process.wait()
+    except ProcessLookupError:
+        pass
+
+
+def _remove_partial_volumes(dest_basename: Path) -> None:
+    """Delete any <dest>.7z.NNN files left after a cancelled pack.
+
+    Only files whose suffix after the last dot consists entirely of digits
+    are considered volumes (e.g. ``.001``, ``.002``).
+    """
+
+    archive_name = dest_basename.with_suffix(".7z").name
+    prefix = f"{archive_name}."
+    for entry in dest_basename.parent.iterdir():
+        if entry.name.startswith(prefix) and entry.name[len(prefix):].isdigit():
+            try:
+                entry.unlink()
+            except OSError as exc:
+                logging.warning("Could not remove partial volume %s: %s", entry, exc)
+
+
 async def _stream_7z_progress(
     process: asyncio.subprocess.Process,
     progress_cb: Callable[[str], Awaitable[None]],
+    cancellation: "JobCancellation | None" = None,
 ) -> None:
-    """Throttle 7z stdout updates to one progress_cb call every 2 seconds."""
+    """Throttle 7z stdout updates to one progress_cb call every 2 seconds.
+
+    When ``cancellation`` is provided and its event becomes set, the loop
+    exits so the caller can terminate the subprocess.
+    """
 
     if process.stdout is None:
         return
@@ -133,6 +194,8 @@ async def _stream_7z_progress(
     last_update = 0.0
     loop = asyncio.get_running_loop()
     while True:
+        if cancellation is not None and cancellation.event.is_set():
+            return
         line = await process.stdout.readline()
         if not line:
             break

--- a/bot/archive.py
+++ b/bot/archive.py
@@ -131,7 +131,7 @@ async def _stream_7z_progress(
         return
 
     last_update = 0.0
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     while True:
         line = await process.stdout.readline()
         if not line:

--- a/bot/archive.py
+++ b/bot/archive.py
@@ -7,11 +7,14 @@ helpers used by bot.services.archive_service.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
 import unicodedata
+from collections.abc import Callable, Sequence
 from datetime import datetime
 from pathlib import Path
+from typing import Awaitable
 
 from bot.security_limits import BOTAPI_VOLUME_SIZE_MB, MTPROTO_VOLUME_SIZE_MB
 
@@ -54,3 +57,92 @@ def is_7z_available() -> bool:
     """Return True when the 7z binary is present in PATH."""
 
     return shutil.which("7z") is not None
+
+
+async def pack_to_volumes(
+    sources: Sequence[Path],
+    dest_basename: Path,
+    volume_size_mb: int,
+    *,
+    progress_cb: Callable[[str], Awaitable[None]] | None = None,
+) -> list[Path]:
+    """Pack ``sources`` into a 7z multi-volume archive at ``dest_basename``.
+
+    Resulting volumes are named ``<dest_basename>.7z.001``, ``.002`` etc.
+    Returns the sorted list of created volume paths.
+
+    The 7z process is invoked with ``-t7z -v<size>m -mx0 -mmt=on`` because:
+    - the inputs are already-compressed media (mp3/mp4/m4a), so further
+      compression buys nothing while costing significant CPU,
+    - multi-threading speeds the I/O-bound packing on multi-core hosts.
+
+    Raises:
+        ValueError: when ``sources`` is empty.
+        RuntimeError: when 7z exits with a non-zero status.
+    """
+
+    if not sources:
+        raise ValueError("empty sources")
+
+    archive_path = dest_basename.with_suffix(".7z")
+    args = [
+        "7z",
+        "a",
+        "-t7z",
+        f"-v{volume_size_mb}m",
+        "-mx0",
+        "-mmt=on",
+        str(archive_path),
+        *[str(src) for src in sources],
+    ]
+
+    logging.info("Running 7z pack: %s", " ".join(args))
+    process = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    if progress_cb is not None:
+        await _stream_7z_progress(process, progress_cb)
+
+    stdout, stderr = await process.communicate()
+    if process.returncode != 0:
+        err = stderr.decode("utf-8", errors="replace")[:200]
+        raise RuntimeError(f"7z failed (exit {process.returncode}): {err}")
+
+    parent = dest_basename.parent
+    prefix = f"{archive_path.name}."
+    volumes = sorted(
+        p for p in parent.iterdir()
+        if p.name.startswith(prefix) and p.name[len(prefix):].isdigit()
+    )
+    logging.info("7z packed %d volume(s) for %s", len(volumes), archive_path)
+    return volumes
+
+
+async def _stream_7z_progress(
+    process: asyncio.subprocess.Process,
+    progress_cb: Callable[[str], Awaitable[None]],
+) -> None:
+    """Throttle 7z stdout updates to one progress_cb call every 2 seconds."""
+
+    if process.stdout is None:
+        return
+
+    last_update = 0.0
+    loop = asyncio.get_event_loop()
+    while True:
+        line = await process.stdout.readline()
+        if not line:
+            break
+        now = loop.time()
+        if now - last_update < 2.0:
+            continue
+        decoded = line.decode("utf-8", errors="replace").strip()
+        if decoded:
+            try:
+                await progress_cb(decoded)
+            except Exception as exc:  # progress is best-effort
+                logging.warning("Archive progress callback failed: %s", exc)
+            last_update = now

--- a/bot/cleanup.py
+++ b/bot/cleanup.py
@@ -9,8 +9,11 @@ import time
 import shutil
 import logging
 import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
 
 from bot.config import DOWNLOAD_PATH
+from bot.security_limits import PLAYLIST_ARCHIVE_RETENTION_MIN
 
 
 def cleanup_old_files(directory, max_age_hours=24):
@@ -155,6 +158,80 @@ def monitor_disk_space():
             cleanup_old_files(DOWNLOAD_PATH, max_age_hours=24)
 
 
+_ARCHIVE_PREFIXES = ("pl_", "big_")
+
+
+def _purge_archive_workspaces(chat_dir: Path, retention_min: int) -> int:
+    """Remove archive workspaces older than retention_min, unless locked.
+
+    Workspaces are subdirectories named ``pl_*`` or ``big_*``. A
+    ``.lock`` file inside a young workspace blocks deletion (used during
+    pack/send operations). After 24h workspaces are removed regardless
+    of the lock — the long-running cleanup acts as a safety net.
+    """
+
+    if not chat_dir.exists():
+        return 0
+
+    now = time.time()
+    threshold = retention_min * 60
+    safety_net = 24 * 3600
+    removed = 0
+
+    for entry in chat_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        if not any(entry.name.startswith(p) for p in _ARCHIVE_PREFIXES):
+            continue
+        try:
+            age = now - entry.stat().st_mtime
+        except OSError as exc:
+            logging.warning("Could not stat %s: %s", entry, exc)
+            continue
+
+        lock = entry / ".lock"
+        if age <= threshold:
+            continue
+        if lock.exists() and age <= safety_net:
+            continue
+
+        try:
+            shutil.rmtree(entry)
+            removed += 1
+            logging.info("Removed stale archive workspace: %s (age %.1f h)",
+                         entry, age / 3600)
+        except OSError as exc:
+            logging.error("Failed to remove %s: %s", entry, exc)
+
+    return removed
+
+
+def _purge_pending_archive_jobs(retention_min: int) -> int:
+    """Drop pending_archive_jobs entries older than retention_min and delete files."""
+
+    from bot.session_store import pending_archive_jobs
+
+    cutoff = datetime.now() - timedelta(minutes=retention_min)
+    removed = 0
+    for chat_id in list(pending_archive_jobs):
+        bucket = pending_archive_jobs.get(chat_id) or {}
+        for token in list(bucket):
+            state = bucket[token]
+            if state.created_at >= cutoff:
+                continue
+            bucket.pop(token, None)
+            try:
+                os.remove(str(state.file_path))
+            except OSError:
+                pass
+            removed += 1
+        if not bucket:
+            pending_archive_jobs.pop(chat_id, None)
+        else:
+            pending_archive_jobs[chat_id] = bucket
+    return removed
+
+
 def periodic_cleanup():
     """
     Function run periodically in separate thread.
@@ -174,6 +251,11 @@ def periodic_cleanup():
 
             if deleted_count > 0:
                 logging.info("Periodic cleanup: deleted %d old files", deleted_count)
+
+            for chat_dir in Path(DOWNLOAD_PATH).iterdir():
+                if chat_dir.is_dir():
+                    _purge_archive_workspaces(chat_dir, PLAYLIST_ARCHIVE_RETENTION_MIN)
+            _purge_pending_archive_jobs(PLAYLIST_ARCHIVE_RETENTION_MIN)
 
         except Exception as e:
             logging.error("Error during periodic cleanup: %s", e)

--- a/bot/cleanup.py
+++ b/bot/cleanup.py
@@ -232,6 +232,34 @@ def _purge_pending_archive_jobs(retention_min: int) -> int:
     return removed
 
 
+def _purge_archived_deliveries(retention_min: int) -> int:
+    """Drop archived_deliveries entries older than retention_min.
+
+    The on-disk workspace is removed by _purge_archive_workspaces; this
+    function drops the in-memory metadata (volume paths + caption) so the
+    user is not offered a 'Wyślij ponownie' button that would fail with
+    FileNotFoundError because the workspace already vanished.
+    """
+
+    from bot.session_store import archived_deliveries
+
+    cutoff = datetime.now() - timedelta(minutes=retention_min)
+    removed = 0
+    for chat_id in list(archived_deliveries):
+        bucket = archived_deliveries.get(chat_id) or {}
+        for token in list(bucket):
+            state = bucket[token]
+            if state.created_at >= cutoff:
+                continue
+            bucket.pop(token, None)
+            removed += 1
+        if not bucket:
+            archived_deliveries.pop(chat_id, None)
+        else:
+            archived_deliveries[chat_id] = bucket
+    return removed
+
+
 def periodic_cleanup():
     """
     Function run periodically in separate thread.
@@ -256,6 +284,7 @@ def periodic_cleanup():
                 if chat_dir.is_dir():
                     _purge_archive_workspaces(chat_dir, PLAYLIST_ARCHIVE_RETENTION_MIN)
             _purge_pending_archive_jobs(PLAYLIST_ARCHIVE_RETENTION_MIN)
+            _purge_archived_deliveries(PLAYLIST_ARCHIVE_RETENTION_MIN)
 
         except Exception as e:
             logging.error("Error during periodic cleanup: %s", e)

--- a/bot/cleanup.py
+++ b/bot/cleanup.py
@@ -13,7 +13,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from bot.config import DOWNLOAD_PATH
-from bot.security_limits import PLAYLIST_ARCHIVE_RETENTION_MIN
+from bot.jobs import job_registry
+from bot.security_limits import JOB_DEAD_AGE_HOURS, PLAYLIST_ARCHIVE_RETENTION_MIN
 
 
 def cleanup_old_files(directory, max_age_hours=24):
@@ -260,6 +261,42 @@ def _purge_archived_deliveries(retention_min: int) -> int:
     return removed
 
 
+def _purge_dead_jobs(retention_hours: int) -> int:
+    """Remove zombie entries from JobRegistry older than retention_hours.
+
+    Delegates to JobRegistry.purge_dead which logs each removed entry
+    at WARNING level so stale jobs are visible in the audit trail.
+    """
+
+    return job_registry.purge_dead(timedelta(hours=retention_hours))
+
+
+def _purge_partial_archive_workspaces(retention_min: int) -> int:
+    """Drop partial_archive_workspaces entries older than retention_min.
+
+    In-memory state only — the on-disk workspace (if any) is already
+    handled by _purge_archive_workspaces which scans chat directories.
+    """
+
+    from bot.session_store import partial_archive_workspaces
+
+    cutoff = datetime.now() - timedelta(minutes=retention_min)
+    removed = 0
+    for chat_id in list(partial_archive_workspaces):
+        bucket = partial_archive_workspaces.get(chat_id) or {}
+        for token in list(bucket):
+            state = bucket[token]
+            if state.created_at >= cutoff:
+                continue
+            bucket.pop(token, None)
+            removed += 1
+        if not bucket:
+            partial_archive_workspaces.pop(chat_id, None)
+        else:
+            partial_archive_workspaces[chat_id] = bucket
+    return removed
+
+
 def periodic_cleanup():
     """
     Function run periodically in separate thread.
@@ -285,6 +322,8 @@ def periodic_cleanup():
                     _purge_archive_workspaces(chat_dir, PLAYLIST_ARCHIVE_RETENTION_MIN)
             _purge_pending_archive_jobs(PLAYLIST_ARCHIVE_RETENTION_MIN)
             _purge_archived_deliveries(PLAYLIST_ARCHIVE_RETENTION_MIN)
+            _purge_dead_jobs(JOB_DEAD_AGE_HOURS)
+            _purge_partial_archive_workspaces(PLAYLIST_ARCHIVE_RETENTION_MIN)
 
         except Exception as e:
             logging.error("Error during periodic cleanup: %s", e)

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -722,11 +722,16 @@ async def _handle_arc_cancel(update, chat_id: int, token: str) -> None:
         pending_archive_jobs.pop(chat_id, None)
     else:
         pending_archive_jobs[chat_id] = bucket
-    if state is not None:
+    if state is None:
         try:
-            os.remove(str(state.file_path))
-        except OSError:
-            pass
+            await update.callback_query.edit_message_text("Sesja wygasła.")
+        except Exception as exc:
+            logging.debug("arc_cancel edit failed: %s", exc)
+        return
+    try:
+        os.remove(str(state.file_path))
+    except OSError:
+        pass
     try:
         await update.callback_query.edit_message_text("Anulowano. Plik usunięty.")
     except Exception as exc:
@@ -780,7 +785,13 @@ async def _handle_arc_purge(update, chat_id: int, token: str) -> None:
         archived_deliveries.pop(chat_id, None)
     else:
         archived_deliveries[chat_id] = bucket
-    if state is not None and state.workspace.exists():
+    if state is None:
+        try:
+            await update.callback_query.edit_message_text("Sesja wygasła.")
+        except Exception as exc:
+            logging.debug("arc_purge edit failed: %s", exc)
+        return
+    if state.workspace.exists():
         shutil.rmtree(state.workspace, ignore_errors=True)
     try:
         await update.callback_query.edit_message_text("Folder usunięty.")

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -432,6 +432,7 @@ async def download_file(
                     output_dir=chat_download_path,
                     executor=_executor,
                     status_callback=lambda status: update_status(f"Transkrypcja w toku...\n\n{status}"),
+                    cancellation=cancellation,
                 )
 
                 if not transcript_path or not os.path.exists(transcript_path):
@@ -580,9 +581,9 @@ async def download_file(
                                 f"{reason}"
                             )
                         if media_type == "audio":
-                            ok = await send_audio_mtproto(chat_id, downloaded_file_path, title=title, caption=title, thumb_path=thumb_path)
+                            ok = await send_audio_mtproto(chat_id, downloaded_file_path, title=title, caption=title, thumb_path=thumb_path, cancellation=cancellation)
                         else:
-                            ok = await send_video_mtproto(chat_id, downloaded_file_path, caption=title, thumb_path=thumb_path)
+                            ok = await send_video_mtproto(chat_id, downloaded_file_path, caption=title, thumb_path=thumb_path, cancellation=cancellation)
                         if not ok:
                             raise RuntimeError("Wysyłanie pliku przez MTProto nie powiodło się.")
                     else:

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -75,6 +75,7 @@ from bot.services.transcription_service import (
     transcript_too_long_for_summary,
 )
 from bot.runtime import record_download_for
+from bot.jobs import JobDescriptor, job_registry
 from bot.handlers.media_extras_callbacks import (
     _handle_instagram_download as _extracted_handle_instagram_download,
     _show_spotify_summary_options as _extracted_show_spotify_summary_options,
@@ -339,308 +340,321 @@ async def download_file(
     title = "Unknown"
     success_recorded = False
 
-    async def update_status(text):
-        await safe_edit_message(query, text)
-
-    media_name = get_media_label(_get_session_context_value(context, chat_id, "platform", legacy_key="platform"))
-    await update_status(f"Pobieranie informacji o {media_name}...")
-
-    chat_download_path = os.path.join(DOWNLOAD_PATH, str(chat_id))
-    os.makedirs(chat_download_path, exist_ok=True)
-
-    time_range = _get_session_value(context, chat_id, "time_range", user_time_ranges)
-    try:
-        plan = prepare_download_plan(
-            url=url,
-            media_type=media_type,
-            format_choice=format,
-            chat_download_path=chat_download_path,
-            time_range=time_range,
-            transcribe=transcribe,
-            use_format_id=use_format_id,
-            audio_quality=audio_quality,
-        )
-    except ValueError:
-        await update_status("Nieobsługiwana jakość audio. Spróbuj zmienić opcję.")
-        return
-
-    if not plan:
-        await update_status(f"Wystąpił błąd podczas pobierania informacji o {media_name}.")
-        return
-
-    info = plan.info
-    title = plan.title
-    duration_str = plan.duration_str
-    sanitized_title = plan.sanitized_title
+    descriptor = JobDescriptor(
+        job_id="",
+        chat_id=chat_id,
+        kind="single_dl",
+        label=f"Pojedynczy plik ({media_type} {format}) — pobieranie",
+        started_at=datetime.now(),
+    )
+    cancellation = job_registry.register(chat_id, descriptor)
 
     try:
-        await update_status(f"Sprawdzanie rozmiaru pliku...\n({duration_str})")
-        size_mb = await asyncio.get_event_loop().run_in_executor(_executor, lambda: estimate_download_size(plan))
-        if not ensure_size_within_limit(size_mb, max_size_mb=MAX_FILE_SIZE_MB):
-            await update_status(
-                f"Wybrany format jest zbyt duży!\n\n"
-                f"Rozmiar: {size_mb:.1f} MB\n"
-                f"Maksymalny dozwolony rozmiar: {MAX_FILE_SIZE_MB} MB\n\n"
-                f"Spróbuj wybrać niższą jakość lub pobierz tylko audio."
+        async def update_status(text):
+            await safe_edit_message(query, text)
+
+        media_name = get_media_label(_get_session_context_value(context, chat_id, "platform", legacy_key="platform"))
+        await update_status(f"Pobieranie informacji o {media_name}...")
+
+        chat_download_path = os.path.join(DOWNLOAD_PATH, str(chat_id))
+        os.makedirs(chat_download_path, exist_ok=True)
+
+        time_range = _get_session_value(context, chat_id, "time_range", user_time_ranges)
+        try:
+            plan = prepare_download_plan(
+                url=url,
+                media_type=media_type,
+                format_choice=format,
+                chat_download_path=chat_download_path,
+                time_range=time_range,
+                transcribe=transcribe,
+                use_format_id=use_format_id,
+                audio_quality=audio_quality,
             )
+        except ValueError:
+            await update_status("Nieobsługiwana jakość audio. Spróbuj zmienić opcję.")
             return
 
-        time_range_info = ""
-        if time_range:
-            time_range_info = f"\n✂️ Zakres: {time_range['start']} - {time_range['end']}"
-        await update_status(f"Rozpoczynam pobieranie...\nCzas trwania: {duration_str}{time_range_info}")
-        download_result = await execute_download(
-            plan,
-            chat_id=chat_id,
-            executor=_executor,
-            progress_hook_factory=create_progress_hook,
-            progress_state=_download_progress,
-            status_callback=update_status,
-            format_bytes=format_bytes,
-            format_eta=format_eta,
-        )
-        downloaded_file_path = download_result.file_path
-        file_size_mb = download_result.file_size_mb
+        if not plan:
+            await update_status(f"Wystąpił błąd podczas pobierania informacji o {media_name}.")
+            return
 
-        if transcribe:
-            await update_status(
-                f"Pobieranie zakończone ({file_size_mb:.1f} MB).\n\n"
-                f"Rozpoczynanie transkrypcji audio...\nTo może potrwać kilka minut."
-            )
+        info = plan.info
+        title = plan.title
+        duration_str = plan.duration_str
+        sanitized_title = plan.sanitized_title
 
-            if not get_runtime_value("GROQ_API_KEY", ""):
+        try:
+            await update_status(f"Sprawdzanie rozmiaru pliku...\n({duration_str})")
+            size_mb = await asyncio.get_event_loop().run_in_executor(_executor, lambda: estimate_download_size(plan))
+            if not ensure_size_within_limit(size_mb, max_size_mb=MAX_FILE_SIZE_MB):
                 await update_status(
-                    "Funkcja niedostępna — brak klucza API do transkrypcji.\n"
-                    "Skontaktuj się z administratorem."
+                    f"Wybrany format jest zbyt duży!\n\n"
+                    f"Rozmiar: {size_mb:.1f} MB\n"
+                    f"Maksymalny dozwolony rozmiar: {MAX_FILE_SIZE_MB} MB\n\n"
+                    f"Spróbuj wybrać niższą jakość lub pobierz tylko audio."
                 )
                 return
 
-            transcript_path = await run_transcription_with_progress(
-                source_path=downloaded_file_path,
-                output_dir=chat_download_path,
+            time_range_info = ""
+            if time_range:
+                time_range_info = f"\n✂️ Zakres: {time_range['start']} - {time_range['end']}"
+            await update_status(f"Rozpoczynam pobieranie...\nCzas trwania: {duration_str}{time_range_info}")
+            download_result = await execute_download(
+                plan,
+                chat_id=chat_id,
                 executor=_executor,
-                status_callback=lambda status: update_status(f"Transkrypcja w toku...\n\n{status}"),
+                progress_hook_factory=create_progress_hook,
+                progress_state=_download_progress,
+                status_callback=update_status,
+                format_bytes=format_bytes,
+                format_eta=format_eta,
+                cancellation=cancellation,
             )
+            downloaded_file_path = download_result.file_path
+            file_size_mb = download_result.file_size_mb
 
-            if not transcript_path or not os.path.exists(transcript_path):
-                await update_status("Wystąpił błąd podczas transkrypcji.")
-                return
+            if transcribe:
+                await update_status(
+                    f"Pobieranie zakończone ({file_size_mb:.1f} MB).\n\n"
+                    f"Rozpoczynanie transkrypcji audio...\nTo może potrwać kilka minut."
+                )
 
-            transcript_result = load_transcript_result(transcript_path)
-
-            if summary:
-                if not get_runtime_value("CLAUDE_API_KEY", ""):
+                if not get_runtime_value("GROQ_API_KEY", ""):
                     await update_status(
-                        "Funkcja niedostępna — brak klucza API do podsumowań.\n"
+                        "Funkcja niedostępna — brak klucza API do transkrypcji.\n"
                         "Skontaktuj się z administratorem."
                     )
                     return
 
-                transcript_text = transcript_result.display_text
-                if transcript_too_long_for_summary(transcript_text):
-                    await update_status(
-                        "Transkrypcja zakończona, ale tekst jest zbyt długi na podsumowanie AI.\n\n"
-                        "Wysyłam samą transkrypcję."
+                transcript_path = await run_transcription_with_progress(
+                    source_path=downloaded_file_path,
+                    output_dir=chat_download_path,
+                    executor=_executor,
+                    status_callback=lambda status: update_status(f"Transkrypcja w toku...\n\n{status}"),
+                )
+
+                if not transcript_path or not os.path.exists(transcript_path):
+                    await update_status("Wystąpił błąd podczas transkrypcji.")
+                    return
+
+                transcript_result = load_transcript_result(transcript_path)
+
+                if summary:
+                    if not get_runtime_value("CLAUDE_API_KEY", ""):
+                        await update_status(
+                            "Funkcja niedostępna — brak klucza API do podsumowań.\n"
+                            "Skontaktuj się z administratorem."
+                        )
+                        return
+
+                    transcript_text = transcript_result.display_text
+                    if transcript_too_long_for_summary(transcript_text):
+                        await update_status(
+                            "Transkrypcja zakończona, ale tekst jest zbyt długi na podsumowanie AI.\n\n"
+                            "Wysyłam samą transkrypcję."
+                        )
+                        with open(transcript_path, "rb") as file_obj:
+                            await context.bot.send_document(
+                                chat_id=chat_id,
+                                document=file_obj,
+                                filename=os.path.basename(transcript_path),
+                                caption=f"Transkrypcja: {title} (podsumowanie pominięte — tekst zbyt długi)",
+                                read_timeout=60,
+                                write_timeout=60,
+                            )
+                        record_download_for(context, chat_id, title, url, "transcription", file_size_mb, time_range, selected_format=format)
+                        success_recorded = True
+                        return
+
+                    await update_status("Transkrypcja zakończona.\n\nGeneruję podsumowanie AI...\nTo może potrwać około minuty.")
+                    summary_result = await generate_summary_artifact(
+                        transcript_text=transcript_text,
+                        summary_type=summary_type,
+                        title=title,
+                        sanitized_title=sanitized_title,
+                        output_dir=chat_download_path,
+                        executor=_executor,
                     )
+                    if not summary_result:
+                        await update_status("Wystąpił błąd podczas generowania podsumowania.")
+                        return
+
+                    await update_status("Podsumowanie wygenerowane.\n\nWysyłanie wyników...")
+                    await send_long_message(
+                        context.bot,
+                        chat_id,
+                        summary_result.summary_text,
+                        header=f"*{escape_md(title)} - {summary_result.summary_type_name}*\n\n",
+                    )
+                    await update_status("Wysyłanie pliku z pełną transkrypcją...")
                     with open(transcript_path, "rb") as file_obj:
                         await context.bot.send_document(
                             chat_id=chat_id,
                             document=file_obj,
                             filename=os.path.basename(transcript_path),
-                            caption=f"Transkrypcja: {title} (podsumowanie pominięte — tekst zbyt długi)",
+                            caption=f"Pełna transkrypcja: {title}",
                             read_timeout=60,
                             write_timeout=60,
                         )
+                    record_download_for(
+                        context,
+                        chat_id,
+                        title,
+                        url,
+                        f"transcription_summary_{summary_type}",
+                        file_size_mb,
+                        time_range,
+                        selected_format=format,
+                    )
+                    success_recorded = True
+                    await update_status("Transkrypcja i podsumowanie zostały wysłane!")
+                else:
+                    await update_status("Transkrypcja zakończona.\n\nWysyłanie transkrypcji...")
+                    display_text = transcript_result.display_text
+                    if len(display_text) <= 30000:
+                        await send_long_message(
+                            context.bot,
+                            chat_id,
+                            display_text,
+                            header=f"*Transkrypcja: {escape_md(title)}*\n\n",
+                        )
+                    with open(transcript_path, "rb") as file_obj:
+                        await context.bot.send_document(
+                            chat_id=chat_id,
+                            document=file_obj,
+                            filename=os.path.basename(transcript_path),
+                            caption=(
+                                f"Transkrypcja: {title}"
+                                if len(display_text) <= 30000
+                                else f"Transkrypcja: {title} ({len(display_text):,} znaków — tylko plik)"
+                            ),
+                            read_timeout=60,
+                            write_timeout=60,
+                        )
+                    try:
+                        cleanup_transcription_artifacts(
+                            source_media_path=downloaded_file_path,
+                            output_dir=chat_download_path,
+                            transcript_prefix=sanitized_title,
+                        )
+                    except Exception as exc:
+                        logging.error("Error deleting files: %s", exc)
                     record_download_for(context, chat_id, title, url, "transcription", file_size_mb, time_range, selected_format=format)
+                    success_recorded = True
+                    await update_status("Transkrypcja została wysłana!")
+            else:
+                use_mtproto = file_size_mb > TELEGRAM_UPLOAD_LIMIT_MB
+
+                # Detect files that exceed the active Telegram transport limit.
+                # When too large, offer the 7z archive split instead of failing.
+                transport_limit_mb = volume_size_for(
+                    use_mtproto=_mtproto_unavailability_reason() is None
+                )
+                if file_size_mb > transport_limit_mb and is_7z_available():
+                    await _offer_archive_or_cancel(
+                        update,
+                        context,
+                        chat_id=chat_id,
+                        file_path=downloaded_file_path,
+                        title=title,
+                        media_type=media_type,
+                        format_choice=format,
+                        file_size_mb=file_size_mb,
+                    )
+                    # The archive flow now owns the file; skip cleanup.
                     success_recorded = True
                     return
 
-                await update_status("Transkrypcja zakończona.\n\nGeneruję podsumowanie AI...\nTo może potrwać około minuty.")
-                summary_result = await generate_summary_artifact(
-                    transcript_text=transcript_text,
-                    summary_type=summary_type,
-                    title=title,
-                    sanitized_title=sanitized_title,
-                    output_dir=chat_download_path,
-                    executor=_executor,
-                )
-                if not summary_result:
-                    await update_status("Wystąpił błąd podczas generowania podsumowania.")
-                    return
+                method_label = " (MTProto)" if use_mtproto else ""
+                await update_status(f"Pobieranie zakończone ({file_size_mb:.1f} MB).\n\nWysyłanie pliku do Telegram...{method_label}")
+                thumb_path = await asyncio.get_event_loop().run_in_executor(_executor, download_thumbnail, info, chat_download_path, True)
+                try:
+                    if use_mtproto:
+                        from bot.mtproto import mtproto_unavailability_reason, send_audio_mtproto, send_video_mtproto
 
-                await update_status("Podsumowanie wygenerowane.\n\nWysyłanie wyników...")
-                await send_long_message(
-                    context.bot,
-                    chat_id,
-                    summary_result.summary_text,
-                    header=f"*{escape_md(title)} - {summary_result.summary_type_name}*\n\n",
-                )
-                await update_status("Wysyłanie pliku z pełną transkrypcją...")
-                with open(transcript_path, "rb") as file_obj:
-                    await context.bot.send_document(
-                        chat_id=chat_id,
-                        document=file_obj,
-                        filename=os.path.basename(transcript_path),
-                        caption=f"Pełna transkrypcja: {title}",
-                        read_timeout=60,
-                        write_timeout=60,
-                    )
+                        reason = mtproto_unavailability_reason()
+                        if reason is not None:
+                            raise RuntimeError(
+                                f"Plik za duży dla Bot API ({file_size_mb:.0f} MB, limit: {TELEGRAM_UPLOAD_LIMIT_MB} MB).\n"
+                                f"{reason}"
+                            )
+                        if media_type == "audio":
+                            ok = await send_audio_mtproto(chat_id, downloaded_file_path, title=title, caption=title, thumb_path=thumb_path)
+                        else:
+                            ok = await send_video_mtproto(chat_id, downloaded_file_path, caption=title, thumb_path=thumb_path)
+                        if not ok:
+                            raise RuntimeError("Wysyłanie pliku przez MTProto nie powiodło się.")
+                    else:
+                        with open(downloaded_file_path, "rb") as file_obj:
+                            thumb_file = open(thumb_path, "rb") if thumb_path else None
+                            try:
+                                if media_type == "audio":
+                                    await context.bot.send_audio(
+                                        chat_id=chat_id,
+                                        audio=file_obj,
+                                        title=title,
+                                        caption=title,
+                                        thumbnail=thumb_file,
+                                        read_timeout=60,
+                                        write_timeout=60,
+                                    )
+                                else:
+                                    await context.bot.send_video(
+                                        chat_id=chat_id,
+                                        video=file_obj,
+                                        caption=title,
+                                        thumbnail=thumb_file,
+                                        read_timeout=60,
+                                        write_timeout=60,
+                                    )
+                            finally:
+                                if thumb_file:
+                                    thumb_file.close()
+                finally:
+                    if thumb_path and os.path.exists(thumb_path):
+                        try:
+                            os.remove(thumb_path)
+                        except OSError:
+                            pass
+
+                try:
+                    os.remove(downloaded_file_path)
+                except OSError:
+                    pass
+                record_download_for(context, chat_id, title, url, f"{media_type}_{format}", file_size_mb, time_range, selected_format=format)
+                success_recorded = True
+                await update_status("Plik został wysłany!")
+        except Exception as exc:
+            if not success_recorded:
                 record_download_for(
                     context,
                     chat_id,
                     title,
                     url,
-                    f"transcription_summary_{summary_type}",
-                    file_size_mb,
-                    time_range,
+                    f"{media_type}_{format}",
+                    status="failure",
                     selected_format=format,
+                    error_message=str(exc),
                 )
-                success_recorded = True
-                await update_status("Transkrypcja i podsumowanie zostały wysłane!")
+            logging.error("Error in download_file: %s", exc)
+
+            error_str = str(exc).lower()
+            if any(keyword in error_str for keyword in ("login", "sign in", "cookie", "authentication")):
+                platform_name = _get_session_context_value(
+                    context, chat_id, "platform", legacy_key="platform"
+                )
+                config = get_platform(platform_name)
+                hint = (
+                    config.cookies_hint
+                    if config and config.cookies_hint
+                    else GENERIC_COOKIES_HINT
+                )
+                await update_status(hint)
             else:
-                await update_status("Transkrypcja zakończona.\n\nWysyłanie transkrypcji...")
-                display_text = transcript_result.display_text
-                if len(display_text) <= 30000:
-                    await send_long_message(
-                        context.bot,
-                        chat_id,
-                        display_text,
-                        header=f"*Transkrypcja: {escape_md(title)}*\n\n",
-                    )
-                with open(transcript_path, "rb") as file_obj:
-                    await context.bot.send_document(
-                        chat_id=chat_id,
-                        document=file_obj,
-                        filename=os.path.basename(transcript_path),
-                        caption=(
-                            f"Transkrypcja: {title}"
-                            if len(display_text) <= 30000
-                            else f"Transkrypcja: {title} ({len(display_text):,} znaków — tylko plik)"
-                        ),
-                        read_timeout=60,
-                        write_timeout=60,
-                    )
-                try:
-                    cleanup_transcription_artifacts(
-                        source_media_path=downloaded_file_path,
-                        output_dir=chat_download_path,
-                        transcript_prefix=sanitized_title,
-                    )
-                except Exception as exc:
-                    logging.error("Error deleting files: %s", exc)
-                record_download_for(context, chat_id, title, url, "transcription", file_size_mb, time_range, selected_format=format)
-                success_recorded = True
-                await update_status("Transkrypcja została wysłana!")
-        else:
-            use_mtproto = file_size_mb > TELEGRAM_UPLOAD_LIMIT_MB
-
-            # Detect files that exceed the active Telegram transport limit.
-            # When too large, offer the 7z archive split instead of failing.
-            transport_limit_mb = volume_size_for(
-                use_mtproto=_mtproto_unavailability_reason() is None
-            )
-            if file_size_mb > transport_limit_mb and is_7z_available():
-                await _offer_archive_or_cancel(
-                    update,
-                    context,
-                    chat_id=chat_id,
-                    file_path=downloaded_file_path,
-                    title=title,
-                    media_type=media_type,
-                    format_choice=format,
-                    file_size_mb=file_size_mb,
-                )
-                # The archive flow now owns the file; skip cleanup.
-                success_recorded = True
-                return
-
-            method_label = " (MTProto)" if use_mtproto else ""
-            await update_status(f"Pobieranie zakończone ({file_size_mb:.1f} MB).\n\nWysyłanie pliku do Telegram...{method_label}")
-            thumb_path = await asyncio.get_event_loop().run_in_executor(_executor, download_thumbnail, info, chat_download_path, True)
-            try:
-                if use_mtproto:
-                    from bot.mtproto import mtproto_unavailability_reason, send_audio_mtproto, send_video_mtproto
-
-                    reason = mtproto_unavailability_reason()
-                    if reason is not None:
-                        raise RuntimeError(
-                            f"Plik za duży dla Bot API ({file_size_mb:.0f} MB, limit: {TELEGRAM_UPLOAD_LIMIT_MB} MB).\n"
-                            f"{reason}"
-                        )
-                    if media_type == "audio":
-                        ok = await send_audio_mtproto(chat_id, downloaded_file_path, title=title, caption=title, thumb_path=thumb_path)
-                    else:
-                        ok = await send_video_mtproto(chat_id, downloaded_file_path, caption=title, thumb_path=thumb_path)
-                    if not ok:
-                        raise RuntimeError("Wysyłanie pliku przez MTProto nie powiodło się.")
-                else:
-                    with open(downloaded_file_path, "rb") as file_obj:
-                        thumb_file = open(thumb_path, "rb") if thumb_path else None
-                        try:
-                            if media_type == "audio":
-                                await context.bot.send_audio(
-                                    chat_id=chat_id,
-                                    audio=file_obj,
-                                    title=title,
-                                    caption=title,
-                                    thumbnail=thumb_file,
-                                    read_timeout=60,
-                                    write_timeout=60,
-                                )
-                            else:
-                                await context.bot.send_video(
-                                    chat_id=chat_id,
-                                    video=file_obj,
-                                    caption=title,
-                                    thumbnail=thumb_file,
-                                    read_timeout=60,
-                                    write_timeout=60,
-                                )
-                        finally:
-                            if thumb_file:
-                                thumb_file.close()
-            finally:
-                if thumb_path and os.path.exists(thumb_path):
-                    try:
-                        os.remove(thumb_path)
-                    except OSError:
-                        pass
-
-            try:
-                os.remove(downloaded_file_path)
-            except OSError:
-                pass
-            record_download_for(context, chat_id, title, url, f"{media_type}_{format}", file_size_mb, time_range, selected_format=format)
-            success_recorded = True
-            await update_status("Plik został wysłany!")
-    except Exception as exc:
-        if not success_recorded:
-            record_download_for(
-                context,
-                chat_id,
-                title,
-                url,
-                f"{media_type}_{format}",
-                status="failure",
-                selected_format=format,
-                error_message=str(exc),
-            )
-        logging.error("Error in download_file: %s", exc)
-
-        error_str = str(exc).lower()
-        if any(keyword in error_str for keyword in ("login", "sign in", "cookie", "authentication")):
-            platform_name = _get_session_context_value(
-                context, chat_id, "platform", legacy_key="platform"
-            )
-            config = get_platform(platform_name)
-            hint = (
-                config.cookies_hint
-                if config and config.cookies_hint
-                else GENERIC_COOKIES_HINT
-            )
-            await update_status(hint)
-        else:
-            await update_status("Wystąpił błąd podczas pobierania. Spróbuj ponownie.")
+                await update_status("Wystąpił błąd podczas pobierania. Spróbuj ponownie.")
+    finally:
+        job_registry.unregister(cancellation.job_id)
 
 
 async def handle_formats_list(update: Update, context: ContextTypes.DEFAULT_TYPE, url):

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -42,7 +42,7 @@ from bot.session_store import (
     user_time_ranges,
     user_urls,
 )
-from bot.archive import volume_size_for
+from bot.archive import is_7z_available, volume_size_for
 from bot.mtproto import mtproto_unavailability_reason as _mtproto_unavailability_reason
 from bot.services.archive_service import (
     execute_single_file_archive_flow,
@@ -530,7 +530,7 @@ async def download_file(
             transport_limit_mb = volume_size_for(
                 use_mtproto=_mtproto_unavailability_reason() is None
             )
-            if file_size_mb > transport_limit_mb:
+            if file_size_mb > transport_limit_mb and is_7z_available():
                 await _offer_archive_or_cancel(
                     update,
                     context,

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -700,7 +700,7 @@ async def _offer_archive_or_cancel(
 
 
 async def handle_archive_callback(update, context, data: str) -> None:
-    """Dispatch arc_split_/arc_cancel_/arc_resend_/arc_purge_ callbacks."""
+    """Dispatch arc_split_/arc_cancel_/arc_pack_partial_/arc_purge_partial_/arc_resend_/arc_purge_ callbacks."""
 
     chat_id = update.effective_chat.id
 
@@ -714,6 +714,21 @@ async def handle_archive_callback(update, context, data: str) -> None:
     if data.startswith("arc_cancel_"):
         token = data[len("arc_cancel_"):]
         await _handle_arc_cancel(update, chat_id, token)
+        return
+
+    # arc_pack_partial_ and arc_purge_partial_ must be matched before arc_purge_
+    # to avoid the shorter prefix swallowing the longer one.
+    if data.startswith("arc_pack_partial_"):
+        token = data[len("arc_pack_partial_"):]
+        from bot.services.archive_service import execute_partial_archive_flow
+        await execute_partial_archive_flow(
+            update, context, chat_id=chat_id, token=token,
+        )
+        return
+
+    if data.startswith("arc_purge_partial_"):
+        token = data[len("arc_purge_partial_"):]
+        await _handle_arc_purge_partial(update, chat_id, token)
         return
 
     if data.startswith("arc_resend_"):
@@ -808,3 +823,26 @@ async def _handle_arc_purge(update, chat_id: int, token: str) -> None:
         await update.callback_query.edit_message_text("Folder usunięty.")
     except Exception as exc:
         logging.debug("arc_purge edit failed: %s", exc)
+
+
+async def _handle_arc_purge_partial(update, chat_id: int, token: str) -> None:
+    from bot.session_store import partial_archive_workspaces
+
+    bucket = partial_archive_workspaces.get(chat_id) or {}
+    state = bucket.pop(token, None)
+    if not bucket:
+        partial_archive_workspaces.pop(chat_id, None)
+    else:
+        partial_archive_workspaces[chat_id] = bucket
+    if state is None:
+        try:
+            await update.callback_query.edit_message_text("Sesja wygasła.")
+        except Exception:
+            pass
+        return
+    if state.workspace.exists():
+        shutil.rmtree(state.workspace, ignore_errors=True)
+    try:
+        await update.callback_query.edit_message_text("Folder usunięty.")
+    except Exception as exc:
+        logging.debug("arc_purge_partial edit failed: %s", exc)

--- a/bot/handlers/download_callbacks.py
+++ b/bot/handlers/download_callbacks.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import shutil
 import time
 from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import yt_dlp
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, InputMediaPhoto, Update
@@ -32,10 +34,20 @@ from bot.session_context import (
     set_session_value as _set_session_value,
 )
 from bot.session_store import (
+    ArchiveJobState,
+    archived_deliveries,
     download_progress as _download_progress,
+    pending_archive_jobs,
     user_playlist_data,
     user_time_ranges,
     user_urls,
+)
+from bot.archive import volume_size_for
+from bot.mtproto import mtproto_unavailability_reason as _mtproto_unavailability_reason
+from bot.services.archive_service import (
+    execute_single_file_archive_flow,
+    register_pending_archive_job,
+    send_volumes,
 )
 from bot.transcription_limits import CORRECTION_DURATION_LIMIT_MIN, SUMMARY_DURATION_LIMIT_MIN
 from bot.downloader_media import COOKIES_FILE, download_photo, download_thumbnail
@@ -512,6 +524,27 @@ async def download_file(
                 await update_status("Transkrypcja została wysłana!")
         else:
             use_mtproto = file_size_mb > TELEGRAM_UPLOAD_LIMIT_MB
+
+            # Detect files that exceed the active Telegram transport limit.
+            # When too large, offer the 7z archive split instead of failing.
+            transport_limit_mb = volume_size_for(
+                use_mtproto=_mtproto_unavailability_reason() is None
+            )
+            if file_size_mb > transport_limit_mb:
+                await _offer_archive_or_cancel(
+                    update,
+                    context,
+                    chat_id=chat_id,
+                    file_path=downloaded_file_path,
+                    title=title,
+                    media_type=media_type,
+                    format_choice=format,
+                    file_size_mb=file_size_mb,
+                )
+                # The archive flow now owns the file; skip cleanup.
+                success_recorded = True
+                return
+
             method_label = " (MTProto)" if use_mtproto else ""
             await update_status(f"Pobieranie zakończone ({file_size_mb:.1f} MB).\n\nWysyłanie pliku do Telegram...{method_label}")
             thumb_path = await asyncio.get_event_loop().run_in_executor(_executor, download_thumbnail, info, chat_download_path, True)
@@ -613,3 +646,143 @@ async def download_playlist(update: Update, context: ContextTypes.DEFAULT_TYPE, 
 
 async def _show_spotify_summary_options(update: Update, context: ContextTypes.DEFAULT_TYPE):
     return await _extracted_show_spotify_summary_options(update, context)
+
+
+async def _offer_archive_or_cancel(
+    update,
+    context,
+    *,
+    chat_id: int,
+    file_path: str,
+    title: str,
+    media_type: str,
+    format_choice: str,
+    file_size_mb: float,
+) -> None:
+    """Register a pending archive job and present [Wyślij jako 7z]/[Anuluj]."""
+
+    use_mtproto = _mtproto_unavailability_reason() is None
+    volume_size_mb = volume_size_for(use_mtproto)
+    state = ArchiveJobState(
+        file_path=Path(file_path),
+        title=title,
+        media_type=media_type,
+        format_choice=format_choice,
+        file_size_mb=file_size_mb,
+        use_mtproto=use_mtproto,
+        created_at=datetime.now(),
+    )
+    token = register_pending_archive_job(chat_id, state)
+
+    keyboard = InlineKeyboardMarkup([
+        [InlineKeyboardButton("Wyślij jako 7z", callback_data=f"arc_split_{token}")],
+        [InlineKeyboardButton("Anuluj", callback_data=f"arc_cancel_{token}")],
+    ])
+    text = (
+        f"Plik za duży dla Telegrama: {file_size_mb:.0f} MB > limit {volume_size_mb} MB.\n"
+        f"Mogę spakować go w wolumeny 7z (po {volume_size_mb} MB) i wysłać paczki."
+    )
+    try:
+        await update.callback_query.edit_message_text(text, reply_markup=keyboard)
+    except Exception as exc:
+        logging.debug("offer-archive edit failed: %s", exc)
+
+
+async def handle_archive_callback(update, context, data: str) -> None:
+    """Dispatch arc_split_/arc_cancel_/arc_resend_/arc_purge_ callbacks."""
+
+    chat_id = update.effective_chat.id
+
+    if data.startswith("arc_split_"):
+        token = data[len("arc_split_"):]
+        await execute_single_file_archive_flow(
+            update, context, chat_id=chat_id, token=token,
+        )
+        return
+
+    if data.startswith("arc_cancel_"):
+        token = data[len("arc_cancel_"):]
+        await _handle_arc_cancel(update, chat_id, token)
+        return
+
+    if data.startswith("arc_resend_"):
+        await _handle_arc_resend(update, context, chat_id, data)
+        return
+
+    if data.startswith("arc_purge_"):
+        token = data[len("arc_purge_"):]
+        await _handle_arc_purge(update, chat_id, token)
+        return
+
+
+async def _handle_arc_cancel(update, chat_id: int, token: str) -> None:
+    bucket = pending_archive_jobs.get(chat_id) or {}
+    state = bucket.pop(token, None)
+    if not bucket:
+        pending_archive_jobs.pop(chat_id, None)
+    else:
+        pending_archive_jobs[chat_id] = bucket
+    if state is not None:
+        try:
+            os.remove(str(state.file_path))
+        except OSError:
+            pass
+    try:
+        await update.callback_query.edit_message_text("Anulowano. Plik usunięty.")
+    except Exception as exc:
+        logging.debug("arc_cancel edit failed: %s", exc)
+
+
+async def _handle_arc_resend(update, context, chat_id: int, data: str) -> None:
+    rest = data[len("arc_resend_"):]
+    if "_" not in rest:
+        return
+    token, idx_str = rest.rsplit("_", 1)
+    try:
+        start_index = int(idx_str)
+    except ValueError:
+        return
+
+    bucket = archived_deliveries.get(chat_id) or {}
+    state = bucket.get(token)
+    if state is None:
+        try:
+            await update.callback_query.edit_message_text("Sesja wygasła.")
+        except Exception:
+            pass
+        return
+
+    async def status(text: str) -> None:
+        try:
+            await update.callback_query.edit_message_text(text)
+        except Exception:
+            pass
+
+    try:
+        await send_volumes(
+            context.bot,
+            chat_id=chat_id,
+            volumes=state.volumes,
+            caption_prefix=state.caption_prefix,
+            use_mtproto=state.use_mtproto,
+            start_index=start_index,
+            status_cb=status,
+        )
+        await status(f"Wysłano paczki od [{start_index + 1}/{len(state.volumes)}].")
+    except Exception as exc:
+        await status(f"Wysyłka nadal nie powiodła się: {exc}")
+
+
+async def _handle_arc_purge(update, chat_id: int, token: str) -> None:
+    bucket = archived_deliveries.get(chat_id) or {}
+    state = bucket.pop(token, None)
+    if not bucket:
+        archived_deliveries.pop(chat_id, None)
+    else:
+        archived_deliveries[chat_id] = bucket
+    if state is not None and state.workspace.exists():
+        shutil.rmtree(state.workspace, ignore_errors=True)
+    try:
+        await update.callback_query.edit_message_text("Folder usunięty.")
+    except Exception as exc:
+        logging.debug("arc_purge edit failed: %s", exc)

--- a/bot/handlers/inbound_media.py
+++ b/bot/handlers/inbound_media.py
@@ -26,6 +26,7 @@ from bot.security_policy import (
 )
 from bot.security_throttling import check_rate_limit
 from bot.services.auth_service import store_pending_action
+from bot.runtime import get_app_runtime
 from bot.services.playlist_service import build_playlist_message, load_playlist
 from bot.session_store import block_until, user_playlist_data, user_time_ranges, user_urls
 from bot.services.spotify_service import (
@@ -278,9 +279,15 @@ async def handle_youtube_link(update: Update, context: ContextTypes.DEFAULT_TYPE
     await process_youtube_link(update, context, message_text)
 
 
-def _build_playlist_message(playlist_info: dict) -> tuple[str, InlineKeyboardMarkup]:
-    """Compatibility wrapper around the playlist service message builder."""
-    return build_playlist_message(playlist_info)
+def _build_playlist_message(playlist_info: dict, context=None) -> tuple[str, InlineKeyboardMarkup]:
+    """Compatibility wrapper around the playlist service message builder.
+
+    When ``context`` is supplied, the live ``AppRuntime`` is queried so that
+    ``archive_available`` reflects whether 7-zip is present on this host.
+    """
+    runtime = get_app_runtime(context) if context is not None else None
+    archive_available = runtime.archive_available if runtime is not None else False
+    return build_playlist_message(playlist_info, archive_available=archive_available)
 
 
 async def extracted_process_playlist_link(update: Update, context: ContextTypes.DEFAULT_TYPE, url):
@@ -299,7 +306,7 @@ async def extracted_process_playlist_link(update: Update, context: ContextTypes.
 
     _set_session_value(context, chat_id, "playlist_data", playlist_info, user_playlist_data)
     _set_session_value(context, chat_id, "current_url", url, user_urls)
-    msg, reply_markup = _build_playlist_message(playlist_info)
+    msg, reply_markup = _build_playlist_message(playlist_info, context=context)
     await progress_message.edit_text(msg, reply_markup=reply_markup, parse_mode="Markdown")
 
 

--- a/bot/handlers/playlist_callbacks.py
+++ b/bot/handlers/playlist_callbacks.py
@@ -23,7 +23,7 @@ from bot.services.playlist_service import (
     load_playlist,
     parse_playlist_download_choice,
 )
-from bot.runtime import record_download_for
+from bot.runtime import get_app_runtime, record_download_for
 from bot.session_context import (
     clear_session_value as _clear_session_value,
     get_session_context_value as _get_session_context_value,
@@ -82,7 +82,11 @@ async def handle_playlist_callback(update: Update, context: ContextTypes.DEFAULT
                 await query.edit_message_text("Nie udało się pobrać informacji o playliście.")
                 return
             _set_session_value(context, chat_id, "playlist_data", playlist_info, user_playlist_data)
-            msg, reply_markup = build_playlist_message(playlist_info)
+            runtime = get_app_runtime(context)
+            archive_available = runtime.archive_available if runtime is not None else False
+            msg, reply_markup = build_playlist_message(
+                playlist_info, archive_available=archive_available,
+            )
             await query.edit_message_text(msg, reply_markup=reply_markup, parse_mode="Markdown")
         return
 
@@ -95,7 +99,11 @@ async def handle_playlist_callback(update: Update, context: ContextTypes.DEFAULT
                 await query.edit_message_text("Nie udało się pobrać rozszerzonej listy.")
                 return
             _set_session_value(context, chat_id, "playlist_data", playlist_info, user_playlist_data)
-            msg, reply_markup = build_playlist_message(playlist_info)
+            runtime = get_app_runtime(context)
+            archive_available = runtime.archive_available if runtime is not None else False
+            msg, reply_markup = build_playlist_message(
+                playlist_info, archive_available=archive_available,
+            )
             await query.edit_message_text(msg, reply_markup=reply_markup, parse_mode="Markdown")
         return
 

--- a/bot/handlers/playlist_callbacks.py
+++ b/bot/handlers/playlist_callbacks.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 
 from telegram import InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
@@ -23,6 +24,7 @@ from bot.services.playlist_service import (
     load_playlist,
     parse_playlist_download_choice,
 )
+from bot.jobs import JobDescriptor, job_registry
 from bot.runtime import get_app_runtime, record_download_for
 from bot.session_context import (
     clear_session_value as _clear_session_value,
@@ -133,38 +135,71 @@ async def download_playlist(update: Update, context: ContextTypes.DEFAULT_TYPE, 
     succeeded = 0
     failed_titles = []
 
+    descriptor = JobDescriptor(
+        job_id="",
+        chat_id=chat_id,
+        kind="playlist_legacy",
+        label=f"Playlist ({media_type} {format_choice}) [0/{total}]",
+        started_at=datetime.now(),
+    )
+    cancellation = job_registry.register(chat_id, descriptor)
+
     await query.edit_message_text(
-        f"Rozpoczynam pobieranie playlisty ({total} filmów)...\nFormat: {media_type} {format_choice}"
+        f"Rozpoczynam pobieranie playlisty ({total} filmów)...\n"
+        f"Format: {media_type} {format_choice}"
     )
 
-    for i, entry in enumerate(entries, 1):
-        entry_url = entry["url"]
-        entry_title = entry.get("title", f"Film {i}")
+    try:
+        for i, entry in enumerate(entries, 1):
+            if cancellation.event.is_set():
+                break
+            entry_url = entry["url"]
+            entry_title = entry.get("title", f"Film {i}")
+            job_registry.update_label(
+                cancellation.job_id,
+                f"Playlist ({media_type} {format_choice}) [{i}/{total}]",
+            )
 
-        try:
-            status_msg = await context.bot.send_message(chat_id=chat_id, text=f"[{i}/{total}] Pobieranie: {entry_title}...")
-            await _download_single_playlist_item(context, chat_id, entry_url, entry_title, media_type, format_choice, status_msg)
-            succeeded += 1
-        except Exception as exc:
-            failed_titles.append(entry_title)
-            logging.error("Playlist item %d/%d failed: %s", i, total, exc)
             try:
-                await status_msg.edit_text(f"[{i}/{total}] Błąd: {entry_title}\n{str(exc)[:100]}")
-            except Exception:
-                pass
+                status_msg = await context.bot.send_message(
+                    chat_id=chat_id,
+                    text=f"[{i}/{total}] Pobieranie: {entry_title}...",
+                )
+                await _download_single_playlist_item(
+                    context, chat_id, entry_url, entry_title,
+                    media_type, format_choice, status_msg,
+                )
+                succeeded += 1
+            except Exception as exc:
+                failed_titles.append(entry_title)
+                logging.error("Playlist item %d/%d failed: %s", i, total, exc)
+                try:
+                    await status_msg.edit_text(
+                        f"[{i}/{total}] Błąd: {entry_title}\n{str(exc)[:100]}"
+                    )
+                except Exception:
+                    pass
 
-        if i < total:
-            await asyncio.sleep(1)
+            if i < total and not cancellation.event.is_set():
+                await asyncio.sleep(1)
 
-    failed = len(failed_titles)
-    summary = f"Playlista zakończona!\n\nPobrano: {succeeded}/{total}\n"
-    if failed:
-        summary += f"Błędy: {failed}\n"
-        for title in failed_titles[:5]:
-            summary += f"  - {title[:40]}\n"
+        failed = len(failed_titles)
+        if cancellation.event.is_set():
+            summary = (
+                f"⏹ Zatrzymano playlistę. Pobrano {succeeded}/{total} "
+                f"(pliki usunięte).\n"
+            )
+        else:
+            summary = f"Playlista zakończona!\n\nPobrano: {succeeded}/{total}\n"
+        if failed:
+            summary += f"Błędy: {failed}\n"
+            for title in failed_titles[:5]:
+                summary += f"  - {title[:40]}\n"
 
-    await context.bot.send_message(chat_id=chat_id, text=summary)
-    _clear_session_value(context, chat_id, "playlist_data", user_playlist_data)
+        await context.bot.send_message(chat_id=chat_id, text=summary)
+        _clear_session_value(context, chat_id, "playlist_data", user_playlist_data)
+    finally:
+        job_registry.unregister(cancellation.job_id)
 
 
 async def _download_single_playlist_item(context, chat_id, url, title, media_type, format_choice, status_msg):

--- a/bot/handlers/playlist_callbacks.py
+++ b/bot/handlers/playlist_callbacks.py
@@ -15,6 +15,7 @@ from bot.downloader_metadata import get_video_info
 from bot.handlers.common_ui import build_main_keyboard, escape_md
 from bot.security_limits import MAX_PLAYLIST_ITEMS, MAX_PLAYLIST_ITEMS_EXPANDED, TELEGRAM_UPLOAD_LIMIT_MB
 from bot.security_policy import get_media_label
+from bot.services.archive_service import execute_playlist_archive_flow
 from bot.services.playlist_service import (
     build_playlist_message,
     build_single_video_url,
@@ -96,6 +97,10 @@ async def handle_playlist_callback(update: Update, context: ContextTypes.DEFAULT
             _set_session_value(context, chat_id, "playlist_data", playlist_info, user_playlist_data)
             msg, reply_markup = build_playlist_message(playlist_info)
             await query.edit_message_text(msg, reply_markup=reply_markup, parse_mode="Markdown")
+        return
+
+    if data.startswith("pl_zip_dl_"):
+        await _dispatch_archive_playlist(update, context, data)
         return
 
     if data.startswith("pl_dl_"):
@@ -234,3 +239,32 @@ async def _download_single_playlist_item(context, chat_id, url, title, media_typ
 
     record_download_for(context, chat_id, title, url, f"{media_type}_{format_choice}", file_size_mb)
     await status_msg.edit_text(f"[✅] {title}")
+
+
+async def _dispatch_archive_playlist(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    callback_data: str,
+) -> None:
+    """Dispatch a `pl_zip_dl_*` callback to the archive (7z) flow."""
+
+    chat_id = update.effective_chat.id
+    playlist = _get_session_value(context, chat_id, "playlist_data", user_playlist_data)
+    if not playlist:
+        await update.callback_query.edit_message_text(
+            "Sesja playlisty wygasła. Wyślij link ponownie."
+        )
+        return
+
+    choice = parse_playlist_download_choice(callback_data)
+
+    await execute_playlist_archive_flow(
+        update,
+        context,
+        chat_id=chat_id,
+        playlist=playlist,
+        media_type=choice.media_type,
+        format_choice=choice.format_choice,
+        executor=_executor,
+    )
+    _clear_session_value(context, chat_id, "playlist_data", user_playlist_data)

--- a/bot/jobs.py
+++ b/bot/jobs.py
@@ -66,7 +66,13 @@ class JobRegistry:
         self._cancellations: dict[str, JobCancellation] = {}
 
     def register(self, chat_id: int, descriptor: JobDescriptor) -> JobCancellation:
-        """Register a new job for ``chat_id`` and return its cancellation handle."""
+        """Register a new job for ``chat_id`` and return its cancellation handle.
+
+        Note: ``asyncio.Event()`` is created here and must be bound to an
+        active event loop. Call this from an async context (e.g. a Telegram
+        handler coroutine). Calling from a synchronous thread without a
+        running loop is not supported in Python >=3.10.
+        """
 
         job_id = secrets.token_hex(4)
         with self._lock:

--- a/bot/jobs.py
+++ b/bot/jobs.py
@@ -14,7 +14,7 @@ import asyncio
 import logging
 import secrets
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from threading import RLock
 from typing import Literal
 
@@ -169,6 +169,29 @@ class JobRegistry:
 
         logging.info("job cancel_async done: id=%s reason=%r", job_id, reason)
         return True
+
+    def purge_dead(self, threshold: timedelta) -> int:
+        """Drop entries older than ``threshold``. Used by cleanup.py.
+
+        Returns the number of entries removed. Logs each as a warning —
+        a zombie job means a layer failed to call unregister in finally.
+        """
+
+        cutoff = datetime.now() - threshold
+        removed = 0
+        with self._lock:
+            for job_id in list(self._descriptors):
+                descriptor = self._descriptors[job_id]
+                if descriptor.started_at < cutoff:
+                    age_h = (datetime.now() - descriptor.started_at).total_seconds() / 3600
+                    logging.warning(
+                        "purge zombie job: id=%s kind=%s chat=%d age=%.1fh",
+                        job_id, descriptor.kind, descriptor.chat_id, age_h,
+                    )
+                    self._descriptors.pop(job_id, None)
+                    self._cancellations.pop(job_id, None)
+                    removed += 1
+        return removed
 
 
 # Global singleton consumed by handlers/services.

--- a/bot/jobs.py
+++ b/bot/jobs.py
@@ -117,6 +117,59 @@ class JobRegistry:
                 descriptor.chat_id, descriptor.kind, job_id,
             )
 
+    def cancel(self, job_id: str, reason: str = "user via /stop") -> bool:
+        """Sync cancel: set the event + reason. Subprocess/task teardown happens
+        in cancel_async (called by the /stop handler which is async).
+
+        Returns True if the job was registered and signalled, False otherwise.
+        """
+
+        with self._lock:
+            cancellation = self._cancellations.get(job_id)
+            if cancellation is None:
+                return False
+            cancellation.cancelled_reason = reason
+            cancellation.event.set()
+        logging.info("job cancel: id=%s reason=%r", job_id, reason)
+        return True
+
+    async def cancel_async(self, job_id: str, reason: str = "user via /stop") -> bool:
+        """Async cancel: also terminates an attached subprocess and cancels an
+        attached pyrogram_task. Used by the /stop callback handler."""
+
+        from bot.security_limits import JOB_TERMINATE_GRACE_SEC
+
+        with self._lock:
+            cancellation = self._cancellations.get(job_id)
+            if cancellation is None:
+                return False
+            cancellation.cancelled_reason = reason
+            cancellation.event.set()
+            process = cancellation.process
+            task = cancellation.pyrogram_task
+
+        if process is not None:
+            try:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(
+                        process.wait(), timeout=JOB_TERMINATE_GRACE_SEC,
+                    )
+                except asyncio.TimeoutError:
+                    logging.warning(
+                        "job %s: SIGTERM grace expired, sending SIGKILL", job_id,
+                    )
+                    process.kill()
+            except ProcessLookupError:
+                # Already exited — nothing to do.
+                pass
+
+        if task is not None and not task.done():
+            task.cancel()
+
+        logging.info("job cancel_async done: id=%s reason=%r", job_id, reason)
+        return True
+
 
 # Global singleton consumed by handlers/services.
 job_registry = JobRegistry()

--- a/bot/jobs.py
+++ b/bot/jobs.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import secrets
-from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from dataclasses import dataclass
+from datetime import datetime
 from threading import RLock
 from typing import Literal
 

--- a/bot/jobs.py
+++ b/bot/jobs.py
@@ -1,0 +1,122 @@
+"""In-memory registry of long-running jobs that can be cancelled.
+
+Boundaries:
+- Knows nothing about Telegram, sessions, downloads, or 7z.
+- Consumers (handlers, services) import JobRegistry/JobCancellation and
+  attach process/pyrogram_task references on their own.
+- The global ``job_registry`` singleton is the canonical instance — tests
+  build their own JobRegistry() to stay isolated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from threading import RLock
+from typing import Literal
+
+
+JobKind = Literal[
+    "playlist_legacy",
+    "playlist_zip",
+    "single_dl",
+    "transcription",
+    "summary",
+    "archive_pack",
+    "archive_send",
+]
+
+
+@dataclass
+class JobCancellation:
+    """Cancellation handle shared across async/threadpool/subprocess layers.
+
+    The single Event is the primary signal — every long-running loop
+    polls it. ``process`` and ``pyrogram_task`` are optional resources
+    that JobRegistry.cancel() will tear down at signal time.
+    """
+
+    job_id: str
+    event: asyncio.Event
+    process: asyncio.subprocess.Process | None = None
+    pyrogram_task: asyncio.Task | None = None
+    cancelled_reason: str | None = None
+
+
+@dataclass
+class JobDescriptor:
+    """User-facing description of a job, listed by /stop."""
+
+    job_id: str
+    chat_id: int
+    kind: JobKind
+    label: str
+    started_at: datetime
+
+
+class JobRegistry:
+    """Thread-safe registry of running JobCancellation handles."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._descriptors: dict[str, JobDescriptor] = {}
+        self._cancellations: dict[str, JobCancellation] = {}
+
+    def register(self, chat_id: int, descriptor: JobDescriptor) -> JobCancellation:
+        """Register a new job for ``chat_id`` and return its cancellation handle."""
+
+        job_id = secrets.token_hex(4)
+        with self._lock:
+            descriptor.job_id = job_id
+            descriptor.chat_id = chat_id
+            self._descriptors[job_id] = descriptor
+            cancellation = JobCancellation(job_id=job_id, event=asyncio.Event())
+            self._cancellations[job_id] = cancellation
+        logging.info(
+            "job register: chat=%d kind=%s id=%s label=%r",
+            chat_id, descriptor.kind, job_id, descriptor.label,
+        )
+        return cancellation
+
+    def get(self, job_id: str) -> JobCancellation | None:
+        """Return the cancellation handle, or None if unknown / already finished."""
+
+        with self._lock:
+            return self._cancellations.get(job_id)
+
+    def list_for_chat(self, chat_id: int) -> list[JobDescriptor]:
+        """Return descriptors for jobs running in ``chat_id`` (sorted by start)."""
+
+        with self._lock:
+            descriptors = [
+                d for d in self._descriptors.values() if d.chat_id == chat_id
+            ]
+        descriptors.sort(key=lambda d: d.started_at)
+        return descriptors
+
+    def update_label(self, job_id: str, label: str) -> None:
+        """Change the displayed label of a running job. No-op when unknown."""
+
+        with self._lock:
+            descriptor = self._descriptors.get(job_id)
+            if descriptor is not None:
+                descriptor.label = label
+
+    def unregister(self, job_id: str) -> None:
+        """Drop a finished job. No-op when unknown."""
+
+        with self._lock:
+            descriptor = self._descriptors.pop(job_id, None)
+            self._cancellations.pop(job_id, None)
+        if descriptor is not None:
+            logging.info(
+                "job unregister: chat=%d kind=%s id=%s",
+                descriptor.chat_id, descriptor.kind, job_id,
+            )
+
+
+# Global singleton consumed by handlers/services.
+job_registry = JobRegistry()

--- a/bot/mtproto.py
+++ b/bot/mtproto.py
@@ -267,3 +267,65 @@ async def send_video_mtproto(
     except Exception as e:
         logging.error("MTProto send_video failed: %s", e)
         return False
+
+
+async def send_document_mtproto(
+    chat_id: int,
+    file_path: str,
+    caption: str | None = None,
+    file_name: str | None = None,
+) -> bool:
+    """Send a document file via MTProto (up to 2 GB).
+
+    Used to ship 7z volumes (.7z.001, ...) so Telegram does not try to
+    render them as media. ``file_name`` (when provided) overrides the
+    visible attachment name in the chat — useful when the on-disk path
+    contains a workspace prefix we don't want users to see.
+
+    Args:
+        chat_id: Destination chat ID.
+        file_path: Local path to the document.
+        caption: Optional message caption.
+        file_name: Optional override for the displayed filename.
+
+    Returns:
+        True on success, False on error.
+    """
+
+    try:
+        from pyrogram import Client  # noqa: F401
+    except ImportError:
+        logging.error("pyrogram not installed — cannot send large document")
+        return False
+
+    api_id = get_runtime_value("TELEGRAM_API_ID", "")
+    api_hash = get_runtime_value("TELEGRAM_API_HASH", "")
+    if not api_id or not api_hash:
+        logging.error("TELEGRAM_API_ID/TELEGRAM_API_HASH not configured")
+        return False
+
+    api_id_int = _parse_api_id(api_id)
+    if api_id_int is None:
+        return False
+
+    client = _build_client(chat_id, "send_document", api_id_int, api_hash)
+
+    try:
+        async with client:
+            send_kwargs: dict = {
+                "chat_id": chat_id,
+                "document": file_path,
+                "caption": caption,
+            }
+            if file_name is not None:
+                send_kwargs["file_name"] = file_name
+            await client.send_document(**send_kwargs)
+            file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
+            logging.info(
+                "MTProto send_document OK: %s (%.1f MB) to chat %d",
+                os.path.basename(file_path), file_size_mb, chat_id,
+            )
+            return True
+    except Exception as e:
+        logging.error("MTProto send_document failed: %s", e)
+        return False

--- a/bot/mtproto.py
+++ b/bot/mtproto.py
@@ -33,6 +33,13 @@ def mtproto_unavailability_reason() -> str | None:
         has_pyrogram = True
     except ImportError:
         has_pyrogram = False
+    except Exception as exc:
+        # pyrogram <2.x calls asyncio.get_event_loop() at import time which
+        # raises RuntimeError on Python 3.12+ when no loop is running. Treat
+        # any other import-time failure as "not usable" rather than crashing
+        # the surrounding handler.
+        logging.warning("pyrogram import failed: %s", exc)
+        has_pyrogram = False
 
     has_creds = bool(get_runtime_value("TELEGRAM_API_ID")) and bool(
         get_runtime_value("TELEGRAM_API_HASH")

--- a/bot/mtproto.py
+++ b/bot/mtproto.py
@@ -9,10 +9,15 @@ Configuration: TELEGRAM_API_ID and TELEGRAM_API_HASH in api_key.md or env vars.
 These are free credentials from https://my.telegram.org
 """
 
+import asyncio
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from bot.config import get_runtime_value
+
+if TYPE_CHECKING:
+    from bot.jobs import JobCancellation
 
 
 def mtproto_unavailability_reason() -> str | None:
@@ -162,8 +167,13 @@ async def send_audio_mtproto(
     title: str | None = None,
     caption: str | None = None,
     thumb_path: str | None = None,
+    *,
+    cancellation: "JobCancellation | None" = None,
 ) -> bool:
     """Send an audio file via MTProto (up to 2 GB).
+
+    When cancellation is provided, the underlying upload task is attached
+    so /stop can cancel it.
 
     Args:
         chat_id: Destination chat ID.
@@ -171,6 +181,9 @@ async def send_audio_mtproto(
         title: Audio track title shown in the player.
         caption: Message caption.
         thumb_path: Optional thumbnail image path.
+        cancellation: Optional job cancellation handle; when set, the upload
+            coroutine is wrapped in a Task and assigned to
+            cancellation.pyrogram_task so /stop can abort it.
 
     Returns:
         True on success, False on error.
@@ -196,13 +209,22 @@ async def send_audio_mtproto(
 
     try:
         async with client:
-            await client.send_audio(
+            coro = client.send_audio(
                 chat_id=chat_id,
                 audio=file_path,
                 title=title,
                 caption=caption,
                 thumb=thumb_path,
             )
+            if cancellation is not None:
+                task = asyncio.ensure_future(coro)
+                cancellation.pyrogram_task = task
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    return False
+            else:
+                await coro
             file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
             logging.info(
                 "MTProto send_audio OK: %s (%.1f MB) to chat %d",
@@ -219,14 +241,22 @@ async def send_video_mtproto(
     file_path: str,
     caption: str | None = None,
     thumb_path: str | None = None,
+    *,
+    cancellation: "JobCancellation | None" = None,
 ) -> bool:
     """Send a video file via MTProto (up to 2 GB).
+
+    When cancellation is provided, the underlying upload task is attached
+    so /stop can cancel it.
 
     Args:
         chat_id: Destination chat ID.
         file_path: Local path to the video file.
         caption: Message caption.
         thumb_path: Optional thumbnail image path.
+        cancellation: Optional job cancellation handle; when set, the upload
+            coroutine is wrapped in a Task and assigned to
+            cancellation.pyrogram_task so /stop can abort it.
 
     Returns:
         True on success, False on error.
@@ -252,12 +282,21 @@ async def send_video_mtproto(
 
     try:
         async with client:
-            await client.send_video(
+            coro = client.send_video(
                 chat_id=chat_id,
                 video=file_path,
                 caption=caption,
                 thumb=thumb_path,
             )
+            if cancellation is not None:
+                task = asyncio.ensure_future(coro)
+                cancellation.pyrogram_task = task
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    return False
+            else:
+                await coro
             file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
             logging.info(
                 "MTProto send_video OK: %s (%.1f MB) to chat %d",
@@ -274,6 +313,8 @@ async def send_document_mtproto(
     file_path: str,
     caption: str | None = None,
     file_name: str | None = None,
+    *,
+    cancellation: "JobCancellation | None" = None,
 ) -> bool:
     """Send a document file via MTProto (up to 2 GB).
 
@@ -282,11 +323,17 @@ async def send_document_mtproto(
     visible attachment name in the chat — useful when the on-disk path
     contains a workspace prefix we don't want users to see.
 
+    When cancellation is provided, the underlying upload task is attached
+    so /stop can cancel it.
+
     Args:
         chat_id: Destination chat ID.
         file_path: Local path to the document.
         caption: Optional message caption.
         file_name: Optional override for the displayed filename.
+        cancellation: Optional job cancellation handle; when set, the upload
+            coroutine is wrapped in a Task and assigned to
+            cancellation.pyrogram_task so /stop can abort it.
 
     Returns:
         True on success, False on error.
@@ -319,7 +366,16 @@ async def send_document_mtproto(
             }
             if file_name is not None:
                 send_kwargs["file_name"] = file_name
-            await client.send_document(**send_kwargs)
+            coro = client.send_document(**send_kwargs)
+            if cancellation is not None:
+                task = asyncio.ensure_future(coro)
+                cancellation.pyrogram_task = task
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    return False
+            else:
+                await coro
             file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
             logging.info(
                 "MTProto send_document OK: %s (%.1f MB) to chat %d",

--- a/bot/runtime.py
+++ b/bot/runtime.py
@@ -42,10 +42,14 @@ class AppRuntime:
     authorized_users_repository: Any
     download_history_repository: Any
     authorized_users_set: set[int]
+    archive_available: bool = False
 
 
 def build_app_runtime() -> AppRuntime:
     """Build an application runtime from the active bootstrap state."""
+    # Local import avoids a potential circular dependency if bot.archive ever
+    # needs to import from bot.runtime in the future.
+    from bot.archive import is_7z_available
 
     return AppRuntime(
         config=get_runtime_config(),
@@ -55,6 +59,7 @@ def build_app_runtime() -> AppRuntime:
         authorized_users_repository=get_authorized_users_repository(),
         download_history_repository=get_download_history_repository(),
         authorized_users_set=get_runtime_authorized_users(),
+        archive_available=is_7z_available(),
     )
 
 

--- a/bot/security_limits.py
+++ b/bot/security_limits.py
@@ -46,3 +46,12 @@ MAX_ARCHIVE_ITEM_SIZE_MB = 10240
 # after success, so the user can resend a single failed volume without
 # having to re-download the whole playlist.
 PLAYLIST_ARCHIVE_RETENTION_MIN = 60
+
+# Cleanup of stale (zombie) entries in JobRegistry. Defends /stop list
+# against operations that never unregistered due to bugs or crashes.
+JOB_DEAD_AGE_HOURS = 6
+
+# Grace between SIGTERM and SIGKILL when terminating a 7z subprocess
+# attached to a JobCancellation. Long enough for 7z to finish writing
+# its current 1 MiB block, short enough to not block /stop UX.
+JOB_TERMINATE_GRACE_SEC = 1.0

--- a/bot/security_limits.py
+++ b/bot/security_limits.py
@@ -28,3 +28,21 @@ FFMPEG_TIMEOUT = 180
 # Maximum number of playlist items to download (default / expanded)
 MAX_PLAYLIST_ITEMS = 10
 MAX_PLAYLIST_ITEMS_EXPANDED = 50
+
+# 7z archive volume size depending on transport.
+# MTProto bot upload caps single message at ~2 GB; we leave 100 MB margin
+# for 7z header overhead and per-message metadata.
+MTPROTO_VOLUME_SIZE_MB = 1900
+
+# Bot API upload caps at 50 MB; 49 MB volume keeps slack for the wrapper.
+BOTAPI_VOLUME_SIZE_MB = 49
+
+# Per-item size cap for playlist archive mode. Playlist 7z mode allows
+# items larger than MAX_FILE_SIZE_MB because the file never has to fit a
+# single Telegram message — it will be split into volumes.
+MAX_ARCHIVE_ITEM_SIZE_MB = 10240
+
+# How long workspaces (pl_*/big_*) and pending archive jobs survive
+# after success, so the user can resend a single failed volume without
+# having to re-download the whole playlist.
+PLAYLIST_ARCHIVE_RETENTION_MIN = 60

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -16,7 +16,10 @@ import shutil
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+if TYPE_CHECKING:
+    from bot.jobs import JobCancellation
 
 from bot.archive import (
     compute_archive_basename,
@@ -159,13 +162,17 @@ async def download_playlist_into(
     format_choice: str,
     executor: ThreadPoolExecutor,
     status_cb: Callable[[str], Awaitable[None]],
+    cancellation: "JobCancellation | None" = None,
 ) -> tuple[list[Path], list[str]]:
     """Download every entry into workspace, keeping the files (no os.remove).
 
+    When ``cancellation.event`` becomes set, the loop breaks early; titles
+    of entries that didn't run get ``" (anulowano)"`` suffix in failed_titles.
+
     Returns (downloaded_paths, failed_titles). Items exceeding the
     MAX_ARCHIVE_ITEM_SIZE_MB cap are reported on failed_titles with a
-    ``(za duzy: X MB)`` suffix. Network failures are similarly recorded
-    with the original title.
+    ``(za duzy: X MB)`` suffix. Network failures are recorded with the
+    original title.
     """
 
     downloaded: list[Path] = []
@@ -174,6 +181,10 @@ async def download_playlist_into(
 
     for idx, entry in enumerate(entries, 1):
         title = entry.get("title", f"item_{idx}")
+        if cancellation is not None and cancellation.event.is_set():
+            for skipped in entries[idx - 1:]:
+                failed.append(f"{skipped.get('title', '?')} (anulowano)")
+            break
         await status_cb(f"[{idx}/{total}] Pobieranie: {title}...")
         try:
             path, size = await _download_one_into_workspace(

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -218,6 +218,7 @@ async def send_volumes(
     *,
     start_index: int = 0,
     status_cb: Callable[[str], Awaitable[None]] | None = None,
+    cancellation: "JobCancellation | None" = None,
 ) -> None:
     """Send 7z volumes [start_index:] to ``chat_id`` as documents.
 
@@ -229,6 +230,8 @@ async def send_volumes(
     ``use_mtproto`` is informational for higher layers — the per-volume
     transport decision is based solely on volume size vs TELEGRAM_UPLOAD_LIMIT_MB.
 
+    When cancellation.event is set the loop breaks before the next volume.
+
     Raises:
         RuntimeError: when a volume needs MTProto but it is unavailable, or
             when MTProto sending returns False.
@@ -236,6 +239,8 @@ async def send_volumes(
 
     total = len(volumes)
     for idx in range(start_index, total):
+        if cancellation is not None and cancellation.event.is_set():
+            return
         volume = volumes[idx]
         size_mb = volume.stat().st_size / (1024 * 1024)
         caption = f"{caption_prefix} [{idx + 1}/{total}]"

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -515,6 +515,107 @@ async def _save_partial_state_after_cancel(
         logging.debug("partial-state edit failed: %s", exc)
 
 
+async def execute_partial_archive_flow(
+    update,
+    context,
+    *,
+    chat_id: int,
+    token: str,
+) -> None:
+    """Pack and send a previously-cancelled playlist's downloaded files.
+
+    Triggered by the [Spakuj co mam] button on a cancel-status message.
+    Reads ArchivePartialState from session_store, registers a fresh
+    archive_pack job, and runs pack_to_volumes + send_volumes.
+    """
+
+    bucket = partial_archive_workspaces.get(chat_id) or {}
+    state = bucket.get(token)
+    if state is None:
+        await _safe_status_edit(update, "Sesja wygasła.")
+        return
+
+    if not is_7z_available():
+        await _safe_status_edit(
+            update,
+            "Funkcja 7z niedostępna — administrator nie zainstalował p7zip-full.",
+        )
+        return
+
+    use_mtproto = mtproto_unavailability_reason() is None
+    volume_size_mb = volume_size_for(use_mtproto)
+
+    descriptor = JobDescriptor(
+        job_id="", chat_id=chat_id, kind="archive_pack",
+        label=f"Pakowanie częściowej playlisty ({state.title})",
+        started_at=datetime.now(),
+    )
+    cancellation = job_registry.register(chat_id, descriptor)
+
+    async def status(text: str) -> None:
+        await _safe_status_edit(update, text)
+
+    try:
+        await status(f"Pakowanie do 7z (vol_size={volume_size_mb} MB)...")
+        slug = _build_slug(state.title)
+        dest_basename = state.workspace / compute_archive_basename(
+            f"{slug}_{state.media_type}_{state.format_choice}", datetime.now()
+        )
+        volumes = await pack_to_volumes(
+            state.downloaded, dest_basename, volume_size_mb,
+            cancellation=cancellation,
+        )
+
+        if cancellation.event.is_set():
+            await status("⏹ Zatrzymano w trakcie pakowania.")
+            return
+
+        caption_prefix = f"{state.title} ({state.media_type} {state.format_choice})"
+        job_registry.update_label(
+            cancellation.job_id,
+            f"Wysyłka częściowej playlisty [0/{len(volumes)}]",
+        )
+        await status(f"Pakowanie OK: {len(volumes)} paczek. Wysyłanie...")
+        await send_volumes(
+            context.bot, chat_id=chat_id, volumes=volumes,
+            caption_prefix=caption_prefix, use_mtproto=use_mtproto,
+            status_cb=status, cancellation=cancellation,
+        )
+
+        delivery = ArchivedDeliveryState(
+            workspace=state.workspace, volumes=volumes,
+            caption_prefix=caption_prefix, use_mtproto=use_mtproto,
+            created_at=datetime.now(),
+        )
+        delivery_token = register_archived_delivery(chat_id, delivery)
+
+        keyboard = InlineKeyboardMarkup([
+            [InlineKeyboardButton(
+                "Wyślij wszystkie paczki ponownie",
+                callback_data=f"arc_resend_{delivery_token}_0",
+            )],
+            [InlineKeyboardButton(
+                "Usuń teraz",
+                callback_data=f"arc_purge_{delivery_token}",
+            )],
+        ])
+        await update.callback_query.edit_message_text(
+            f"Częściowa playlista wysłana w {len(volumes)} paczkach.",
+            reply_markup=keyboard,
+        )
+    except Exception as exc:
+        logging.error("Partial archive flow failed: %s", exc)
+        await status(f"Pakowanie/wysyłka nie powiodły się: {exc}")
+    finally:
+        # Consume partial state regardless of outcome.
+        bucket.pop(token, None)
+        if not bucket:
+            partial_archive_workspaces.pop(chat_id, None)
+        else:
+            partial_archive_workspaces[chat_id] = bucket
+        job_registry.unregister(cancellation.job_id)
+
+
 async def execute_single_file_archive_flow(
     update,
     context,

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -20,7 +20,8 @@ from typing import Awaitable, Callable
 from bot.archive import compute_archive_basename, transliterate_to_ascii
 from bot.config import DOWNLOAD_PATH
 from bot.downloader_validation import sanitize_filename
-from bot.security_limits import MAX_ARCHIVE_ITEM_SIZE_MB
+from bot.mtproto import mtproto_unavailability_reason, send_document_mtproto
+from bot.security_limits import MAX_ARCHIVE_ITEM_SIZE_MB, TELEGRAM_UPLOAD_LIMIT_MB
 from bot.services.download_service import (
     ensure_size_within_limit,
     estimate_download_size,
@@ -187,3 +188,65 @@ async def download_playlist_into(
         downloaded.append(path)
 
     return downloaded, failed
+
+
+async def send_volumes(
+    bot,
+    chat_id: int,
+    volumes: list[Path],
+    caption_prefix: str,
+    use_mtproto: bool,
+    *,
+    start_index: int = 0,
+    status_cb: Callable[[str], Awaitable[None]] | None = None,
+) -> None:
+    """Send 7z volumes [start_index:] to ``chat_id`` as documents.
+
+    Volumes ≤ TELEGRAM_UPLOAD_LIMIT_MB go via Bot API (``bot.send_document``);
+    larger ones go via MTProto. Caption per volume is
+    ``"<caption_prefix> [j/M]"``. The displayed file name is the volume's
+    original name (``<basename>.7z.001`` etc).
+
+    ``use_mtproto`` is informational for higher layers — the per-volume
+    transport decision is based solely on volume size vs TELEGRAM_UPLOAD_LIMIT_MB.
+
+    Raises:
+        RuntimeError: when a volume needs MTProto but it is unavailable, or
+            when MTProto sending returns False.
+    """
+
+    total = len(volumes)
+    for idx in range(start_index, total):
+        volume = volumes[idx]
+        size_mb = volume.stat().st_size / (1024 * 1024)
+        caption = f"{caption_prefix} [{idx + 1}/{total}]"
+        if status_cb is not None:
+            await status_cb(f"Wysyłanie [{idx + 1}/{total}] ({size_mb:.0f} MB)...")
+
+        if size_mb <= TELEGRAM_UPLOAD_LIMIT_MB:
+            with open(volume, "rb") as handle:
+                await bot.send_document(
+                    chat_id=chat_id,
+                    document=handle,
+                    filename=volume.name,
+                    caption=caption,
+                    read_timeout=120,
+                    write_timeout=120,
+                )
+        else:
+            reason = mtproto_unavailability_reason()
+            if reason is not None:
+                raise RuntimeError(
+                    f"Wolumen {volume.name} przekracza Bot API ({size_mb:.0f} MB), "
+                    f"a MTProto jest niedostępny: {reason}"
+                )
+            ok = await send_document_mtproto(
+                chat_id=chat_id,
+                file_path=str(volume),
+                caption=caption,
+                file_name=volume.name,
+            )
+            if not ok:
+                raise RuntimeError(f"Wysyłka {volume.name} przez MTProto nie powiodła się.")
+
+        logging.info("Sent volume %d/%d: %s (%.1f MB)", idx + 1, total, volume.name, size_mb)

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -10,14 +10,25 @@ Boundaries:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import secrets
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Awaitable, Callable
 
 from bot.archive import compute_archive_basename, transliterate_to_ascii
 from bot.config import DOWNLOAD_PATH
 from bot.downloader_validation import sanitize_filename
+from bot.security_limits import MAX_ARCHIVE_ITEM_SIZE_MB
+from bot.services.download_service import (
+    DownloadResult,
+    ensure_size_within_limit,
+    estimate_download_size,
+    execute_download,
+    prepare_download_plan,
+)
 from bot.session_store import (
     ArchiveJobState,
     ArchivedDeliveryState,
@@ -74,3 +85,103 @@ def register_archived_delivery(chat_id: int, state: ArchivedDeliveryState) -> st
     bucket[token] = state
     archived_deliveries[chat_id] = bucket
     return token
+
+
+async def _noop_status(_text: str) -> None:
+    """No-op async status callback used internally by _download_one_into_workspace."""
+    return None
+
+
+async def _download_one_into_workspace(
+    entry: dict,
+    workspace: Path,
+    *,
+    media_type: str,
+    format_choice: str,
+    executor: ThreadPoolExecutor,
+) -> tuple[Path | None, float | None]:
+    """Download one playlist item into ``workspace``. Returns (path, size_mb).
+
+    Returns (None, size_mb) when the estimated size exceeds
+    MAX_ARCHIVE_ITEM_SIZE_MB; the caller should record this as a failure
+    with a descriptive title.
+    Raises on metadata fetch failure or yt-dlp errors.
+    """
+
+    plan = prepare_download_plan(
+        url=entry["url"],
+        media_type=media_type,
+        format_choice=format_choice,
+        chat_download_path=str(workspace),
+    )
+    if plan is None:
+        raise RuntimeError(f"could not fetch metadata for {entry.get('title')}")
+
+    try:
+        estimated = estimate_download_size(plan)
+    except Exception:
+        estimated = None
+
+    if estimated is not None and not ensure_size_within_limit(
+        estimated, max_size_mb=MAX_ARCHIVE_ITEM_SIZE_MB
+    ):
+        return None, estimated
+
+    result = await execute_download(
+        plan,
+        chat_id=0,  # not used for progress reporting in archive flow
+        executor=executor,
+        progress_hook_factory=lambda _cid: (lambda _data: None),
+        progress_state={},
+        status_callback=_noop_status,
+        format_bytes=lambda v: str(v),
+        format_eta=lambda v: str(v),
+    )
+    return Path(result.file_path), result.file_size_mb
+
+
+async def download_playlist_into(
+    workspace: Path,
+    entries: list[dict],
+    *,
+    media_type: str,
+    format_choice: str,
+    executor: ThreadPoolExecutor,
+    status_cb: Callable[[str], Awaitable[None]],
+) -> tuple[list[Path], list[str]]:
+    """Download every entry into workspace, keeping the files (no os.remove).
+
+    Returns (downloaded_paths, failed_titles). Items exceeding the
+    MAX_ARCHIVE_ITEM_SIZE_MB cap are reported on failed_titles with a
+    ``(za duzy: X MB)`` suffix. Network failures are similarly recorded
+    with the original title.
+    """
+
+    downloaded: list[Path] = []
+    failed: list[str] = []
+    total = len(entries)
+
+    for idx, entry in enumerate(entries, 1):
+        title = entry.get("title", f"item_{idx}")
+        await status_cb(f"[{idx}/{total}] Pobieranie: {title}...")
+        try:
+            path, size = await _download_one_into_workspace(
+                entry,
+                workspace,
+                media_type=media_type,
+                format_choice=format_choice,
+                executor=executor,
+            )
+        except Exception as exc:
+            logging.error("Archive download failed for %s: %s", title, exc)
+            failed.append(title)
+            continue
+
+        if path is None:
+            mb_str = f"{size:.0f} MB" if size is not None else "?"
+            failed.append(f"{title} (za duzy: {mb_str})")
+            continue
+
+        downloaded.append(path)
+
+    return downloaded, failed

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -250,3 +250,243 @@ async def send_volumes(
                 raise RuntimeError(f"Wysyłka {volume.name} przez MTProto nie powiodła się.")
 
         logging.info("Sent volume %d/%d: %s (%.1f MB)", idx + 1, total, volume.name, size_mb)
+
+
+import shutil
+from typing import Any
+
+from bot.archive import is_7z_available, pack_to_volumes, volume_size_for
+
+
+async def _safe_status_edit(update, text: str) -> None:
+    """Edit the inline-keyboard message body, ignoring 'message not modified' errors."""
+
+    try:
+        await update.callback_query.edit_message_text(text)
+    except Exception as exc:
+        logging.debug("status edit failed (non-fatal): %s", exc)
+
+
+async def execute_playlist_archive_flow(
+    update,
+    context,
+    *,
+    chat_id: int,
+    playlist: dict[str, Any],
+    media_type: str,
+    format_choice: str,
+    executor: ThreadPoolExecutor,
+) -> None:
+    """End-to-end: workspace → download all → pack to 7z → send volumes."""
+
+    if not is_7z_available():
+        await _safe_status_edit(
+            update,
+            "Funkcja 7z niedostępna — administrator nie zainstalował p7zip-full.",
+        )
+        return
+
+    use_mtproto = mtproto_unavailability_reason() is None
+    volume_size_mb = volume_size_for(use_mtproto)
+
+    title = playlist.get("title", "Playlista")
+    entries = playlist.get("entries") or []
+    total = len(entries)
+
+    workspace = prepare_playlist_workspace(chat_id, title, prefix="pl")
+    lock_path = workspace / ".lock"
+    lock_path.touch()
+
+    async def status(text: str) -> None:
+        await _safe_status_edit(update, text)
+
+    await status(f"Playlista → 7z ({media_type} {format_choice})\n[0/{total}] Pobieranie...")
+
+    try:
+        downloaded, failed = await download_playlist_into(
+            workspace,
+            entries,
+            media_type=media_type,
+            format_choice=format_choice,
+            executor=executor,
+            status_cb=status,
+        )
+
+        if not downloaded:
+            shutil.rmtree(workspace, ignore_errors=True)
+            await status("Nie udało się pobrać żadnego elementu.")
+            return
+
+        await status(f"Pakowanie do 7z (vol_size={volume_size_mb} MB)...")
+        slug = _build_slug(title)
+        dest_basename = workspace / compute_archive_basename(
+            f"{slug}_{media_type}_{format_choice}", datetime.now()
+        )
+        volumes = await pack_to_volumes(downloaded, dest_basename, volume_size_mb)
+
+        caption_prefix = f"{title} ({media_type} {format_choice})"
+        await status(f"Pakowanie OK: {len(volumes)} paczek. Wysyłanie...")
+        await send_volumes(
+            context.bot,
+            chat_id=chat_id,
+            volumes=volumes,
+            caption_prefix=caption_prefix,
+            use_mtproto=use_mtproto,
+            status_cb=status,
+        )
+
+        delivery = ArchivedDeliveryState(
+            workspace=workspace,
+            volumes=volumes,
+            caption_prefix=caption_prefix,
+            use_mtproto=use_mtproto,
+            created_at=datetime.now(),
+        )
+        token = register_archived_delivery(chat_id, delivery)
+
+        summary_lines = [
+            "Playlista zakończona.",
+            f"Pobrano: {len(downloaded)}/{total}",
+            f"Spakowano: {len(downloaded)} plików → {len(volumes)} paczek 7z",
+            f"Wysłano: {len(volumes)}/{len(volumes)}",
+            "Folder zostanie usunięty po 60 min.",
+        ]
+        if failed:
+            summary_lines.append("")
+            summary_lines.append("Nieudane elementy:")
+            for title_ in failed[:5]:
+                summary_lines.append(f"  - {title_[:60]}")
+
+        from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+        keyboard = InlineKeyboardMarkup([
+            [InlineKeyboardButton(
+                "Wyślij wszystkie paczki ponownie",
+                callback_data=f"arc_resend_{token}_0",
+            )],
+            [InlineKeyboardButton(
+                "Usuń teraz",
+                callback_data=f"arc_purge_{token}",
+            )],
+        ])
+        try:
+            await update.callback_query.edit_message_text(
+                "\n".join(summary_lines),
+                reply_markup=keyboard,
+            )
+        except Exception as exc:
+            logging.debug("summary edit failed: %s", exc)
+    except Exception as exc:
+        logging.error("Playlist archive flow failed: %s", exc)
+        await status(f"Pakowanie/wysyłka nie powiodły się: {exc}")
+        # Workspace stays so user can retry; cleanup will remove it after retention.
+    finally:
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass
+
+
+async def execute_single_file_archive_flow(
+    update,
+    context,
+    *,
+    chat_id: int,
+    token: str,
+) -> None:
+    """End-to-end fallback for an oversized single file pre-registered as token."""
+
+    if not is_7z_available():
+        await _safe_status_edit(
+            update,
+            "Funkcja 7z niedostępna — administrator nie zainstalował p7zip-full.",
+        )
+        return
+
+    bucket = pending_archive_jobs.get(chat_id) or {}
+    state = bucket.get(token)
+    if state is None:
+        await _safe_status_edit(update, "Sesja wygasła. Wyślij plik ponownie.")
+        return
+
+    use_mtproto = mtproto_unavailability_reason() is None
+    volume_size_mb = volume_size_for(use_mtproto)
+
+    workspace = prepare_playlist_workspace(chat_id, state.title, prefix="big")
+    lock_path = workspace / ".lock"
+    lock_path.touch()
+
+    src = Path(state.file_path)
+    moved_path = workspace / src.name
+    try:
+        shutil.move(str(src), moved_path)
+    except OSError as exc:
+        await _safe_status_edit(update, f"Nie można przenieść pliku do workspace: {exc}")
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass
+        return
+
+    async def status(text: str) -> None:
+        await _safe_status_edit(update, text)
+
+    await status(f"Pakowanie do 7z (vol_size={volume_size_mb} MB)...")
+    try:
+        slug = _build_slug(state.title)
+        dest_basename = workspace / compute_archive_basename(slug, datetime.now())
+        volumes = await pack_to_volumes([moved_path], dest_basename, volume_size_mb)
+
+        caption_prefix = state.title
+        await status(f"Pakowanie OK: {len(volumes)} paczek. Wysyłanie...")
+        await send_volumes(
+            context.bot,
+            chat_id=chat_id,
+            volumes=volumes,
+            caption_prefix=caption_prefix,
+            use_mtproto=use_mtproto,
+            status_cb=status,
+        )
+
+        delivery = ArchivedDeliveryState(
+            workspace=workspace,
+            volumes=volumes,
+            caption_prefix=caption_prefix,
+            use_mtproto=use_mtproto,
+            created_at=datetime.now(),
+        )
+        delivery_token = register_archived_delivery(chat_id, delivery)
+
+        from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+        keyboard = InlineKeyboardMarkup([
+            [InlineKeyboardButton(
+                "Wyślij wszystkie paczki ponownie",
+                callback_data=f"arc_resend_{delivery_token}_0",
+            )],
+            [InlineKeyboardButton(
+                "Usuń teraz",
+                callback_data=f"arc_purge_{delivery_token}",
+            )],
+        ])
+        try:
+            await update.callback_query.edit_message_text(
+                f"Plik wysłany w {len(volumes)} paczkach. Folder zostanie usunięty po 60 min.",
+                reply_markup=keyboard,
+            )
+        except Exception as exc:
+            logging.debug("summary edit failed: %s", exc)
+    except Exception as exc:
+        logging.error("Single-file archive flow failed: %s", exc)
+        await status(f"Pakowanie/wysyłka nie powiodły się: {exc}")
+    finally:
+        # Always consume the pending job so the token cannot be re-used.
+        bucket.pop(token, None)
+        if not bucket:
+            pending_archive_jobs.pop(chat_id, None)
+        else:
+            pending_archive_jobs[chat_id] = bucket
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -12,12 +12,19 @@ from __future__ import annotations
 
 import logging
 import secrets
+import shutil
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import Any, Awaitable, Callable
 
-from bot.archive import compute_archive_basename, transliterate_to_ascii
+from bot.archive import (
+    compute_archive_basename,
+    is_7z_available,
+    pack_to_volumes,
+    transliterate_to_ascii,
+    volume_size_for,
+)
 from bot.config import DOWNLOAD_PATH
 from bot.downloader_validation import sanitize_filename
 from bot.mtproto import mtproto_unavailability_reason, send_document_mtproto
@@ -34,6 +41,7 @@ from bot.session_store import (
     archived_deliveries,
     pending_archive_jobs,
 )
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 
 _SLUG_MAX_LEN = 60
@@ -252,12 +260,6 @@ async def send_volumes(
         logging.info("Sent volume %d/%d: %s (%.1f MB)", idx + 1, total, volume.name, size_mb)
 
 
-import shutil
-from typing import Any
-
-from bot.archive import is_7z_available, pack_to_volumes, volume_size_for
-
-
 async def _safe_status_edit(update, text: str) -> None:
     """Edit the inline-keyboard message body, ignoring 'message not modified' errors."""
 
@@ -357,8 +359,6 @@ async def execute_playlist_archive_flow(
             for title_ in failed[:5]:
                 summary_lines.append(f"  - {title_[:60]}")
 
-        from telegram import InlineKeyboardButton, InlineKeyboardMarkup
-
         keyboard = InlineKeyboardMarkup([
             [InlineKeyboardButton(
                 "Wyślij wszystkie paczki ponownie",
@@ -456,8 +456,6 @@ async def execute_single_file_archive_flow(
             created_at=datetime.now(),
         )
         delivery_token = register_archived_delivery(chat_id, delivery)
-
-        from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
         keyboard = InlineKeyboardMarkup([
             [InlineKeyboardButton(

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -28,7 +28,7 @@ from bot.archive import (
 from bot.config import DOWNLOAD_PATH
 from bot.downloader_validation import sanitize_filename
 from bot.mtproto import mtproto_unavailability_reason, send_document_mtproto
-from bot.security_limits import MAX_ARCHIVE_ITEM_SIZE_MB, TELEGRAM_UPLOAD_LIMIT_MB
+from bot.security_limits import MAX_ARCHIVE_ITEM_SIZE_MB, PLAYLIST_ARCHIVE_RETENTION_MIN, TELEGRAM_UPLOAD_LIMIT_MB
 from bot.services.download_service import (
     ensure_size_within_limit,
     estimate_download_size,
@@ -351,7 +351,7 @@ async def execute_playlist_archive_flow(
             f"Pobrano: {len(downloaded)}/{total}",
             f"Spakowano: {len(downloaded)} plików → {len(volumes)} paczek 7z",
             f"Wysłano: {len(volumes)}/{len(volumes)}",
-            "Folder zostanie usunięty po 60 min.",
+            f"Folder zostanie usunięty po {PLAYLIST_ARCHIVE_RETENTION_MIN} min.",
         ]
         if failed:
             summary_lines.append("")
@@ -469,7 +469,7 @@ async def execute_single_file_archive_flow(
         ])
         try:
             await update.callback_query.edit_message_text(
-                f"Plik wysłany w {len(volumes)} paczkach. Folder zostanie usunięty po 60 min.",
+                f"Plik wysłany w {len(volumes)} paczkach. Folder zostanie usunięty po {PLAYLIST_ARCHIVE_RETENTION_MIN} min.",
                 reply_markup=keyboard,
             )
         except Exception as exc:

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -10,20 +10,18 @@ Boundaries:
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import secrets
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Awaitable, Callable
+from typing import Awaitable, Callable
 
 from bot.archive import compute_archive_basename, transliterate_to_ascii
 from bot.config import DOWNLOAD_PATH
 from bot.downloader_validation import sanitize_filename
 from bot.security_limits import MAX_ARCHIVE_ITEM_SIZE_MB
 from bot.services.download_service import (
-    DownloadResult,
     ensure_size_within_limit,
     estimate_download_size,
     execute_download,
@@ -127,9 +125,13 @@ async def _download_one_into_workspace(
     ):
         return None, estimated
 
+    # chat_id=0 with an isolated local progress_state={} dict so per-chat
+    # progress reporting (which writes to that dict by chat_id) does not
+    # leak across concurrent archive flows. Do not pass session_store's
+    # global download_progress here.
     result = await execute_download(
         plan,
-        chat_id=0,  # not used for progress reporting in archive flow
+        chat_id=0,
         executor=executor,
         progress_hook_factory=lambda _cid: (lambda _data: None),
         progress_state={},

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -1,0 +1,76 @@
+"""End-to-end orchestration for 7z archive flows (playlist + single-file).
+
+Boundaries:
+- ``bot.archive`` — pure 7z wrapper, no Telegram/session knowledge.
+- ``archive_service`` (this module) — knows about sessions, downloads,
+  Telegram bot client, and gluing them together.
+- ``bot.handlers.*`` — translate inline keyboard callbacks into calls
+  on this service, never call ``bot.archive`` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime
+from pathlib import Path
+
+from bot.archive import compute_archive_basename, transliterate_to_ascii
+from bot.config import DOWNLOAD_PATH
+from bot.downloader_validation import sanitize_filename
+from bot.session_store import (
+    ArchiveJobState,
+    ArchivedDeliveryState,
+    archived_deliveries,
+    pending_archive_jobs,
+)
+
+
+_SLUG_MAX_LEN = 60
+
+
+def _build_slug(title: str) -> str:
+    """Translit-then-sanitize playlist/file title for use in filesystem path."""
+
+    transliterated = transliterate_to_ascii(title)
+    sanitized = sanitize_filename(transliterated)
+    cleaned = sanitized.replace(" ", "_")
+    return cleaned[:_SLUG_MAX_LEN] or "untitled"
+
+
+def prepare_playlist_workspace(
+    chat_id: int,
+    playlist_title: str,
+    *,
+    prefix: str = "pl",
+) -> Path:
+    """Create ``downloads/<chat_id>/<prefix>_<slug>_<ts>/`` and return it."""
+
+    slug = _build_slug(playlist_title)
+    basename = compute_archive_basename(slug, datetime.now())
+    chat_dir = Path(DOWNLOAD_PATH) / str(chat_id)
+    chat_dir.mkdir(parents=True, exist_ok=True)
+    workspace = chat_dir / f"{prefix}_{basename}"
+    workspace.mkdir(parents=True, exist_ok=True)
+    logging.info("Archive workspace ready: %s", workspace)
+    return workspace
+
+
+def register_pending_archive_job(chat_id: int, state: ArchiveJobState) -> str:
+    """Store a pending archive job and return the lookup token (8 hex chars)."""
+
+    token = secrets.token_hex(4)
+    bucket = pending_archive_jobs.get(chat_id) or {}
+    bucket[token] = state
+    pending_archive_jobs[chat_id] = bucket
+    return token
+
+
+def register_archived_delivery(chat_id: int, state: ArchivedDeliveryState) -> str:
+    """Store delivery metadata for retry/purge actions and return its token."""
+
+    token = secrets.token_hex(4)
+    bucket = archived_deliveries.get(chat_id) or {}
+    bucket[token] = state
+    archived_deliveries[chat_id] = bucket
+    return token

--- a/bot/services/archive_service.py
+++ b/bot/services/archive_service.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable
 if TYPE_CHECKING:
     from bot.jobs import JobCancellation
 
+from bot.jobs import JobDescriptor, job_registry
 from bot.archive import (
     compute_archive_basename,
     is_7z_available,
@@ -40,8 +41,10 @@ from bot.services.download_service import (
 )
 from bot.session_store import (
     ArchiveJobState,
+    ArchivePartialState,
     ArchivedDeliveryState,
     archived_deliveries,
+    partial_archive_workspaces,
     pending_archive_jobs,
 )
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
@@ -295,7 +298,12 @@ async def execute_playlist_archive_flow(
     format_choice: str,
     executor: ThreadPoolExecutor,
 ) -> None:
-    """End-to-end: workspace → download all → pack to 7z → send volumes."""
+    """End-to-end: workspace → download all → pack to 7z → send volumes.
+
+    Registers a job with job_registry so /stop can cancel mid-flight.
+    On cancel during download phase, saves an ArchivePartialState so the
+    user can click [Spakuj co mam] from the cancel-status message.
+    """
 
     if not is_7z_available():
         await _safe_status_edit(
@@ -311,6 +319,15 @@ async def execute_playlist_archive_flow(
     entries = playlist.get("entries") or []
     total = len(entries)
 
+    descriptor = JobDescriptor(
+        job_id="",  # filled by registry
+        chat_id=chat_id,
+        kind="playlist_zip",
+        label=f"Playlist 7z ({media_type} {format_choice}) — start",
+        started_at=datetime.now(),
+    )
+    cancellation = job_registry.register(chat_id, descriptor)
+
     workspace = prepare_playlist_workspace(chat_id, title, prefix="pl")
     lock_path = workspace / ".lock"
     lock_path.touch()
@@ -318,9 +335,18 @@ async def execute_playlist_archive_flow(
     async def status(text: str) -> None:
         await _safe_status_edit(update, text)
 
-    await status(f"Playlista → 7z ({media_type} {format_choice})\n[0/{total}] Pobieranie...")
+    await status(
+        f"Playlista → 7z ({media_type} {format_choice})\n"
+        f"[0/{total}] Pobieranie..."
+    )
 
+    downloaded: list[Path] = []
+    failed: list[str] = []
     try:
+        job_registry.update_label(
+            cancellation.job_id,
+            f"Playlist 7z ({media_type} {format_choice}) — pobieranie [0/{total}]",
+        )
         downloaded, failed = await download_playlist_into(
             workspace,
             entries,
@@ -328,21 +354,48 @@ async def execute_playlist_archive_flow(
             format_choice=format_choice,
             executor=executor,
             status_cb=status,
+            cancellation=cancellation,
         )
+
+        if cancellation.event.is_set():
+            await _save_partial_state_after_cancel(
+                update, chat_id, workspace, downloaded, title,
+                media_type, format_choice, use_mtproto, total,
+            )
+            return
 
         if not downloaded:
             shutil.rmtree(workspace, ignore_errors=True)
             await status("Nie udało się pobrać żadnego elementu.")
             return
 
+        job_registry.update_label(
+            cancellation.job_id,
+            f"Playlist 7z ({media_type} {format_choice}) — pakowanie",
+        )
         await status(f"Pakowanie do 7z (vol_size={volume_size_mb} MB)...")
         slug = _build_slug(title)
         dest_basename = workspace / compute_archive_basename(
             f"{slug}_{media_type}_{format_choice}", datetime.now()
         )
-        volumes = await pack_to_volumes(downloaded, dest_basename, volume_size_mb)
+        volumes = await pack_to_volumes(
+            downloaded, dest_basename, volume_size_mb,
+            cancellation=cancellation,
+        )
+
+        if cancellation.event.is_set():
+            # User cancelled during pack — pack_to_volumes already cleaned partials.
+            await _save_partial_state_after_cancel(
+                update, chat_id, workspace, downloaded, title,
+                media_type, format_choice, use_mtproto, total,
+            )
+            return
 
         caption_prefix = f"{title} ({media_type} {format_choice})"
+        job_registry.update_label(
+            cancellation.job_id,
+            f"Playlist 7z ({media_type} {format_choice}) — wysyłka [0/{len(volumes)}]",
+        )
         await status(f"Pakowanie OK: {len(volumes)} paczek. Wysyłanie...")
         await send_volumes(
             context.bot,
@@ -351,6 +404,7 @@ async def execute_playlist_archive_flow(
             caption_prefix=caption_prefix,
             use_mtproto=use_mtproto,
             status_cb=status,
+            cancellation=cancellation,
         )
 
         delivery = ArchivedDeliveryState(
@@ -362,13 +416,19 @@ async def execute_playlist_archive_flow(
         )
         token = register_archived_delivery(chat_id, delivery)
 
+        was_cancelled_in_send = cancellation.event.is_set()
         summary_lines = [
-            "Playlista zakończona.",
+            "Playlista zakończona." if not was_cancelled_in_send else "⏹ Wysyłka anulowana.",
             f"Pobrano: {len(downloaded)}/{total}",
             f"Spakowano: {len(downloaded)} plików → {len(volumes)} paczek 7z",
-            f"Wysłano: {len(volumes)}/{len(volumes)}",
-            f"Folder zostanie usunięty po {PLAYLIST_ARCHIVE_RETENTION_MIN} min.",
         ]
+        if was_cancelled_in_send:
+            summary_lines.append(f"Wysłano: <{len(volumes)} (anulowano)")
+        else:
+            summary_lines.append(f"Wysłano: {len(volumes)}/{len(volumes)}")
+        summary_lines.append(
+            f"Folder zostanie usunięty po {PLAYLIST_ARCHIVE_RETENTION_MIN} min."
+        )
         if failed:
             summary_lines.append("")
             summary_lines.append("Nieudane elementy:")
@@ -380,27 +440,79 @@ async def execute_playlist_archive_flow(
                 "Wyślij wszystkie paczki ponownie",
                 callback_data=f"arc_resend_{token}_0",
             )],
-            [InlineKeyboardButton(
-                "Usuń teraz",
-                callback_data=f"arc_purge_{token}",
-            )],
+            [InlineKeyboardButton("Usuń teraz", callback_data=f"arc_purge_{token}")],
         ])
         try:
             await update.callback_query.edit_message_text(
-                "\n".join(summary_lines),
-                reply_markup=keyboard,
+                "\n".join(summary_lines), reply_markup=keyboard,
             )
         except Exception as exc:
             logging.debug("summary edit failed: %s", exc)
     except Exception as exc:
         logging.error("Playlist archive flow failed: %s", exc)
         await status(f"Pakowanie/wysyłka nie powiodły się: {exc}")
-        # Workspace stays so user can retry; cleanup will remove it after retention.
     finally:
         try:
             lock_path.unlink()
         except OSError:
             pass
+        job_registry.unregister(cancellation.job_id)
+
+
+async def _save_partial_state_after_cancel(
+    update,
+    chat_id: int,
+    workspace: Path,
+    downloaded: list[Path],
+    title: str,
+    media_type: str,
+    format_choice: str,
+    use_mtproto: bool,
+    total: int,
+) -> None:
+    """Persist ArchivePartialState and edit the status message with recovery buttons."""
+
+    if not downloaded:
+        # Nothing to recover — drop the workspace.
+        shutil.rmtree(workspace, ignore_errors=True)
+        try:
+            await update.callback_query.edit_message_text(
+                "⏹ Zatrzymano. Nie pobrano żadnego elementu."
+            )
+        except Exception:
+            pass
+        return
+
+    state = ArchivePartialState(
+        workspace=workspace,
+        downloaded=list(downloaded),
+        title=title,
+        media_type=media_type,
+        format_choice=format_choice,
+        use_mtproto=use_mtproto,
+        created_at=datetime.now(),
+    )
+    bucket = partial_archive_workspaces.get(chat_id) or {}
+    token = secrets.token_hex(4)
+    bucket[token] = state
+    partial_archive_workspaces[chat_id] = bucket
+
+    keyboard = InlineKeyboardMarkup([
+        [InlineKeyboardButton(
+            "Spakuj co mam", callback_data=f"arc_pack_partial_{token}",
+        )],
+        [InlineKeyboardButton(
+            "Usuń teraz", callback_data=f"arc_purge_partial_{token}",
+        )],
+    ])
+    try:
+        await update.callback_query.edit_message_text(
+            f"⏹ Zatrzymano. Pobrano {len(downloaded)}/{total} plików.\n"
+            f"Workspace zostanie usunięty po {PLAYLIST_ARCHIVE_RETENTION_MIN} min.",
+            reply_markup=keyboard,
+        )
+    except Exception as exc:
+        logging.debug("partial-state edit failed: %s", exc)
 
 
 async def execute_single_file_archive_flow(

--- a/bot/services/download_service.py
+++ b/bot/services/download_service.py
@@ -20,7 +20,7 @@ import os
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import yt_dlp
 
@@ -28,6 +28,9 @@ from bot.config import YTDLP_REMOTE_COMPONENTS
 from bot.downloader_metadata import COOKIES_FILE, get_video_info
 from bot.downloader_validation import is_valid_audio_quality, sanitize_filename
 from bot.security_limits import MAX_FILE_SIZE_MB
+
+if TYPE_CHECKING:
+    from bot.jobs import JobCancellation
 
 
 ArtifactSuffixes = ('_transcript.md', '_transcript.txt', '_summary.md')
@@ -227,6 +230,25 @@ def estimate_download_size(plan: DownloadPlan) -> float | None:
     return size_mb
 
 
+def _build_cancellable_progress_hook(
+    base_hook: Callable[[dict[str, Any]], None],
+    cancellation: "JobCancellation",
+) -> Callable[[dict[str, Any]], None]:
+    """Wrap a yt-dlp progress hook so it raises DownloadError on cancel.
+
+    yt-dlp invokes the hook synchronously many times per second; raising
+    DownloadError lets it clean up the .part file and propagate the error
+    out of the threadpool worker into ``execute_download``'s caller.
+    """
+
+    def hook(d: dict[str, Any]) -> None:
+        if cancellation.event.is_set():
+            raise yt_dlp.utils.DownloadError("cancelled by user")
+        base_hook(d)
+
+    return hook
+
+
 async def execute_download(
     plan: DownloadPlan,
     *,
@@ -237,14 +259,23 @@ async def execute_download(
     status_callback: Callable[[str], Any],
     format_bytes: Callable[[int | float | None], str],
     format_eta: Callable[[int | float | None], str],
+    cancellation: "JobCancellation | None" = None,
 ) -> DownloadResult:
     """Run yt-dlp download and stream progress updates through a callback.
+
+    When ``cancellation`` is provided, the progress hook raises
+    yt_dlp.utils.DownloadError("cancelled by user") whenever the event is
+    set. yt-dlp catches that and cleans up the .part file automatically.
 
     Raises FileNotFoundError when yt-dlp finishes without producing a file.
     """
 
     ydl_opts = plan.ydl_opts.copy()
-    ydl_opts['progress_hooks'] = [progress_hook_factory(chat_id)]
+    base_hook = progress_hook_factory(chat_id)
+    if cancellation is not None:
+        ydl_opts['progress_hooks'] = [_build_cancellable_progress_hook(base_hook, cancellation)]
+    else:
+        ydl_opts['progress_hooks'] = [base_hook]
     progress_state[chat_id] = {'status': 'starting', 'updated': time.time()}
 
     loop = asyncio.get_event_loop()

--- a/bot/services/playlist_service.py
+++ b/bot/services/playlist_service.py
@@ -28,6 +28,7 @@ class PlaylistDownloadChoice:
 
     media_type: str
     format_choice: str
+    as_archive: bool = False
 
 
 def load_playlist(url: str, *, max_items: int) -> dict[str, Any] | None:
@@ -36,8 +37,16 @@ def load_playlist(url: str, *, max_items: int) -> dict[str, Any] | None:
     return get_playlist_info(url, max_items=max_items)
 
 
-def build_playlist_message(playlist_info: dict[str, Any]) -> tuple[str, InlineKeyboardMarkup]:
-    """Build playlist listing text and controls."""
+def build_playlist_message(
+    playlist_info: dict[str, Any],
+    *,
+    archive_available: bool = False,
+) -> tuple[str, InlineKeyboardMarkup]:
+    """Build playlist listing text and controls.
+
+    When ``archive_available`` is True, four extra "... jako 7z" buttons
+    are inserted alongside the existing per-item-send buttons.
+    """
 
     entries = playlist_info['entries']
     total = playlist_info.get('playlist_count', len(entries))
@@ -54,12 +63,19 @@ def build_playlist_message(playlist_info: dict[str, Any]) -> tuple[str, InlineKe
         dur_str = f"{duration // 60}:{duration % 60:02d}" if duration else "?"
         msg += f"{i}. {title} ({dur_str})\n"
 
-    keyboard = [
-        [InlineKeyboardButton("Pobierz wszystkie — Audio MP3", callback_data="pl_dl_audio_mp3")],
-        [InlineKeyboardButton("Pobierz wszystkie — Audio M4A", callback_data="pl_dl_audio_m4a")],
-        [InlineKeyboardButton("Pobierz wszystkie — Video (najlepsza)", callback_data="pl_dl_video_best")],
-        [InlineKeyboardButton("Pobierz wszystkie — Video 720p", callback_data="pl_dl_video_720p")],
+    options = [
+        ("Pobierz wszystkie — Audio MP3", "pl_dl_audio_mp3", "pl_zip_dl_audio_mp3"),
+        ("Pobierz wszystkie — Audio M4A", "pl_dl_audio_m4a", "pl_zip_dl_audio_m4a"),
+        ("Pobierz wszystkie — Video (najlepsza)", "pl_dl_video_best", "pl_zip_dl_video_best"),
+        ("Pobierz wszystkie — Video 720p", "pl_dl_video_720p", "pl_zip_dl_video_720p"),
     ]
+    keyboard: list[list[InlineKeyboardButton]] = []
+    for label, plain, archive_cb in options:
+        keyboard.append([InlineKeyboardButton(label, callback_data=plain)])
+        if archive_available:
+            keyboard.append([
+                InlineKeyboardButton(f"{label} jako 7z", callback_data=archive_cb)
+            ])
 
     if total > len(entries) and len(entries) < MAX_PLAYLIST_ITEMS_EXPANDED:
         more_count = min(total, MAX_PLAYLIST_ITEMS_EXPANDED)
@@ -78,13 +94,31 @@ def build_single_video_url(url: str) -> str:
 
 
 def parse_playlist_download_choice(callback_data: str) -> PlaylistDownloadChoice:
-    """Parse playlist batch-download callback data."""
+    """Parse playlist batch-download callback data.
 
-    format_part = callback_data.replace("pl_dl_", "", 1)
-    parts = format_part.split("_", 1)
+    Recognizes two prefixes:
+    - ``pl_dl_<media>_<format>``      → standard per-item send (legacy).
+    - ``pl_zip_dl_<media>_<format>``  → archive (7z) flow.
+    """
+
+    if callback_data.startswith("pl_zip_dl_"):
+        rest = callback_data.replace("pl_zip_dl_", "", 1)
+        as_archive = True
+    elif callback_data.startswith("pl_dl_"):
+        rest = callback_data.replace("pl_dl_", "", 1)
+        as_archive = False
+    else:
+        rest = callback_data
+        as_archive = False
+
+    parts = rest.split("_", 1)
     media_type = parts[0]
     format_choice = parts[1] if len(parts) > 1 else "best"
-    return PlaylistDownloadChoice(media_type=media_type, format_choice=format_choice)
+    return PlaylistDownloadChoice(
+        media_type=media_type,
+        format_choice=format_choice,
+        as_archive=as_archive,
+    )
 
 
 def build_playlist_item_download_plan(

--- a/bot/services/transcription_service.py
+++ b/bot/services/transcription_service.py
@@ -6,7 +6,10 @@ import asyncio
 import os
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from bot.jobs import JobCancellation
 
 from bot.transcription_limits import is_text_too_long_for_summary
 from bot.transcription_pipeline import transcribe_mp3_file
@@ -45,8 +48,13 @@ async def run_transcription_with_progress(
     output_dir: str,
     executor: Any,
     status_callback: Callable[[str], Any],
+    cancellation: "JobCancellation | None" = None,
 ) -> str | None:
-    """Run the MP3 transcription pipeline and forward progress updates."""
+    """Run the MP3 transcription pipeline and forward progress updates.
+
+    When cancellation is provided, it propagates to transcribe_mp3_file
+    so chunk-level polling can stop processing early.
+    """
 
     current_status = {"text": ""}
 
@@ -56,7 +64,13 @@ async def run_transcription_with_progress(
     loop = asyncio.get_event_loop()
     future = loop.run_in_executor(
         executor,
-        lambda: transcribe_mp3_file(source_path, output_dir, progress_callback, language=None),
+        lambda: transcribe_mp3_file(
+            source_path,
+            output_dir,
+            progress_callback,
+            language=None,
+            cancellation=cancellation,
+        ),
     )
 
     last_status = ""

--- a/bot/session_store.py
+++ b/bot/session_store.py
@@ -38,6 +38,24 @@ class ArchivedDeliveryState:
 
 
 @dataclass
+class ArchivePartialState:
+    """In-memory state for a cancelled-mid-flight playlist archive.
+
+    Captured by execute_playlist_archive_flow when a cancel signal arrives
+    after some entries downloaded; lets the user click [Spakuj co mam] to
+    package whatever was already pulled.
+    """
+
+    workspace: Any        # pathlib.Path
+    downloaded: list[Any] # list[Path]
+    title: str
+    media_type: str
+    format_choice: str
+    use_mtproto: bool
+    created_at: Any       # datetime
+
+
+@dataclass
 class SessionState:
     """Chat-scoped runtime state used by Telegram handlers."""
 
@@ -55,6 +73,7 @@ class SessionState:
     subtitle_pending: dict[str, Any] | None = None
     pending_archive_jobs: dict[str, "ArchiveJobState"] | None = None
     archived_deliveries: dict[str, "ArchivedDeliveryState"] | None = None
+    partial_archive_workspaces: dict[str, "ArchivePartialState"] | None = None
 
 
 @dataclass
@@ -191,6 +210,7 @@ class SessionStore:
             and session.subtitle_pending is None
             and session.pending_archive_jobs is None
             and session.archived_deliveries is None
+            and session.partial_archive_workspaces is None
         ):
             self._sessions.pop(chat_id, None)
 
@@ -237,6 +257,7 @@ user_playlist_data = SessionFieldMap(session_store, "playlist_data")
 download_progress = SessionFieldMap(session_store, "download_progress")
 pending_archive_jobs = SessionFieldMap(session_store, "pending_archive_jobs")
 archived_deliveries = SessionFieldMap(session_store, "archived_deliveries")
+partial_archive_workspaces = SessionFieldMap(session_store, "partial_archive_workspaces")
 
 
 class SecurityStore:

--- a/bot/session_store.py
+++ b/bot/session_store.py
@@ -10,6 +10,34 @@ from typing import Any
 
 
 @dataclass
+class ArchiveJobState:
+    """In-memory state for a single-file archive flow waiting for user choice.
+
+    Created when a downloaded file exceeds the active Telegram transport
+    limit; consumed by arc_split_<token> / arc_cancel_<token> callbacks.
+    """
+
+    file_path: Any  # pathlib.Path; Any avoids importing Path here
+    title: str
+    media_type: str
+    format_choice: str
+    file_size_mb: float
+    use_mtproto: bool
+    created_at: Any  # datetime
+
+
+@dataclass
+class ArchivedDeliveryState:
+    """In-memory state for a sent archive set, kept for retry/purge buttons."""
+
+    workspace: Any        # pathlib.Path
+    volumes: list[Any]    # list[Path]
+    caption_prefix: str
+    use_mtproto: bool
+    created_at: Any       # datetime
+
+
+@dataclass
 class SessionState:
     """Chat-scoped runtime state used by Telegram handlers."""
 
@@ -25,6 +53,8 @@ class SessionState:
     audio_file_path: str | None = None
     audio_file_title: str | None = None
     subtitle_pending: dict[str, Any] | None = None
+    pending_archive_jobs: dict[str, "ArchiveJobState"] | None = None
+    archived_deliveries: dict[str, "ArchivedDeliveryState"] | None = None
 
 
 @dataclass
@@ -159,6 +189,8 @@ class SessionStore:
             and session.audio_file_path is None
             and session.audio_file_title is None
             and session.subtitle_pending is None
+            and session.pending_archive_jobs is None
+            and session.archived_deliveries is None
         ):
             self._sessions.pop(chat_id, None)
 
@@ -203,6 +235,8 @@ user_urls = SessionFieldMap(session_store, "current_url")
 user_time_ranges = SessionFieldMap(session_store, "time_range")
 user_playlist_data = SessionFieldMap(session_store, "playlist_data")
 download_progress = SessionFieldMap(session_store, "download_progress")
+pending_archive_jobs = SessionFieldMap(session_store, "pending_archive_jobs")
+archived_deliveries = SessionFieldMap(session_store, "archived_deliveries")
 
 
 class SecurityStore:

--- a/bot/telegram_callbacks.py
+++ b/bot/telegram_callbacks.py
@@ -111,7 +111,7 @@ async def handle_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await _extracted_handle_archive_callback(update, context, data)
         return
 
-    if data.startswith("stop_") or data == "stop_all":
+    if data.startswith("stop_"):
         from bot.telegram_commands import handle_stop_callback
         await handle_stop_callback(update, context, data)
         return

--- a/bot/telegram_callbacks.py
+++ b/bot/telegram_callbacks.py
@@ -111,6 +111,11 @@ async def handle_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await _extracted_handle_archive_callback(update, context, data)
         return
 
+    if data.startswith("stop_") or data == "stop_all":
+        from bot.telegram_commands import handle_stop_callback
+        await handle_stop_callback(update, context, data)
+        return
+
     if data.startswith("pl_"):
         await handle_playlist_callback(update, context, data)
         return

--- a/bot/telegram_callbacks.py
+++ b/bot/telegram_callbacks.py
@@ -100,6 +100,11 @@ async def handle_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await query.edit_message_text("Przekroczono limit requestów. Spróbuj ponownie za chwilę.")
         return
 
+    if data.startswith("arc_"):
+        from bot.handlers.download_callbacks import handle_archive_callback
+        await handle_archive_callback(update, context, data)
+        return
+
     if data.startswith("pl_"):
         await handle_playlist_callback(update, context, data)
         return

--- a/bot/telegram_callbacks.py
+++ b/bot/telegram_callbacks.py
@@ -34,6 +34,7 @@ from bot.handlers.download_callbacks import (
     create_progress_hook as _extracted_create_progress_hook,
     download_file as _extracted_download_file,
     download_spotify_resolved as _extracted_download_spotify_resolved,
+    handle_archive_callback as _extracted_handle_archive_callback,
     show_time_range_options as _extracted_show_time_range_options,
 )
 from bot.handlers.media_extras_callbacks import (
@@ -101,8 +102,7 @@ async def handle_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
 
     if data.startswith("arc_"):
-        from bot.handlers.download_callbacks import handle_archive_callback
-        await handle_archive_callback(update, context, data)
+        await _extracted_handle_archive_callback(update, context, data)
         return
 
     if data.startswith("pl_"):

--- a/bot/telegram_callbacks.py
+++ b/bot/telegram_callbacks.py
@@ -57,6 +57,7 @@ from bot.handlers.transcription_callbacks import (
     show_summary_options as _extracted_show_summary_options,
     transcribe_audio_file as _extracted_transcribe_audio_file,
 )
+from bot.runtime import get_app_runtime
 from bot.security_policy import get_media_label, normalize_url
 from bot.security_throttling import check_rate_limit
 from bot.services.playlist_service import build_playlist_message, load_playlist
@@ -81,10 +82,15 @@ def _build_main_keyboard(platform: str, large_file: bool = False) -> list:
     return build_main_keyboard(platform, large_file=large_file)
 
 
-def _build_playlist_message(playlist_info: dict) -> tuple[str, InlineKeyboardMarkup]:
-    """Compatibility wrapper for playlist menu rendering."""
+def _build_playlist_message(playlist_info: dict, context=None) -> tuple[str, InlineKeyboardMarkup]:
+    """Compatibility wrapper for playlist menu rendering.
 
-    return build_playlist_message(playlist_info)
+    Resolves ``archive_available`` from the live runtime when ``context`` is
+    provided, so callers don't need to import ``bot.runtime`` themselves.
+    """
+    runtime = get_app_runtime(context) if context is not None else None
+    archive_available = runtime.archive_available if runtime is not None else False
+    return build_playlist_message(playlist_info, archive_available=archive_available)
 
 
 async def handle_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/bot/telegram_commands.py
+++ b/bot/telegram_commands.py
@@ -316,16 +316,12 @@ async def process_video_file(
     return await _extracted_process_video_file(update, context, video_info)
 
 
-async def stop_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """List running jobs in this chat with cancel buttons."""
+def _build_stop_list_message(descriptors: list) -> tuple[str, InlineKeyboardMarkup]:
+    """Build the /stop list text + keyboard from active job descriptors.
 
-    chat_id = update.effective_chat.id
-    descriptors = job_registry.list_for_chat(chat_id)
-
-    if not descriptors:
-        await update.effective_message.reply_text("Brak aktywnych operacji.")
-        return
-
+    Shared between the initial stop_command render and the stop_refresh
+    callback re-render.
+    """
     lines = [f"Aktywne operacje ({len(descriptors)}):", ""]
     keyboard_rows: list[list[InlineKeyboardButton]] = []
     for idx, descriptor in enumerate(descriptors, 1):
@@ -344,11 +340,21 @@ async def stop_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         InlineKeyboardButton("Odśwież", callback_data="stop_refresh"),
         InlineKeyboardButton("Anuluj listę", callback_data="stop_dismiss"),
     ])
+    return "\n".join(lines), InlineKeyboardMarkup(keyboard_rows)
 
-    await update.effective_message.reply_text(
-        "\n".join(lines),
-        reply_markup=InlineKeyboardMarkup(keyboard_rows),
-    )
+
+async def stop_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """List running jobs in this chat with cancel buttons."""
+
+    chat_id = update.effective_chat.id
+    descriptors = job_registry.list_for_chat(chat_id)
+
+    if not descriptors:
+        await update.effective_message.reply_text("Brak aktywnych operacji.")
+        return
+
+    text, keyboard = _build_stop_list_message(descriptors)
+    await update.effective_message.reply_text(text, reply_markup=keyboard)
 
 
 async def handle_stop_callback(update: Update, context: ContextTypes.DEFAULT_TYPE, data: str) -> None:
@@ -378,29 +384,9 @@ async def handle_stop_callback(update: Update, context: ContextTypes.DEFAULT_TYP
             except Exception:
                 pass
             return
-        lines = [f"Aktywne operacje ({len(descriptors)}):", ""]
-        keyboard_rows: list[list[InlineKeyboardButton]] = []
-        for idx, descriptor in enumerate(descriptors, 1):
-            age_min = max(
-                0,
-                int((datetime.now() - descriptor.started_at).total_seconds() // 60),
-            )
-            lines.append(f"{idx}. {descriptor.label} ({age_min} min)")
-            keyboard_rows.append([InlineKeyboardButton(
-                f"Zatrzymaj {idx}", callback_data=f"stop_{descriptor.job_id}",
-            )])
-        keyboard_rows.append([InlineKeyboardButton(
-            "Zatrzymaj wszystkie", callback_data="stop_all",
-        )])
-        keyboard_rows.append([
-            InlineKeyboardButton("Odśwież", callback_data="stop_refresh"),
-            InlineKeyboardButton("Anuluj listę", callback_data="stop_dismiss"),
-        ])
+        text, keyboard = _build_stop_list_message(descriptors)
         try:
-            await update.callback_query.edit_message_text(
-                "\n".join(lines),
-                reply_markup=InlineKeyboardMarkup(keyboard_rows),
-            )
+            await update.callback_query.edit_message_text(text, reply_markup=keyboard)
         except Exception:
             pass
         return

--- a/bot/telegram_commands.py
+++ b/bot/telegram_commands.py
@@ -346,6 +346,13 @@ def _build_stop_list_message(descriptors: list) -> tuple[str, InlineKeyboardMark
 async def stop_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """List running jobs in this chat with cancel buttons."""
 
+    user_id = update.effective_user.id
+    if not _is_authorized(context, user_id):
+        await update.effective_message.reply_text(
+            "Brak autoryzacji. Użyj /start aby się zalogować."
+        )
+        return
+
     chat_id = update.effective_chat.id
     descriptors = job_registry.list_for_chat(chat_id)
 

--- a/bot/telegram_commands.py
+++ b/bot/telegram_commands.py
@@ -8,9 +8,12 @@ feature logic to the extracted handler modules.
 from __future__ import annotations
 
 import subprocess
+from datetime import datetime
 
-from telegram import InlineKeyboardMarkup, Update
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
+
+from bot.jobs import job_registry
 
 from bot.cleanup import cleanup_old_files, get_disk_usage
 from bot.config import DOWNLOAD_PATH, get_download_stats, get_runtime_value
@@ -311,3 +314,112 @@ async def process_video_file(
 ):
     _sync_inbound_media_dependencies()
     return await _extracted_process_video_file(update, context, video_info)
+
+
+async def stop_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """List running jobs in this chat with cancel buttons."""
+
+    chat_id = update.effective_chat.id
+    descriptors = job_registry.list_for_chat(chat_id)
+
+    if not descriptors:
+        await update.effective_message.reply_text("Brak aktywnych operacji.")
+        return
+
+    lines = [f"Aktywne operacje ({len(descriptors)}):", ""]
+    keyboard_rows: list[list[InlineKeyboardButton]] = []
+    for idx, descriptor in enumerate(descriptors, 1):
+        age_min = max(
+            0,
+            int((datetime.now() - descriptor.started_at).total_seconds() // 60),
+        )
+        lines.append(f"{idx}. {descriptor.label} ({age_min} min)")
+        keyboard_rows.append([InlineKeyboardButton(
+            f"Zatrzymaj {idx}", callback_data=f"stop_{descriptor.job_id}",
+        )])
+    keyboard_rows.append([InlineKeyboardButton(
+        "Zatrzymaj wszystkie", callback_data="stop_all",
+    )])
+    keyboard_rows.append([
+        InlineKeyboardButton("Odśwież", callback_data="stop_refresh"),
+        InlineKeyboardButton("Anuluj listę", callback_data="stop_dismiss"),
+    ])
+
+    await update.effective_message.reply_text(
+        "\n".join(lines),
+        reply_markup=InlineKeyboardMarkup(keyboard_rows),
+    )
+
+
+async def handle_stop_callback(update: Update, context: ContextTypes.DEFAULT_TYPE, data: str) -> None:
+    """Dispatch stop_<id>, stop_all, stop_refresh, stop_dismiss."""
+
+    chat_id = update.effective_chat.id
+
+    if data == "stop_all":
+        descriptors = job_registry.list_for_chat(chat_id)
+        cancelled = 0
+        for descriptor in descriptors:
+            if await job_registry.cancel_async(descriptor.job_id, "user via /stop"):
+                cancelled += 1
+        try:
+            await update.callback_query.edit_message_text(
+                f"Wysłano sygnał zatrzymania do {cancelled} operacji."
+            )
+        except Exception:
+            pass
+        return
+
+    if data == "stop_refresh":
+        descriptors = job_registry.list_for_chat(chat_id)
+        if not descriptors:
+            try:
+                await update.callback_query.edit_message_text("Brak aktywnych operacji.")
+            except Exception:
+                pass
+            return
+        lines = [f"Aktywne operacje ({len(descriptors)}):", ""]
+        keyboard_rows: list[list[InlineKeyboardButton]] = []
+        for idx, descriptor in enumerate(descriptors, 1):
+            age_min = max(
+                0,
+                int((datetime.now() - descriptor.started_at).total_seconds() // 60),
+            )
+            lines.append(f"{idx}. {descriptor.label} ({age_min} min)")
+            keyboard_rows.append([InlineKeyboardButton(
+                f"Zatrzymaj {idx}", callback_data=f"stop_{descriptor.job_id}",
+            )])
+        keyboard_rows.append([InlineKeyboardButton(
+            "Zatrzymaj wszystkie", callback_data="stop_all",
+        )])
+        keyboard_rows.append([
+            InlineKeyboardButton("Odśwież", callback_data="stop_refresh"),
+            InlineKeyboardButton("Anuluj listę", callback_data="stop_dismiss"),
+        ])
+        try:
+            await update.callback_query.edit_message_text(
+                "\n".join(lines),
+                reply_markup=InlineKeyboardMarkup(keyboard_rows),
+            )
+        except Exception:
+            pass
+        return
+
+    if data == "stop_dismiss":
+        try:
+            await update.callback_query.edit_message_text("Lista zamknięta.")
+        except Exception:
+            pass
+        return
+
+    if data.startswith("stop_"):
+        job_id = data[len("stop_"):]
+        ok = await job_registry.cancel_async(job_id, reason="user via /stop")
+        text = (
+            "Wysłano sygnał zatrzymania. Czekam na potwierdzenie..."
+            if ok else "Operacja już zakończona."
+        )
+        try:
+            await update.callback_query.edit_message_text(text)
+        except Exception:
+            pass

--- a/bot/telegram_commands.py
+++ b/bot/telegram_commands.py
@@ -240,8 +240,15 @@ async def handle_youtube_link(update: Update, context: ContextTypes.DEFAULT_TYPE
     return await _extracted_handle_youtube_link(update, context)
 
 
-def _build_playlist_message(playlist_info: dict) -> tuple[str, InlineKeyboardMarkup]:
-    return build_playlist_message(playlist_info)
+def _build_playlist_message(playlist_info: dict, context=None) -> tuple[str, InlineKeyboardMarkup]:
+    """Compatibility wrapper for playlist menu rendering.
+
+    Resolves ``archive_available`` from the live runtime when ``context`` is
+    provided, so callers don't need to import ``bot.runtime`` themselves.
+    """
+    runtime = get_app_runtime(context) if context is not None else None
+    archive_available = runtime.archive_available if runtime is not None else False
+    return build_playlist_message(playlist_info, archive_available=archive_available)
 
 
 async def process_playlist_link(update: Update, context: ContextTypes.DEFAULT_TYPE, url):

--- a/bot/transcription_pipeline.py
+++ b/bot/transcription_pipeline.py
@@ -6,6 +6,10 @@ import logging
 import os
 import shutil
 import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bot.jobs import JobCancellation
 
 from bot.transcription_chunking import get_part_number, split_mp3
 from bot.transcription_limits import estimate_token_count, is_text_too_long_for_correction
@@ -23,6 +27,7 @@ def transcribe_mp3_file(
     progress_callback=None,
     language=None,
     *,
+    cancellation: "JobCancellation | None" = None,
     get_api_key_fn=get_api_key,
     get_claude_api_key_fn=get_claude_api_key,
     split_mp3_fn=split_mp3,
@@ -33,7 +38,11 @@ def transcribe_mp3_file(
     is_text_too_long_for_correction_fn=is_text_too_long_for_correction,
     rmtree_fn=shutil.rmtree,
 ):
-    """Transcribe an MP3 file, splitting and post-processing when needed."""
+    """Transcribe an MP3 file, splitting and post-processing when needed.
+
+    When ``cancellation.event`` becomes set between chunks, processing
+    stops and the function returns None (no transcription text).
+    """
 
     api_key = get_api_key_fn()
     if not api_key:
@@ -60,6 +69,10 @@ def transcribe_mp3_file(
     logging.info("Found %s part files to transcribe.", total_parts)
 
     for index, part_path in enumerate(part_files):
+        if cancellation is not None and cancellation.event.is_set():
+            logging.info("Transcription cancelled before part %s", index + 1)
+            return None
+
         part_num = index + 1
         part_size_mb = os.path.getsize(part_path) / (1024 * 1024)
         logging.info("Transcribing file %s/%s: %s", part_num, total_parts, part_path)

--- a/docs/superpowers/plans/2026-05-02-playlist-zip-download-plan.md
+++ b/docs/superpowers/plans/2026-05-02-playlist-zip-download-plan.md
@@ -1,0 +1,3167 @@
+# Plan implementacji: Tryb „pobierz playlistę / duży plik jako 7z"
+
+> **Dla agentic worker:** WYMAGANY SUB-SKILL — `superpowers:subagent-driven-development` (rekomendowany) lub `superpowers:executing-plans`. Kroki używają składni checkbox `- [ ]`.
+
+**Cel:** Dodać do bota Telegram (`/mnt/c/code/ytdown`) tryb pobrania całej playlisty YouTube / pojedynczego dużego pliku jako multi-volume archiwum 7z, mieszczące się w limicie wysyłki Telegrama (1900 MB z MTProto, 49 MB bez).
+
+**Architektura:** Niskopoziomowy wrapper na `7z` CLI (`bot/archive.py`) odseparowany od warstwy Telegrama. Serwis orkiestracji (`bot/services/archive_service.py`) łączy pobieranie, pakowanie, wysyłkę wolumenów i obsługę retry/purge. UI: dodatkowe przyciski „… jako 7z" w menu playlisty + fallback `[Wyślij jako 7z] [Anuluj]` dla pojedynczych plików > limit.
+
+**Tech Stack:** Python 3.11+, `asyncio.create_subprocess_exec`, `7z` (p7zip-full 26.00) — już zainstalowany, `pyrogram` (już używane), `python-telegram-bot`, `pytest` + `pytest-asyncio` (jeśli istnieje, inaczej `unittest.mock.AsyncMock`).
+
+**Branża:** wszystkie taski commitujemy bezpośrednio na `develop` (zgodnie z polityką repo: nigdy direct na `main`, zawsze `develop` → PR).
+
+**Spec referencyjny:** `docs/superpowers/specs/2026-05-02-playlist-zip-download-design.md` (commit `cc53dad`).
+
+---
+
+## Mapa plików
+
+| Plik | Akcja | Odpowiedzialność |
+|---|---|---|
+| `bot/security_limits.py` | modify | Nowe stałe rozmiarów wolumenów + retencja. |
+| `bot/archive.py` | **create** | Wrapper na `7z` CLI: helpers + `pack_to_volumes`. |
+| `bot/mtproto.py` | modify | Dodać `send_document_mtproto`. |
+| `bot/session_store.py` | modify | Pola `pending_archive_jobs`, `archived_deliveries` + mapy. |
+| `bot/services/archive_service.py` | **create** | Orkiestracja: workspace → download → pack → send. |
+| `bot/services/playlist_service.py` | modify | Parser callback + nowe przyciski. |
+| `bot/handlers/playlist_callbacks.py` | modify | Dispatch dla `pl_zip_dl_*`. |
+| `bot/handlers/download_callbacks.py` | modify | Dispatch dla `arc_*` + fallback po pobraniu. |
+| `bot/runtime.py` | modify | Flag `archive_available` w `AppRuntime`. |
+| `bot/cleanup.py` | modify | Cleanup workspace’ów `pl_*`/`big_*` i pending jobs. |
+| `tests/test_archive.py` | **create** | Unit + 1 integration test dla `bot/archive.py`. |
+| `tests/test_archive_service.py` | **create** | Unit dla `bot/services/archive_service.py`. |
+| `tests/test_playlist_service.py` | modify | Testy parsera + nowych przycisków. |
+| `tests/test_callback_download_handlers.py` | modify | Testy `arc_*` i fallback po pobraniu. |
+| `tests/test_playlist.py` | modify | Test handler-level: `pl_zip_dl_*` deleguje. |
+| `tests/test_cleanup.py` | modify | Testy purge workspace’ów + pending jobs. |
+| `tests/test_mtproto.py` | modify | Testy `send_document_mtproto`. |
+
+---
+
+## Task 1: Stałe w `bot/security_limits.py`
+
+**Files:**
+- Modify: `bot/security_limits.py`
+- Test: `tests/test_security_unit.py`
+
+- [ ] **Step 1.1: Dodać failing test dla obecności i typów stałych**
+
+Dopisz na końcu `tests/test_security_unit.py`:
+
+```python
+def test_archive_volume_size_constants_defined():
+    from bot import security_limits
+
+    assert security_limits.MTPROTO_VOLUME_SIZE_MB == 1900
+    assert security_limits.BOTAPI_VOLUME_SIZE_MB == 49
+    assert security_limits.BOTAPI_VOLUME_SIZE_MB < security_limits.TELEGRAM_UPLOAD_LIMIT_MB
+
+
+def test_archive_item_size_limit_defined():
+    from bot import security_limits
+
+    assert security_limits.MAX_ARCHIVE_ITEM_SIZE_MB == 10240
+    assert security_limits.MAX_ARCHIVE_ITEM_SIZE_MB > security_limits.MAX_FILE_SIZE_MB
+
+
+def test_playlist_archive_retention_defined():
+    from bot import security_limits
+
+    assert security_limits.PLAYLIST_ARCHIVE_RETENTION_MIN == 60
+```
+
+- [ ] **Step 1.2: Uruchomić test — oczekiwany FAIL (`AttributeError`)**
+
+```bash
+source /home/pi/venv/bin/activate
+pytest tests/test_security_unit.py::test_archive_volume_size_constants_defined -v
+```
+
+Oczekiwany wynik: `AttributeError: module 'bot.security_limits' has no attribute 'MTPROTO_VOLUME_SIZE_MB'`.
+
+- [ ] **Step 1.3: Dodać stałe w `bot/security_limits.py`**
+
+Dopisz na końcu `bot/security_limits.py`:
+
+```python
+# Maximum number of playlist items to download (default / expanded)
+MAX_PLAYLIST_ITEMS = 10
+MAX_PLAYLIST_ITEMS_EXPANDED = 50
+
+# 7z archive volume size depending on transport.
+# MTProto bot upload caps single message at ~2 GB; we leave 100 MB margin
+# for 7z header overhead and per-message metadata.
+MTPROTO_VOLUME_SIZE_MB = 1900
+
+# Bot API upload caps at 50 MB; 49 MB volume keeps slack for the wrapper.
+BOTAPI_VOLUME_SIZE_MB = 49
+
+# Per-item size cap for playlist archive mode. Playlist 7z mode allows
+# items larger than MAX_FILE_SIZE_MB because the file never has to fit a
+# single Telegram message — it will be split into volumes.
+MAX_ARCHIVE_ITEM_SIZE_MB = 10240
+
+# How long workspaces (pl_*/big_*) and pending archive jobs survive
+# after success, so the user can resend a single failed volume without
+# having to re-download the whole playlist.
+PLAYLIST_ARCHIVE_RETENTION_MIN = 60
+```
+
+(Pierwsze dwa wpisy — `MAX_PLAYLIST_ITEMS` / `MAX_PLAYLIST_ITEMS_EXPANDED` — już istnieją w pliku; zachowaj je niezmienione, dopisz nowe stałe poniżej.)
+
+- [ ] **Step 1.4: Uruchomić testy ponownie — oczekiwany PASS**
+
+```bash
+pytest tests/test_security_unit.py -v
+```
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add bot/security_limits.py tests/test_security_unit.py
+git commit -m "Add archive size and retention constants for 7z mode"
+```
+
+---
+
+## Task 2: Helper-y w `bot/archive.py` (volume_size_for, transliteracja, basename, detekcja 7z)
+
+**Files:**
+- Create: `bot/archive.py`
+- Test: `tests/test_archive.py` (create)
+
+- [ ] **Step 2.1: Utworzyć `tests/test_archive.py` z failing testami**
+
+```python
+"""Unit tests for bot.archive low-level helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest import mock
+
+import pytest
+
+
+def test_volume_size_for_mtproto_returns_mtproto_constant():
+    from bot import archive
+    from bot.security_limits import MTPROTO_VOLUME_SIZE_MB
+
+    assert archive.volume_size_for(use_mtproto=True) == MTPROTO_VOLUME_SIZE_MB
+
+
+def test_volume_size_for_botapi_returns_botapi_constant():
+    from bot import archive
+    from bot.security_limits import BOTAPI_VOLUME_SIZE_MB
+
+    assert archive.volume_size_for(use_mtproto=False) == BOTAPI_VOLUME_SIZE_MB
+
+
+def test_transliterate_to_ascii_replaces_polish_letters():
+    from bot.archive import transliterate_to_ascii
+
+    assert transliterate_to_ascii("Pączki ąęłżźćń") == "Paczki aelzzcn"
+
+
+def test_transliterate_to_ascii_preserves_safe_characters():
+    from bot.archive import transliterate_to_ascii
+
+    assert transliterate_to_ascii("Hello world - 2026!") == "Hello world - 2026!"
+
+
+def test_transliterate_to_ascii_handles_uppercase():
+    from bot.archive import transliterate_to_ascii
+
+    assert transliterate_to_ascii("ŻÓŁW") == "ZOLW"
+
+
+def test_compute_archive_basename_format():
+    from bot.archive import compute_archive_basename
+
+    ts = datetime(2026, 5, 2, 14, 5, 33)
+    assert compute_archive_basename("playlist", ts) == "playlist_20260502-140533"
+
+
+def test_is_7z_available_when_present():
+    from bot import archive
+
+    with mock.patch("bot.archive.shutil.which", return_value="/usr/bin/7z"):
+        assert archive.is_7z_available() is True
+
+
+def test_is_7z_available_when_absent():
+    from bot import archive
+
+    with mock.patch("bot.archive.shutil.which", return_value=None):
+        assert archive.is_7z_available() is False
+```
+
+- [ ] **Step 2.2: Uruchomić testy — oczekiwany FAIL (brak modułu)**
+
+```bash
+pytest tests/test_archive.py -v
+```
+
+Oczekiwany: `ModuleNotFoundError: No module named 'bot.archive'`.
+
+- [ ] **Step 2.3: Utworzyć `bot/archive.py` z helperami**
+
+```python
+"""Low-level wrapper around the system 7z binary.
+
+This module knows nothing about Telegram, sessions, or downloads. It only
+shells out to 7z, normalizes its output, and exposes a few naming/sizing
+helpers used by bot.services.archive_service.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import unicodedata
+from datetime import datetime
+from pathlib import Path
+
+from bot.security_limits import BOTAPI_VOLUME_SIZE_MB, MTPROTO_VOLUME_SIZE_MB
+
+
+def volume_size_for(use_mtproto: bool) -> int:
+    """Volume size for 7z multi-volume archives, in MiB.
+
+    MTProto allows ~2 GB per message, Bot API caps at 50 MB; we leave a
+    margin in both cases so the resulting volume always slots in.
+    """
+
+    return MTPROTO_VOLUME_SIZE_MB if use_mtproto else BOTAPI_VOLUME_SIZE_MB
+
+
+def transliterate_to_ascii(text: str) -> str:
+    """Best-effort ASCII transliteration of Polish/diacritic characters.
+
+    NFKD decomposes characters like 'ą' into 'a' + combining ogonek, and
+    we drop the combining marks. The handful of Polish letters that NFKD
+    does not decompose (notably 'ł' / 'Ł') are mapped explicitly.
+    Used for naming 7z volumes shipped to a Windows host.
+    """
+
+    explicit_map = {
+        "ł": "l",
+        "Ł": "L",
+    }
+    translated = "".join(explicit_map.get(ch, ch) for ch in text)
+    decomposed = unicodedata.normalize("NFKD", translated)
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+
+
+def compute_archive_basename(slug: str, ts: datetime) -> str:
+    """Deterministic prefix for archive volumes: <slug>_<YYYYMMDD-HHMMSS>."""
+
+    return f"{slug}_{ts.strftime('%Y%m%d-%H%M%S')}"
+
+
+def is_7z_available() -> bool:
+    """Return True when the 7z binary is present in PATH."""
+
+    return shutil.which("7z") is not None
+```
+
+- [ ] **Step 2.4: Uruchomić testy ponownie — oczekiwany PASS**
+
+```bash
+pytest tests/test_archive.py -v
+```
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add bot/archive.py tests/test_archive.py
+git commit -m "Add archive helpers: volume sizing, ASCII translit, basename, 7z detection"
+```
+
+---
+
+## Task 3: `pack_to_volumes` w `bot/archive.py`
+
+**Files:**
+- Modify: `bot/archive.py`
+- Test: `tests/test_archive.py` (extend)
+
+- [ ] **Step 3.1: Dodać failing testy dla `pack_to_volumes`**
+
+Dopisz w `tests/test_archive.py`:
+
+```python
+import asyncio
+
+
+def test_pack_to_volumes_raises_on_empty_sources():
+    from bot.archive import pack_to_volumes
+
+    with pytest.raises(ValueError, match="empty sources"):
+        asyncio.run(pack_to_volumes([], Path("/tmp/x"), volume_size_mb=10))
+
+
+def test_pack_to_volumes_invokes_7z_with_correct_args(tmp_path):
+    from bot import archive
+
+    src1 = tmp_path / "a.bin"
+    src1.write_bytes(b"x")
+    src2 = tmp_path / "b.bin"
+    src2.write_bytes(b"y")
+    dest = tmp_path / "out_archive"
+
+    completed = mock.AsyncMock()
+    completed.communicate = mock.AsyncMock(return_value=(b"", b""))
+    completed.returncode = 0
+
+    captured: dict = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["args"] = args
+        # Simulate 7z producing two volumes.
+        (tmp_path / "out_archive.7z.001").write_bytes(b"a")
+        (tmp_path / "out_archive.7z.002").write_bytes(b"b")
+        return completed
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        result = asyncio.run(
+            archive.pack_to_volumes([src1, src2], dest, volume_size_mb=42)
+        )
+
+    assert captured["args"][:6] == (
+        "7z",
+        "a",
+        "-t7z",
+        "-v42m",
+        "-mx0",
+        "-mmt=on",
+    )
+    assert str(dest.with_suffix(".7z")) in captured["args"]
+    assert str(src1) in captured["args"]
+    assert str(src2) in captured["args"]
+    assert result == [tmp_path / "out_archive.7z.001", tmp_path / "out_archive.7z.002"]
+
+
+def test_pack_to_volumes_returns_sorted_volume_paths(tmp_path):
+    from bot import archive
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+    dest = tmp_path / "playlist"
+
+    completed = mock.AsyncMock()
+    completed.communicate = mock.AsyncMock(return_value=(b"", b""))
+    completed.returncode = 0
+
+    async def fake_exec(*args, **kwargs):
+        # Volumes intentionally created out of order on disk.
+        for i in (3, 1, 2):
+            (tmp_path / f"playlist.7z.00{i}").write_bytes(b"z")
+        return completed
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        result = asyncio.run(archive.pack_to_volumes([src], dest, volume_size_mb=10))
+
+    assert [p.name for p in result] == [
+        "playlist.7z.001",
+        "playlist.7z.002",
+        "playlist.7z.003",
+    ]
+
+
+def test_pack_to_volumes_raises_when_7z_exits_nonzero(tmp_path):
+    from bot import archive
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+
+    completed = mock.AsyncMock()
+    completed.communicate = mock.AsyncMock(return_value=(b"", b"E_NO_DISK_SPACE\n"))
+    completed.returncode = 2
+
+    async def fake_exec(*args, **kwargs):
+        return completed
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        with pytest.raises(RuntimeError, match="7z failed"):
+            asyncio.run(
+                archive.pack_to_volumes([src], tmp_path / "x", volume_size_mb=1)
+            )
+
+
+def test_pack_to_volumes_real_7z_small_volumes(tmp_path):
+    """Integration test: spawn the real 7z binary on a small file."""
+
+    import shutil as _shutil
+    if _shutil.which("7z") is None:
+        pytest.skip("7z binary not available on this host")
+
+    from bot import archive
+
+    src = tmp_path / "data.bin"
+    # 3 MB content, with -v1m volumes -> at least 3 volumes.
+    src.write_bytes(b"Z" * (3 * 1024 * 1024))
+    dest = tmp_path / "intg"
+
+    result = asyncio.run(archive.pack_to_volumes([src], dest, volume_size_mb=1))
+
+    assert len(result) >= 3
+    assert all(p.exists() for p in result)
+    assert all(p.name.startswith("intg.7z.") for p in result)
+```
+
+- [ ] **Step 3.2: Uruchomić testy — oczekiwany FAIL (`AttributeError: pack_to_volumes`)**
+
+```bash
+pytest tests/test_archive.py -v -k "pack_to_volumes"
+```
+
+- [ ] **Step 3.3: Implementacja `pack_to_volumes`**
+
+Dopisz w `bot/archive.py`:
+
+```python
+import asyncio
+from typing import Awaitable, Callable, Sequence
+
+
+async def pack_to_volumes(
+    sources: Sequence[Path],
+    dest_basename: Path,
+    volume_size_mb: int,
+    *,
+    progress_cb: Callable[[str], Awaitable[None]] | None = None,
+) -> list[Path]:
+    """Pack ``sources`` into a 7z multi-volume archive at ``dest_basename``.
+
+    Resulting volumes are named ``<dest_basename>.7z.001``, ``.002`` etc.
+    Returns the sorted list of created volume paths.
+
+    The 7z process is invoked with ``-t7z -v<size>m -mx0 -mmt=on`` because:
+    - the inputs are already-compressed media (mp3/mp4/m4a), so further
+      compression buys nothing while costing significant CPU,
+    - multi-threading speeds the I/O-bound packing on multi-core hosts.
+
+    Raises:
+        ValueError: when ``sources`` is empty.
+        RuntimeError: when 7z exits with a non-zero status.
+    """
+
+    if not sources:
+        raise ValueError("empty sources")
+
+    archive_path = dest_basename.with_suffix(".7z")
+    args = [
+        "7z",
+        "a",
+        "-t7z",
+        f"-v{volume_size_mb}m",
+        "-mx0",
+        "-mmt=on",
+        str(archive_path),
+        *[str(src) for src in sources],
+    ]
+
+    logging.info("Running 7z pack: %s", " ".join(args))
+    process = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    if progress_cb is not None:
+        await _stream_7z_progress(process, progress_cb)
+
+    stdout, stderr = await process.communicate()
+    if process.returncode != 0:
+        err = stderr.decode("utf-8", errors="replace")[:200]
+        raise RuntimeError(f"7z failed (exit {process.returncode}): {err}")
+
+    parent = dest_basename.parent
+    prefix = f"{archive_path.name}."
+    volumes = sorted(
+        p for p in parent.iterdir()
+        if p.name.startswith(prefix) and p.name[len(prefix):].isdigit()
+    )
+    logging.info("7z packed %d volume(s) for %s", len(volumes), archive_path)
+    return volumes
+
+
+async def _stream_7z_progress(
+    process: asyncio.subprocess.Process,
+    progress_cb: Callable[[str], Awaitable[None]],
+) -> None:
+    """Throttle 7z stdout updates to one progress_cb call every 2 seconds."""
+
+    if process.stdout is None:
+        return
+
+    last_update = 0.0
+    loop = asyncio.get_event_loop()
+    while True:
+        line = await process.stdout.readline()
+        if not line:
+            break
+        now = loop.time()
+        if now - last_update < 2.0:
+            continue
+        decoded = line.decode("utf-8", errors="replace").strip()
+        if decoded:
+            try:
+                await progress_cb(decoded)
+            except Exception as exc:  # progress is best-effort
+                logging.warning("Archive progress callback failed: %s", exc)
+            last_update = now
+```
+
+- [ ] **Step 3.4: Uruchomić testy — oczekiwany PASS (4 unit + 1 integration)**
+
+```bash
+pytest tests/test_archive.py -v
+```
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add bot/archive.py tests/test_archive.py
+git commit -m "Add async pack_to_volumes wrapper around 7z multi-volume packing"
+```
+
+---
+
+## Task 4: `send_document_mtproto` w `bot/mtproto.py`
+
+**Files:**
+- Modify: `bot/mtproto.py`
+- Test: `tests/test_mtproto.py` (extend)
+
+- [ ] **Step 4.1: Dodać failing testy do `tests/test_mtproto.py`**
+
+Dopisz na końcu istniejącego pliku:
+
+```python
+def test_send_document_mtproto_returns_false_without_pyrogram(monkeypatch):
+    from bot import mtproto
+
+    monkeypatch.setattr(
+        "builtins.__import__",
+        _make_blocked_import("pyrogram"),
+    )
+    result = asyncio.run(
+        mtproto.send_document_mtproto(123, "/tmp/x.bin", caption="x")
+    )
+    assert result is False
+
+
+def test_send_document_mtproto_returns_false_without_credentials(monkeypatch):
+    from bot import mtproto
+
+    monkeypatch.setattr(
+        mtproto, "get_runtime_value",
+        lambda key, default="": "",
+    )
+    result = asyncio.run(
+        mtproto.send_document_mtproto(123, "/tmp/x.bin", caption="x")
+    )
+    assert result is False
+
+
+def test_send_document_mtproto_returns_false_on_invalid_api_id(monkeypatch):
+    from bot import mtproto
+
+    values = {"TELEGRAM_API_ID": "not-a-number", "TELEGRAM_API_HASH": "abc"}
+    monkeypatch.setattr(
+        mtproto, "get_runtime_value",
+        lambda key, default="": values.get(key, default),
+    )
+    result = asyncio.run(
+        mtproto.send_document_mtproto(123, "/tmp/x.bin", caption="x")
+    )
+    assert result is False
+
+
+def test_send_document_mtproto_invokes_send_document(tmp_path, monkeypatch):
+    from bot import mtproto
+
+    src = tmp_path / "vol.7z.001"
+    src.write_bytes(b"x" * 1024)
+
+    values = {
+        "TELEGRAM_API_ID": "12345",
+        "TELEGRAM_API_HASH": "abc",
+        "TELEGRAM_BOT_TOKEN": "token",
+    }
+    monkeypatch.setattr(
+        mtproto, "get_runtime_value",
+        lambda key, default="": values.get(key, default),
+    )
+
+    captured: dict = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def send_document(self, **kwargs):
+            captured["send_kwargs"] = kwargs
+
+    monkeypatch.setattr(mtproto, "_build_client", lambda *a, **kw: FakeClient())
+
+    result = asyncio.run(
+        mtproto.send_document_mtproto(
+            chat_id=42,
+            file_path=str(src),
+            caption="part 1",
+            file_name="playlist.7z.001",
+        )
+    )
+
+    assert result is True
+    assert captured["send_kwargs"]["chat_id"] == 42
+    assert captured["send_kwargs"]["document"] == str(src)
+    assert captured["send_kwargs"]["caption"] == "part 1"
+    assert captured["send_kwargs"]["file_name"] == "playlist.7z.001"
+```
+
+Jeśli `_make_blocked_import` jeszcze nie istnieje w pliku, dopisz na górze (między importami):
+
+```python
+def _make_blocked_import(blocked: str):
+    real_import = __import__
+
+    def fake(name, *args, **kwargs):
+        if name == blocked or name.startswith(f"{blocked}."):
+            raise ImportError(f"blocked: {name}")
+        return real_import(name, *args, **kwargs)
+
+    return fake
+```
+
+(jeśli helper istnieje pod inną nazwą — użyj istniejącego.)
+
+- [ ] **Step 4.2: Uruchomić testy — oczekiwany FAIL (`AttributeError: send_document_mtproto`)**
+
+```bash
+pytest tests/test_mtproto.py -v -k "send_document_mtproto"
+```
+
+- [ ] **Step 4.3: Implementacja `send_document_mtproto` w `bot/mtproto.py`**
+
+Dopisz na końcu pliku, po `send_video_mtproto`:
+
+```python
+async def send_document_mtproto(
+    chat_id: int,
+    file_path: str,
+    caption: str | None = None,
+    file_name: str | None = None,
+) -> bool:
+    """Send a document file via MTProto (up to 2 GB).
+
+    Used to ship 7z volumes (.7z.001, ...) so Telegram does not try to
+    render them as media. ``file_name`` (when provided) overrides the
+    visible attachment name in the chat — useful when the on-disk path
+    contains a workspace prefix we don't want users to see.
+
+    Args:
+        chat_id: Destination chat ID.
+        file_path: Local path to the document.
+        caption: Optional message caption.
+        file_name: Optional override for the displayed filename.
+
+    Returns:
+        True on success, False on error.
+    """
+
+    try:
+        from pyrogram import Client  # noqa: F401
+    except ImportError:
+        logging.error("pyrogram not installed — cannot send large document")
+        return False
+
+    api_id = get_runtime_value("TELEGRAM_API_ID", "")
+    api_hash = get_runtime_value("TELEGRAM_API_HASH", "")
+    if not api_id or not api_hash:
+        logging.error("TELEGRAM_API_ID/TELEGRAM_API_HASH not configured")
+        return False
+
+    api_id_int = _parse_api_id(api_id)
+    if api_id_int is None:
+        return False
+
+    client = _build_client(chat_id, "send_document", api_id_int, api_hash)
+
+    try:
+        async with client:
+            send_kwargs: dict = {
+                "chat_id": chat_id,
+                "document": file_path,
+                "caption": caption,
+            }
+            if file_name is not None:
+                send_kwargs["file_name"] = file_name
+            await client.send_document(**send_kwargs)
+            file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
+            logging.info(
+                "MTProto send_document OK: %s (%.1f MB) to chat %d",
+                os.path.basename(file_path), file_size_mb, chat_id,
+            )
+            return True
+    except Exception as e:
+        logging.error("MTProto send_document failed: %s", e)
+        return False
+```
+
+- [ ] **Step 4.4: Uruchomić testy — oczekiwany PASS**
+
+```bash
+pytest tests/test_mtproto.py -v
+```
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add bot/mtproto.py tests/test_mtproto.py
+git commit -m "Add send_document_mtproto for shipping 7z volumes via pyrogram"
+```
+
+---
+
+## Task 5: Stany sesji w `bot/session_store.py`
+
+**Files:**
+- Modify: `bot/session_store.py`
+- Test: `tests/test_session_store.py` (extend)
+
+- [ ] **Step 5.1: Dodać failing testy**
+
+Dopisz w `tests/test_session_store.py`:
+
+```python
+def test_pending_archive_jobs_field_is_independent_per_chat():
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+    from datetime import datetime
+    from pathlib import Path
+
+    session_store.reset()
+    state_a = ArchiveJobState(
+        file_path=Path("/tmp/a.mp4"),
+        title="A",
+        media_type="video",
+        format_choice="best",
+        file_size_mb=12.0,
+        use_mtproto=False,
+        created_at=datetime(2026, 5, 2, 12, 0, 0),
+    )
+    pending_archive_jobs[111] = {"tok-a": state_a}
+
+    state_b = ArchiveJobState(
+        file_path=Path("/tmp/b.mp4"),
+        title="B",
+        media_type="video",
+        format_choice="best",
+        file_size_mb=15.0,
+        use_mtproto=False,
+        created_at=datetime(2026, 5, 2, 12, 1, 0),
+    )
+    pending_archive_jobs[222] = {"tok-b": state_b}
+
+    assert pending_archive_jobs[111] == {"tok-a": state_a}
+    assert pending_archive_jobs[222] == {"tok-b": state_b}
+    session_store.reset()
+
+
+def test_archived_deliveries_field_holds_volume_state():
+    from bot.session_store import (
+        ArchivedDeliveryState,
+        archived_deliveries,
+        session_store,
+    )
+    from datetime import datetime
+    from pathlib import Path
+
+    session_store.reset()
+    delivery = ArchivedDeliveryState(
+        workspace=Path("/tmp/pl_ws"),
+        volumes=[Path("/tmp/pl_ws/x.7z.001"), Path("/tmp/pl_ws/x.7z.002")],
+        caption_prefix="My playlist",
+        use_mtproto=True,
+        created_at=datetime(2026, 5, 2, 12, 30, 0),
+    )
+    archived_deliveries[42] = {"tok-z": delivery}
+
+    assert archived_deliveries[42] == {"tok-z": delivery}
+    session_store.reset()
+```
+
+- [ ] **Step 5.2: Uruchomić testy — oczekiwany FAIL (`ImportError`)**
+
+```bash
+pytest tests/test_session_store.py -v -k "archive"
+```
+
+- [ ] **Step 5.3: Dodać dataclass'y i pola w `bot/session_store.py`**
+
+Wstaw przed klasą `SessionState` (linia 12 obecnego pliku):
+
+```python
+@dataclass
+class ArchiveJobState:
+    """In-memory state for a single-file archive flow waiting for user choice.
+
+    Created when a downloaded file exceeds the active Telegram transport
+    limit; consumed by arc_split_<token> / arc_cancel_<token> callbacks.
+    """
+
+    file_path: Any  # pathlib.Path; Any avoids importing Path here
+    title: str
+    media_type: str
+    format_choice: str
+    file_size_mb: float
+    use_mtproto: bool
+    created_at: Any  # datetime
+
+
+@dataclass
+class ArchivedDeliveryState:
+    """In-memory state for a sent archive set, kept for retry/purge buttons."""
+
+    workspace: Any        # pathlib.Path
+    volumes: list[Any]    # list[Path]
+    caption_prefix: str
+    use_mtproto: bool
+    created_at: Any       # datetime
+```
+
+W `SessionState` dodaj dwa nowe pola (po `subtitle_pending`):
+
+```python
+    pending_archive_jobs: dict[str, "ArchiveJobState"] | None = None
+    archived_deliveries: dict[str, "ArchivedDeliveryState"] | None = None
+```
+
+W `_cleanup_if_empty` dopisz koniunkcyjnie nowe pola:
+
+```python
+            and session.subtitle_pending is None
+            and session.pending_archive_jobs is None
+            and session.archived_deliveries is None
+```
+
+Na końcu pliku, obok istniejących mapowań, dodaj:
+
+```python
+pending_archive_jobs = SessionFieldMap(session_store, "pending_archive_jobs")
+archived_deliveries = SessionFieldMap(session_store, "archived_deliveries")
+```
+
+- [ ] **Step 5.4: Uruchomić testy — oczekiwany PASS**
+
+```bash
+pytest tests/test_session_store.py -v
+```
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add bot/session_store.py tests/test_session_store.py
+git commit -m "Add ArchiveJobState and ArchivedDeliveryState session fields"
+```
+
+---
+
+## Task 6: `bot/services/archive_service.py` — workspace + token registry
+
+**Files:**
+- Create: `bot/services/archive_service.py`
+- Test: `tests/test_archive_service.py` (create)
+
+- [ ] **Step 6.1: Stworzyć `tests/test_archive_service.py` z failing testami**
+
+```python
+"""Unit tests for bot.services.archive_service workspace + registry helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+def test_prepare_playlist_workspace_creates_pl_prefixed_dir(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+    fixed_ts = datetime(2026, 5, 2, 9, 30, 15)
+    with mock.patch("bot.services.archive_service.datetime") as dt_mock:
+        dt_mock.now.return_value = fixed_ts
+        ws = archive_service.prepare_playlist_workspace(7, "Lista A")
+
+    assert ws.exists() and ws.is_dir()
+    assert ws.parent == tmp_path / "7"
+    assert ws.name.startswith("pl_")
+    assert "Lista_A" in ws.name or "Lista A" in ws.name
+    assert "20260502-093015" in ws.name
+
+
+def test_prepare_playlist_workspace_transliterates_polish_chars(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+    ws = archive_service.prepare_playlist_workspace(9, "Pączki ąęłż")
+
+    assert "Paczki" in ws.name
+    assert "ą" not in ws.name and "ł" not in ws.name
+
+
+def test_prepare_playlist_workspace_uses_big_prefix_when_requested(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+    ws = archive_service.prepare_playlist_workspace(1, "video", prefix="big")
+
+    assert ws.name.startswith("big_")
+
+
+def test_register_pending_archive_job_returns_unique_tokens(tmp_path):
+    from bot.services import archive_service
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+
+    session_store.reset()
+    state = ArchiveJobState(
+        file_path=Path(tmp_path / "x.mp4"),
+        title="t",
+        media_type="video",
+        format_choice="best",
+        file_size_mb=200.0,
+        use_mtproto=False,
+        created_at=datetime(2026, 5, 2),
+    )
+
+    tokens = {archive_service.register_pending_archive_job(99, state) for _ in range(50)}
+
+    assert len(tokens) == 50
+    assert pending_archive_jobs[99].keys() == tokens
+    session_store.reset()
+
+
+def test_register_archived_delivery_stores_state():
+    from bot.services import archive_service
+    from bot.session_store import (
+        ArchivedDeliveryState,
+        archived_deliveries,
+        session_store,
+    )
+
+    session_store.reset()
+    delivery = ArchivedDeliveryState(
+        workspace=Path("/tmp/pl_ws"),
+        volumes=[Path("/tmp/pl_ws/x.7z.001")],
+        caption_prefix="ABC",
+        use_mtproto=True,
+        created_at=datetime(2026, 5, 2),
+    )
+
+    token = archive_service.register_archived_delivery(11, delivery)
+
+    assert token in archived_deliveries[11]
+    assert archived_deliveries[11][token] is delivery
+    session_store.reset()
+```
+
+- [ ] **Step 6.2: Uruchomić — oczekiwany FAIL**
+
+```bash
+pytest tests/test_archive_service.py -v
+```
+
+- [ ] **Step 6.3: Stworzyć `bot/services/archive_service.py`**
+
+```python
+"""End-to-end orchestration for 7z archive flows (playlist + single-file).
+
+Boundaries:
+- ``bot.archive`` — pure 7z wrapper, no Telegram/session knowledge.
+- ``archive_service`` (this module) — knows about sessions, downloads,
+  Telegram bot client, and gluing them together.
+- ``bot.handlers.*`` — translate inline keyboard callbacks into calls
+  on this service, never call ``bot.archive`` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import shutil
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from bot.archive import compute_archive_basename, transliterate_to_ascii
+from bot.config import DOWNLOAD_PATH
+from bot.downloader_validation import sanitize_filename
+from bot.session_store import (
+    ArchiveJobState,
+    ArchivedDeliveryState,
+    archived_deliveries,
+    pending_archive_jobs,
+)
+
+
+_SLUG_MAX_LEN = 60
+
+
+def _build_slug(title: str) -> str:
+    """Translit-then-sanitize playlist/file title for use in filesystem path."""
+
+    transliterated = transliterate_to_ascii(title)
+    sanitized = sanitize_filename(transliterated)
+    cleaned = sanitized.replace(" ", "_")
+    return cleaned[:_SLUG_MAX_LEN] or "untitled"
+
+
+def prepare_playlist_workspace(
+    chat_id: int,
+    playlist_title: str,
+    *,
+    prefix: str = "pl",
+) -> Path:
+    """Create ``downloads/<chat_id>/<prefix>_<slug>_<ts>/`` and return it."""
+
+    slug = _build_slug(playlist_title)
+    basename = compute_archive_basename(slug, datetime.now())
+    chat_dir = Path(DOWNLOAD_PATH) / str(chat_id)
+    chat_dir.mkdir(parents=True, exist_ok=True)
+    workspace = chat_dir / f"{prefix}_{basename}"
+    workspace.mkdir(parents=True, exist_ok=True)
+    logging.info("Archive workspace ready: %s", workspace)
+    return workspace
+
+
+def register_pending_archive_job(chat_id: int, state: ArchiveJobState) -> str:
+    """Store a pending archive job and return the lookup token (8 hex chars)."""
+
+    token = secrets.token_hex(4)
+    bucket = pending_archive_jobs.get(chat_id) or {}
+    bucket[token] = state
+    pending_archive_jobs[chat_id] = bucket
+    return token
+
+
+def register_archived_delivery(chat_id: int, state: ArchivedDeliveryState) -> str:
+    """Store delivery metadata for retry/purge actions and return its token."""
+
+    token = secrets.token_hex(4)
+    bucket = archived_deliveries.get(chat_id) or {}
+    bucket[token] = state
+    archived_deliveries[chat_id] = bucket
+    return token
+```
+
+- [ ] **Step 6.4: Utworzyć (jeśli nie istnieje) `bot/services/__init__.py`** — istnieje (`tests/test_archive_service.py` poleci, `bot/services` ma `__init__.py`).
+
+- [ ] **Step 6.5: Uruchomić testy — oczekiwany PASS**
+
+```bash
+pytest tests/test_archive_service.py -v
+```
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add bot/services/archive_service.py tests/test_archive_service.py
+git commit -m "Add archive_service workspace creation and pending-job/delivery registries"
+```
+
+---
+
+## Task 7: `download_playlist_into` — pobieranie do workspace bez wysyłki
+
+**Files:**
+- Modify: `bot/services/archive_service.py`
+- Test: `tests/test_archive_service.py` (extend)
+
+- [ ] **Step 7.1: Dodać failing testy**
+
+```python
+def test_download_playlist_into_keeps_files_after_download(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    workspace = tmp_path / "pl_x"
+    workspace.mkdir()
+
+    async def fake_run(entry, workspace_path, *, media_type, format_choice, executor):
+        produced = workspace_path / f"{entry['title']}.bin"
+        produced.write_bytes(b"data")
+        return produced, 1.5  # path, size_mb
+
+    monkeypatch.setattr(archive_service, "_download_one_into_workspace", fake_run)
+
+    entries = [{"url": "u1", "title": "first"}, {"url": "u2", "title": "second"}]
+    import asyncio
+
+    paths, failed = asyncio.run(
+        archive_service.download_playlist_into(
+            workspace,
+            entries,
+            media_type="audio",
+            format_choice="mp3",
+            executor=mock.MagicMock(),
+            status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert {p.name for p in paths} == {"first.bin", "second.bin"}
+    assert failed == []
+    assert (workspace / "first.bin").exists()
+    assert (workspace / "second.bin").exists()
+
+
+def test_download_playlist_into_returns_empty_when_all_fail(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    workspace = tmp_path / "pl_x"
+    workspace.mkdir()
+
+    async def fake_run(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(archive_service, "_download_one_into_workspace", fake_run)
+
+    entries = [{"url": "u1", "title": "a"}, {"url": "u2", "title": "b"}]
+    import asyncio
+
+    paths, failed = asyncio.run(
+        archive_service.download_playlist_into(
+            workspace, entries, media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(), status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert paths == []
+    assert failed == ["a", "b"]
+
+
+def test_download_playlist_into_returns_failed_titles_on_partial(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    workspace = tmp_path / "pl_x"
+    workspace.mkdir()
+    call_count = {"n": 0}
+
+    async def fake_run(entry, workspace_path, **kwargs):
+        call_count["n"] += 1
+        if entry["title"] == "bad":
+            raise RuntimeError("fail")
+        produced = workspace_path / f"{entry['title']}.bin"
+        produced.write_bytes(b"x")
+        return produced, 0.5
+
+    monkeypatch.setattr(archive_service, "_download_one_into_workspace", fake_run)
+
+    entries = [
+        {"url": "u1", "title": "good1"},
+        {"url": "u2", "title": "bad"},
+        {"url": "u3", "title": "good2"},
+    ]
+    import asyncio
+
+    paths, failed = asyncio.run(
+        archive_service.download_playlist_into(
+            workspace, entries, media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(), status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert {p.name for p in paths} == {"good1.bin", "good2.bin"}
+    assert failed == ["bad"]
+
+
+def test_download_playlist_into_respects_max_archive_item_size(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    workspace = tmp_path / "pl_x"
+    workspace.mkdir()
+
+    async def fake_run(entry, workspace_path, **kwargs):
+        # Pretend the second entry is huge.
+        if entry["title"] == "huge":
+            return None, 99999.0  # too big
+        produced = workspace_path / f"{entry['title']}.bin"
+        produced.write_bytes(b"x")
+        return produced, 1.0
+
+    monkeypatch.setattr(archive_service, "_download_one_into_workspace", fake_run)
+
+    entries = [
+        {"url": "u1", "title": "ok"},
+        {"url": "u2", "title": "huge"},
+    ]
+    import asyncio
+
+    paths, failed = asyncio.run(
+        archive_service.download_playlist_into(
+            workspace, entries, media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(), status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert [p.name for p in paths] == ["ok.bin"]
+    assert any("huge" in title for title in failed)
+```
+
+- [ ] **Step 7.2: Uruchomić — oczekiwany FAIL**
+
+```bash
+pytest tests/test_archive_service.py -v -k "download_playlist_into"
+```
+
+- [ ] **Step 7.3: Implementacja**
+
+Dopisz w `bot/services/archive_service.py`:
+
+```python
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import Awaitable, Callable
+
+from bot.security_limits import MAX_ARCHIVE_ITEM_SIZE_MB
+from bot.services.download_service import (
+    ensure_size_within_limit,
+    estimate_download_size,
+    execute_download,
+    prepare_download_plan,
+)
+from bot.downloader_metadata import get_video_info  # used elsewhere; future hook
+
+
+async def _download_one_into_workspace(
+    entry: dict,
+    workspace: Path,
+    *,
+    media_type: str,
+    format_choice: str,
+    executor: ThreadPoolExecutor,
+) -> tuple[Path | None, float | None]:
+    """Download one playlist item into ``workspace``. Returns (path, size_mb).
+
+    On failure, ``path`` is None.
+    Size limit (MAX_ARCHIVE_ITEM_SIZE_MB) is enforced by the caller, but we
+    return the estimated size so the caller can decide what to do.
+    """
+
+    plan = prepare_download_plan(
+        url=entry["url"],
+        media_type=media_type,
+        format_choice=format_choice,
+        chat_download_path=str(workspace),
+    )
+    if plan is None:
+        raise RuntimeError(f"could not fetch metadata for {entry.get('title')}")
+
+    try:
+        estimated = estimate_download_size(plan)
+    except Exception:
+        estimated = None
+
+    if estimated is not None and not ensure_size_within_limit(
+        estimated, max_size_mb=MAX_ARCHIVE_ITEM_SIZE_MB
+    ):
+        return None, estimated
+
+    result = await execute_download(
+        plan,
+        chat_id=0,  # not used for progress reporting in archive flow
+        executor=executor,
+        progress_hook_factory=lambda _cid: (lambda _data: None),
+        progress_state={},
+        status_callback=_noop_status,
+        format_bytes=lambda v: str(v),
+        format_eta=lambda v: str(v),
+    )
+    return Path(result.file_path), result.file_size_mb
+
+
+async def _noop_status(_text: str) -> None:
+    return None
+
+
+async def download_playlist_into(
+    workspace: Path,
+    entries: list[dict],
+    *,
+    media_type: str,
+    format_choice: str,
+    executor: ThreadPoolExecutor,
+    status_cb: Callable[[str], Awaitable[None]],
+) -> tuple[list[Path], list[str]]:
+    """Download every entry into workspace, keeping the files (no os.remove).
+
+    Returns (downloaded_paths, failed_titles). Items exceeding the
+    MAX_ARCHIVE_ITEM_SIZE_MB cap are reported on failed_titles with a
+    ``(too large: X MB)`` suffix. Network failures are similarly recorded
+    with the original title.
+    """
+
+    downloaded: list[Path] = []
+    failed: list[str] = []
+    total = len(entries)
+
+    for idx, entry in enumerate(entries, 1):
+        title = entry.get("title", f"item_{idx}")
+        await status_cb(f"[{idx}/{total}] Pobieranie: {title}...")
+        try:
+            path, size = await _download_one_into_workspace(
+                entry,
+                workspace,
+                media_type=media_type,
+                format_choice=format_choice,
+                executor=executor,
+            )
+        except Exception as exc:
+            logging.error("Archive download failed for %s: %s", title, exc)
+            failed.append(title)
+            continue
+
+        if path is None:
+            mb_str = f"{size:.0f} MB" if size is not None else "?"
+            failed.append(f"{title} (za duzy: {mb_str})")
+            continue
+
+        downloaded.append(path)
+
+    return downloaded, failed
+```
+
+- [ ] **Step 7.4: Uruchomić — oczekiwany PASS**
+
+```bash
+pytest tests/test_archive_service.py -v
+```
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add bot/services/archive_service.py tests/test_archive_service.py
+git commit -m "Add download_playlist_into to keep files for archive packing"
+```
+
+---
+
+## Task 8: `send_volumes` — wysyłka wolumenów Bot API / MTProto
+
+**Files:**
+- Modify: `bot/services/archive_service.py`
+- Test: `tests/test_archive_service.py` (extend)
+
+- [ ] **Step 8.1: Dodać failing testy**
+
+```python
+def test_send_volumes_uses_botapi_for_small_volumes(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    v1 = tmp_path / "out.7z.001"
+    v1.write_bytes(b"x" * (10 * 1024 * 1024))  # 10 MB
+    v2 = tmp_path / "out.7z.002"
+    v2.write_bytes(b"x" * (5 * 1024 * 1024))   # 5 MB
+
+    bot = mock.MagicMock()
+    bot.send_document = mock.AsyncMock()
+
+    mtproto_calls = []
+
+    async def fake_mtproto(*args, **kwargs):
+        mtproto_calls.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr(archive_service, "send_document_mtproto", fake_mtproto)
+
+    import asyncio
+
+    asyncio.run(
+        archive_service.send_volumes(
+            bot,
+            chat_id=42,
+            volumes=[v1, v2],
+            caption_prefix="My playlist (audio mp3)",
+            use_mtproto=False,
+            status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert bot.send_document.await_count == 2
+    assert mtproto_calls == []
+    first_call = bot.send_document.await_args_list[0].kwargs
+    assert first_call["chat_id"] == 42
+    assert first_call["caption"] == "My playlist (audio mp3) [1/2]"
+
+
+def test_send_volumes_uses_mtproto_for_large_volumes(tmp_path, monkeypatch):
+    from bot.security_limits import TELEGRAM_UPLOAD_LIMIT_MB
+    from bot.services import archive_service
+
+    big = tmp_path / "out.7z.001"
+    big.write_bytes(b"x" * int((TELEGRAM_UPLOAD_LIMIT_MB + 5) * 1024 * 1024))
+
+    bot = mock.MagicMock()
+    bot.send_document = mock.AsyncMock()
+
+    mtproto_calls = []
+
+    async def fake_mtproto(chat_id, file_path, caption=None, file_name=None):
+        mtproto_calls.append((chat_id, file_path, caption, file_name))
+        return True
+
+    monkeypatch.setattr(archive_service, "send_document_mtproto", fake_mtproto)
+    monkeypatch.setattr(
+        archive_service, "mtproto_unavailability_reason", lambda: None
+    )
+
+    import asyncio
+
+    asyncio.run(
+        archive_service.send_volumes(
+            bot,
+            chat_id=42,
+            volumes=[big],
+            caption_prefix="X",
+            use_mtproto=True,
+            status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert bot.send_document.await_count == 0
+    assert len(mtproto_calls) == 1
+    assert mtproto_calls[0][0] == 42
+    assert mtproto_calls[0][3] == "out.7z.001"
+
+
+def test_send_volumes_raises_when_volume_too_large_and_no_mtproto(tmp_path, monkeypatch):
+    from bot.security_limits import TELEGRAM_UPLOAD_LIMIT_MB
+    from bot.services import archive_service
+
+    big = tmp_path / "out.7z.001"
+    big.write_bytes(b"x" * int((TELEGRAM_UPLOAD_LIMIT_MB + 5) * 1024 * 1024))
+
+    bot = mock.MagicMock()
+    bot.send_document = mock.AsyncMock()
+
+    monkeypatch.setattr(
+        archive_service, "mtproto_unavailability_reason",
+        lambda: "Skonfiguruj API_ID",
+    )
+
+    import asyncio
+
+    with pytest.raises(RuntimeError, match="MTProto"):
+        asyncio.run(
+            archive_service.send_volumes(
+                bot,
+                chat_id=42,
+                volumes=[big],
+                caption_prefix="X",
+                use_mtproto=False,
+                status_cb=mock.AsyncMock(),
+            )
+        )
+
+
+def test_send_volumes_resumes_from_start_index(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    v1 = tmp_path / "out.7z.001"
+    v1.write_bytes(b"x")
+    v2 = tmp_path / "out.7z.002"
+    v2.write_bytes(b"x")
+    v3 = tmp_path / "out.7z.003"
+    v3.write_bytes(b"x")
+
+    bot = mock.MagicMock()
+    bot.send_document = mock.AsyncMock()
+
+    import asyncio
+
+    asyncio.run(
+        archive_service.send_volumes(
+            bot,
+            chat_id=42,
+            volumes=[v1, v2, v3],
+            caption_prefix="X",
+            use_mtproto=False,
+            start_index=2,
+            status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert bot.send_document.await_count == 1
+    assert bot.send_document.await_args.kwargs["caption"] == "X [3/3]"
+```
+
+- [ ] **Step 8.2: Uruchomić — oczekiwany FAIL**
+
+```bash
+pytest tests/test_archive_service.py -v -k "send_volumes"
+```
+
+- [ ] **Step 8.3: Implementacja**
+
+Dopisz w `bot/services/archive_service.py`:
+
+```python
+from bot.mtproto import mtproto_unavailability_reason, send_document_mtproto
+from bot.security_limits import TELEGRAM_UPLOAD_LIMIT_MB
+
+
+async def send_volumes(
+    bot,
+    chat_id: int,
+    volumes: list[Path],
+    caption_prefix: str,
+    use_mtproto: bool,
+    *,
+    start_index: int = 0,
+    status_cb: Callable[[str], Awaitable[None]] | None = None,
+) -> None:
+    """Send 7z volumes [start_index:] to ``chat_id`` as documents.
+
+    Volumes ≤ TELEGRAM_UPLOAD_LIMIT_MB go via Bot API (``bot.send_document``);
+    larger ones go via MTProto. Caption per volume is
+    ``"<caption_prefix> [j/M]"``. The displayed file name is the volume's
+    original name (``<basename>.7z.001`` etc).
+
+    Raises:
+        RuntimeError: when a volume needs MTProto but it is unavailable, or
+            when MTProto sending returns False.
+    """
+
+    total = len(volumes)
+    for idx in range(start_index, total):
+        volume = volumes[idx]
+        size_mb = volume.stat().st_size / (1024 * 1024)
+        caption = f"{caption_prefix} [{idx + 1}/{total}]"
+        if status_cb is not None:
+            await status_cb(f"Wysyłanie [{idx + 1}/{total}] ({size_mb:.0f} MB)...")
+
+        if size_mb <= TELEGRAM_UPLOAD_LIMIT_MB:
+            with open(volume, "rb") as handle:
+                await bot.send_document(
+                    chat_id=chat_id,
+                    document=handle,
+                    filename=volume.name,
+                    caption=caption,
+                    read_timeout=120,
+                    write_timeout=120,
+                )
+        else:
+            reason = mtproto_unavailability_reason()
+            if reason is not None:
+                raise RuntimeError(
+                    f"Wolumen {volume.name} przekracza Bot API ({size_mb:.0f} MB), "
+                    f"a MTProto jest niedostępny: {reason}"
+                )
+            ok = await send_document_mtproto(
+                chat_id=chat_id,
+                file_path=str(volume),
+                caption=caption,
+                file_name=volume.name,
+            )
+            if not ok:
+                raise RuntimeError(f"Wysyłka {volume.name} przez MTProto nie powiodła się.")
+
+        logging.info("Sent volume %d/%d: %s (%.1f MB)", idx + 1, total, volume.name, size_mb)
+```
+
+(Parametr `use_mtproto` jest informacyjny dla wyższych warstw; sama decyzja transport-per-wolumen jest oparta o rozmiar.)
+
+- [ ] **Step 8.4: Uruchomić — oczekiwany PASS**
+
+```bash
+pytest tests/test_archive_service.py -v
+```
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add bot/services/archive_service.py tests/test_archive_service.py
+git commit -m "Add send_volumes with Bot API/MTProto routing per volume size"
+```
+
+---
+
+## Task 9: `execute_playlist_archive_flow` + `execute_single_file_archive_flow`
+
+**Files:**
+- Modify: `bot/services/archive_service.py`
+- Test: `tests/test_archive_service.py` (extend)
+
+- [ ] **Step 9.1: Dodać failing testy**
+
+```python
+def test_execute_playlist_archive_flow_happy_path(tmp_path, monkeypatch):
+    """Ensures the end-to-end flow chains workspace → download → pack → send."""
+    from bot.services import archive_service
+    from bot.session_store import session_store
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    async def fake_download_into(workspace, entries, **kwargs):
+        path1 = workspace / "a.mp3"
+        path1.write_bytes(b"a")
+        path2 = workspace / "b.mp3"
+        path2.write_bytes(b"b")
+        return [path1, path2], []
+
+    async def fake_pack(sources, dest_basename, volume_size_mb, **kwargs):
+        produced = dest_basename.parent / f"{dest_basename.with_suffix('.7z').name}.001"
+        produced.write_bytes(b"vol")
+        return [produced]
+
+    sent_volumes = []
+
+    async def fake_send_volumes(bot, chat_id, volumes, caption_prefix, use_mtproto, **kwargs):
+        sent_volumes.extend(volumes)
+
+    monkeypatch.setattr(archive_service, "download_playlist_into", fake_download_into)
+    monkeypatch.setattr(archive_service, "pack_to_volumes", fake_pack)
+    monkeypatch.setattr(archive_service, "send_volumes", fake_send_volumes)
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: None)
+
+    status = mock.AsyncMock()
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = status
+    context = mock.MagicMock()
+    context.bot = mock.MagicMock()
+
+    import asyncio
+
+    playlist = {"title": "Hits", "entries": [{"url": "u1", "title": "a"}]}
+
+    asyncio.run(
+        archive_service.execute_playlist_archive_flow(
+            update, context, chat_id=99, playlist=playlist,
+            media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(),
+        )
+    )
+
+    # One volume produced and shipped.
+    assert len(sent_volumes) == 1
+    # Workspace persists for retention.
+    assert any(p.name.startswith("pl_") for p in (tmp_path / "99").iterdir())
+    session_store.reset()
+
+
+def test_execute_playlist_archive_flow_aborts_when_no_items_succeed(tmp_path, monkeypatch):
+    from bot.services import archive_service
+    from bot.session_store import session_store
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    async def fake_download_into(workspace, entries, **kwargs):
+        return [], ["a", "b"]
+
+    pack_called = mock.AsyncMock()
+    monkeypatch.setattr(archive_service, "download_playlist_into", fake_download_into)
+    monkeypatch.setattr(archive_service, "pack_to_volumes", pack_called)
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    import asyncio
+
+    playlist = {"title": "Empty", "entries": [{"url": "u", "title": "a"}]}
+    asyncio.run(
+        archive_service.execute_playlist_archive_flow(
+            update, context, chat_id=99, playlist=playlist,
+            media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(),
+        )
+    )
+    assert pack_called.await_count == 0
+    # Workspace removed because everything failed.
+    chat_dir = tmp_path / "99"
+    assert not any(chat_dir.iterdir()) if chat_dir.exists() else True
+    session_store.reset()
+
+
+def test_execute_single_file_archive_flow_consumes_pending_job(tmp_path, monkeypatch):
+    from bot.services import archive_service
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    src = tmp_path / "input.mp4"
+    src.write_bytes(b"x")
+    state = ArchiveJobState(
+        file_path=src,
+        title="MyVid",
+        media_type="video",
+        format_choice="best",
+        file_size_mb=10.0,
+        use_mtproto=False,
+        created_at=datetime(2026, 5, 2),
+    )
+    token = archive_service.register_pending_archive_job(33, state)
+
+    async def fake_pack(sources, dest_basename, volume_size_mb, **kwargs):
+        produced = dest_basename.parent / f"{dest_basename.with_suffix('.7z').name}.001"
+        produced.write_bytes(b"v")
+        return [produced]
+
+    sent = []
+
+    async def fake_send_volumes(bot, chat_id, volumes, caption_prefix, use_mtproto, **kwargs):
+        sent.extend(volumes)
+
+    monkeypatch.setattr(archive_service, "pack_to_volumes", fake_pack)
+    monkeypatch.setattr(archive_service, "send_volumes", fake_send_volumes)
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+    context.bot = mock.MagicMock()
+
+    import asyncio
+
+    asyncio.run(
+        archive_service.execute_single_file_archive_flow(
+            update, context, chat_id=33, token=token,
+        )
+    )
+
+    # Pending job consumed.
+    assert pending_archive_jobs.get(33, {}).get(token) is None
+    # File migrated into workspace and a volume produced + sent.
+    assert len(sent) == 1
+    session_store.reset()
+```
+
+- [ ] **Step 9.2: Uruchomić — oczekiwany FAIL**
+
+```bash
+pytest tests/test_archive_service.py -v -k "execute_"
+```
+
+- [ ] **Step 9.3: Implementacja**
+
+Dopisz w `bot/services/archive_service.py`:
+
+```python
+from bot.archive import is_7z_available, pack_to_volumes, volume_size_for
+
+
+async def _safe_status_edit(update, text: str) -> None:
+    """Edit the inline-keyboard message body, ignoring 'message not modified' errors."""
+
+    try:
+        await update.callback_query.edit_message_text(text)
+    except Exception as exc:
+        logging.debug("status edit failed (non-fatal): %s", exc)
+
+
+async def execute_playlist_archive_flow(
+    update,
+    context,
+    *,
+    chat_id: int,
+    playlist: dict[str, Any],
+    media_type: str,
+    format_choice: str,
+    executor: ThreadPoolExecutor,
+) -> None:
+    """End-to-end: workspace → download all → pack to 7z → send volumes."""
+
+    if not is_7z_available():
+        await _safe_status_edit(
+            update,
+            "Funkcja 7z niedostępna — administrator nie zainstalował p7zip-full.",
+        )
+        return
+
+    use_mtproto = mtproto_unavailability_reason() is None
+    volume_size_mb = volume_size_for(use_mtproto)
+
+    title = playlist.get("title", "Playlista")
+    entries = playlist.get("entries") or []
+    total = len(entries)
+
+    workspace = prepare_playlist_workspace(chat_id, title, prefix="pl")
+    lock_path = workspace / ".lock"
+    lock_path.touch()
+
+    async def status(text: str) -> None:
+        await _safe_status_edit(update, text)
+
+    await status(f"Playlista → 7z ({media_type} {format_choice})\n[0/{total}] Pobieranie...")
+
+    try:
+        downloaded, failed = await download_playlist_into(
+            workspace,
+            entries,
+            media_type=media_type,
+            format_choice=format_choice,
+            executor=executor,
+            status_cb=status,
+        )
+
+        if not downloaded:
+            shutil.rmtree(workspace, ignore_errors=True)
+            await status("Nie udało się pobrać żadnego elementu.")
+            return
+
+        await status(f"Pakowanie do 7z (vol_size={volume_size_mb} MB)...")
+        slug = _build_slug(title)
+        dest_basename = workspace / compute_archive_basename(
+            f"{slug}_{media_type}_{format_choice}", datetime.now()
+        )
+        volumes = await pack_to_volumes(downloaded, dest_basename, volume_size_mb)
+
+        caption_prefix = f"{title} ({media_type} {format_choice})"
+        await status(f"Pakowanie OK: {len(volumes)} paczek. Wysyłanie...")
+        await send_volumes(
+            context.bot,
+            chat_id=chat_id,
+            volumes=volumes,
+            caption_prefix=caption_prefix,
+            use_mtproto=use_mtproto,
+            status_cb=status,
+        )
+
+        delivery = ArchivedDeliveryState(
+            workspace=workspace,
+            volumes=volumes,
+            caption_prefix=caption_prefix,
+            use_mtproto=use_mtproto,
+            created_at=datetime.now(),
+        )
+        token = register_archived_delivery(chat_id, delivery)
+
+        summary_lines = [
+            "Playlista zakończona.",
+            f"Pobrano: {len(downloaded)}/{total}",
+            f"Spakowano: {len(downloaded)} plików → {len(volumes)} paczek 7z",
+            f"Wysłano: {len(volumes)}/{len(volumes)}",
+            "Folder zostanie usunięty po 60 min.",
+        ]
+        if failed:
+            summary_lines.append("")
+            summary_lines.append("Nieudane elementy:")
+            for title_ in failed[:5]:
+                summary_lines.append(f"  - {title_[:60]}")
+
+        from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+        keyboard = InlineKeyboardMarkup([
+            [InlineKeyboardButton(
+                "Wyślij wszystkie paczki ponownie",
+                callback_data=f"arc_resend_{token}_0",
+            )],
+            [InlineKeyboardButton(
+                "Usuń teraz",
+                callback_data=f"arc_purge_{token}",
+            )],
+        ])
+        try:
+            await update.callback_query.edit_message_text(
+                "\n".join(summary_lines),
+                reply_markup=keyboard,
+            )
+        except Exception as exc:
+            logging.debug("summary edit failed: %s", exc)
+    except Exception as exc:
+        logging.error("Playlist archive flow failed: %s", exc)
+        await status(f"Pakowanie/wysyłka nie powiodły się: {exc}")
+        # Workspace stays so user can retry; cleanup will remove it after retention.
+    finally:
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass
+
+
+async def execute_single_file_archive_flow(
+    update,
+    context,
+    *,
+    chat_id: int,
+    token: str,
+) -> None:
+    """End-to-end fallback for an oversized single file pre-registered as token."""
+
+    if not is_7z_available():
+        await _safe_status_edit(
+            update,
+            "Funkcja 7z niedostępna — administrator nie zainstalował p7zip-full.",
+        )
+        return
+
+    bucket = pending_archive_jobs.get(chat_id) or {}
+    state = bucket.get(token)
+    if state is None:
+        await _safe_status_edit(update, "Sesja wygasła. Wyślij plik ponownie.")
+        return
+
+    use_mtproto = mtproto_unavailability_reason() is None
+    volume_size_mb = volume_size_for(use_mtproto)
+
+    workspace = prepare_playlist_workspace(chat_id, state.title, prefix="big")
+    lock_path = workspace / ".lock"
+    lock_path.touch()
+
+    src = Path(state.file_path)
+    moved_path = workspace / src.name
+    try:
+        shutil.move(str(src), moved_path)
+    except OSError as exc:
+        await _safe_status_edit(update, f"Nie można przenieść pliku do workspace: {exc}")
+        lock_path.unlink(missing_ok=True)
+        return
+
+    async def status(text: str) -> None:
+        await _safe_status_edit(update, text)
+
+    await status(f"Pakowanie do 7z (vol_size={volume_size_mb} MB)...")
+    try:
+        slug = _build_slug(state.title)
+        dest_basename = workspace / compute_archive_basename(slug, datetime.now())
+        volumes = await pack_to_volumes([moved_path], dest_basename, volume_size_mb)
+
+        caption_prefix = state.title
+        await status(f"Pakowanie OK: {len(volumes)} paczek. Wysyłanie...")
+        await send_volumes(
+            context.bot,
+            chat_id=chat_id,
+            volumes=volumes,
+            caption_prefix=caption_prefix,
+            use_mtproto=use_mtproto,
+            status_cb=status,
+        )
+
+        delivery = ArchivedDeliveryState(
+            workspace=workspace,
+            volumes=volumes,
+            caption_prefix=caption_prefix,
+            use_mtproto=use_mtproto,
+            created_at=datetime.now(),
+        )
+        delivery_token = register_archived_delivery(chat_id, delivery)
+
+        from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+        keyboard = InlineKeyboardMarkup([
+            [InlineKeyboardButton(
+                "Wyślij wszystkie paczki ponownie",
+                callback_data=f"arc_resend_{delivery_token}_0",
+            )],
+            [InlineKeyboardButton(
+                "Usuń teraz",
+                callback_data=f"arc_purge_{delivery_token}",
+            )],
+        ])
+        try:
+            await update.callback_query.edit_message_text(
+                f"Plik wysłany w {len(volumes)} paczkach. Folder zostanie usunięty po 60 min.",
+                reply_markup=keyboard,
+            )
+        except Exception as exc:
+            logging.debug("summary edit failed: %s", exc)
+    except Exception as exc:
+        logging.error("Single-file archive flow failed: %s", exc)
+        await status(f"Pakowanie/wysyłka nie powiodły się: {exc}")
+    finally:
+        # Always consume the pending job so the token cannot be re-used.
+        bucket.pop(token, None)
+        if not bucket:
+            pending_archive_jobs.pop(chat_id, None)
+        else:
+            pending_archive_jobs[chat_id] = bucket
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass
+```
+
+- [ ] **Step 9.4: Uruchomić — oczekiwany PASS**
+
+```bash
+pytest tests/test_archive_service.py -v
+```
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add bot/services/archive_service.py tests/test_archive_service.py
+git commit -m "Wire archive_service playlist+single-file flows end-to-end"
+```
+
+---
+
+## Task 10: Parser callback + nowe przyciski w `bot/services/playlist_service.py`
+
+**Files:**
+- Modify: `bot/services/playlist_service.py`
+- Test: `tests/test_playlist_service.py` (extend)
+
+- [ ] **Step 10.1: Dodać failing testy**
+
+```python
+def test_parse_playlist_download_choice_recognizes_zip_prefix():
+    from bot.services.playlist_service import parse_playlist_download_choice
+
+    choice = parse_playlist_download_choice("pl_zip_dl_audio_mp3")
+
+    assert choice.media_type == "audio"
+    assert choice.format_choice == "mp3"
+    assert choice.as_archive is True
+
+
+def test_parse_playlist_download_choice_legacy_prefix_unchanged():
+    from bot.services.playlist_service import parse_playlist_download_choice
+
+    choice = parse_playlist_download_choice("pl_dl_audio_mp3")
+
+    assert choice.media_type == "audio"
+    assert choice.format_choice == "mp3"
+    assert choice.as_archive is False
+
+
+def test_build_playlist_message_includes_zip_buttons_when_archive_available():
+    from bot.services.playlist_service import build_playlist_message
+
+    msg, kb = build_playlist_message(
+        {"title": "X", "entries": [{"title": "a", "duration": 60}], "playlist_count": 1},
+        archive_available=True,
+    )
+
+    callback_data = [btn.callback_data for row in kb.inline_keyboard for btn in row]
+    assert "pl_dl_audio_mp3" in callback_data
+    assert "pl_zip_dl_audio_mp3" in callback_data
+    assert "pl_zip_dl_video_720p" in callback_data
+
+
+def test_build_playlist_message_hides_zip_buttons_when_archive_unavailable():
+    from bot.services.playlist_service import build_playlist_message
+
+    msg, kb = build_playlist_message(
+        {"title": "X", "entries": [{"title": "a", "duration": 60}], "playlist_count": 1},
+        archive_available=False,
+    )
+
+    callback_data = [btn.callback_data for row in kb.inline_keyboard for btn in row]
+    assert "pl_dl_audio_mp3" in callback_data
+    assert not any(cd.startswith("pl_zip_dl_") for cd in callback_data)
+```
+
+- [ ] **Step 10.2: Uruchomić — oczekiwany FAIL**
+
+```bash
+pytest tests/test_playlist_service.py -v -k "zip"
+```
+
+- [ ] **Step 10.3: Modyfikacja `bot/services/playlist_service.py`**
+
+Zmień `PlaylistDownloadChoice`:
+
+```python
+@dataclass
+class PlaylistDownloadChoice:
+    """Parsed playlist callback choice."""
+
+    media_type: str
+    format_choice: str
+    as_archive: bool = False
+```
+
+Zmień `parse_playlist_download_choice`:
+
+```python
+def parse_playlist_download_choice(callback_data: str) -> PlaylistDownloadChoice:
+    """Parse playlist batch-download callback data.
+
+    Recognizes two prefixes:
+    - ``pl_dl_<media>_<format>``      → standard per-item send (legacy).
+    - ``pl_zip_dl_<media>_<format>``  → archive (7z) flow.
+    """
+
+    if callback_data.startswith("pl_zip_dl_"):
+        rest = callback_data.replace("pl_zip_dl_", "", 1)
+        as_archive = True
+    elif callback_data.startswith("pl_dl_"):
+        rest = callback_data.replace("pl_dl_", "", 1)
+        as_archive = False
+    else:
+        rest = callback_data
+        as_archive = False
+
+    parts = rest.split("_", 1)
+    media_type = parts[0]
+    format_choice = parts[1] if len(parts) > 1 else "best"
+    return PlaylistDownloadChoice(
+        media_type=media_type,
+        format_choice=format_choice,
+        as_archive=as_archive,
+    )
+```
+
+Zmień `build_playlist_message` — dodaj parametr `archive_available` (domyślnie `False`, żeby istniejący kod się nie zepsuł), potem rozszerz keyboard:
+
+```python
+def build_playlist_message(
+    playlist_info: dict[str, Any],
+    *,
+    archive_available: bool = False,
+) -> tuple[str, InlineKeyboardMarkup]:
+    """Build playlist listing text and controls.
+
+    When ``archive_available`` is True, four extra "... jako 7z" buttons
+    are inserted alongside the existing per-item-send buttons.
+    """
+
+    entries = playlist_info['entries']
+    total = playlist_info.get('playlist_count', len(entries))
+
+    msg = f"*{escape_markdown(playlist_info['title'], version=1)}*\n"
+    msg += f"Filmów: {len(entries)}"
+    if total > len(entries):
+        msg += f" (z {total})"
+    msg += "\n\n"
+
+    for i, entry in enumerate(entries, 1):
+        title = escape_markdown(entry.get('title', 'Nieznany')[:50], version=1)
+        duration = entry.get('duration')
+        dur_str = f"{duration // 60}:{duration % 60:02d}" if duration else "?"
+        msg += f"{i}. {title} ({dur_str})\n"
+
+    options = [
+        ("Pobierz wszystkie — Audio MP3", "pl_dl_audio_mp3", "pl_zip_dl_audio_mp3"),
+        ("Pobierz wszystkie — Audio M4A", "pl_dl_audio_m4a", "pl_zip_dl_audio_m4a"),
+        ("Pobierz wszystkie — Video (najlepsza)", "pl_dl_video_best", "pl_zip_dl_video_best"),
+        ("Pobierz wszystkie — Video 720p", "pl_dl_video_720p", "pl_zip_dl_video_720p"),
+    ]
+    keyboard: list[list[InlineKeyboardButton]] = []
+    for label, plain, archive_cb in options:
+        keyboard.append([InlineKeyboardButton(label, callback_data=plain)])
+        if archive_available:
+            keyboard.append([
+                InlineKeyboardButton(f"{label} jako 7z", callback_data=archive_cb)
+            ])
+
+    if total > len(entries) and len(entries) < MAX_PLAYLIST_ITEMS_EXPANDED:
+        more_count = min(total, MAX_PLAYLIST_ITEMS_EXPANDED)
+        keyboard.append([InlineKeyboardButton(
+            f"Pokaż więcej (do {more_count})", callback_data="pl_more"
+        )])
+
+    keyboard.append([InlineKeyboardButton("Anuluj", callback_data="pl_cancel")])
+    return msg, InlineKeyboardMarkup(keyboard)
+```
+
+- [ ] **Step 10.4: Uruchomić — oczekiwany PASS**
+
+```bash
+pytest tests/test_playlist_service.py -v
+```
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add bot/services/playlist_service.py tests/test_playlist_service.py
+git commit -m "Add pl_zip_dl_* parser and archive buttons in playlist menu"
+```
+
+---
+
+## Task 11: Dispatch w `bot/handlers/playlist_callbacks.py`
+
+**Files:**
+- Modify: `bot/handlers/playlist_callbacks.py`
+- Test: `tests/test_playlist.py` (extend)
+
+- [ ] **Step 11.1: Dodać failing test**
+
+W `tests/test_playlist.py`:
+
+```python
+import asyncio
+from unittest import mock
+
+
+def test_handle_playlist_callback_pl_zip_dl_dispatches_to_archive_flow():
+    from bot.handlers import playlist_callbacks
+    from bot.session_store import session_store, user_playlist_data
+
+    session_store.reset()
+    user_playlist_data[42] = {
+        "title": "Pl",
+        "entries": [{"url": "u", "title": "a"}],
+    }
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 42
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    fake_flow = mock.AsyncMock()
+    with mock.patch(
+        "bot.handlers.playlist_callbacks.execute_playlist_archive_flow", fake_flow
+    ):
+        asyncio.run(
+            playlist_callbacks.handle_playlist_callback(
+                update, context, "pl_zip_dl_audio_mp3"
+            )
+        )
+
+    assert fake_flow.await_count == 1
+    kwargs = fake_flow.await_args.kwargs
+    assert kwargs["chat_id"] == 42
+    assert kwargs["media_type"] == "audio"
+    assert kwargs["format_choice"] == "mp3"
+    session_store.reset()
+```
+
+- [ ] **Step 11.2: Uruchomić — oczekiwany FAIL**
+
+```bash
+pytest tests/test_playlist.py -v -k "pl_zip_dl"
+```
+
+- [ ] **Step 11.3: Implementacja w `bot/handlers/playlist_callbacks.py`**
+
+Dodaj import na górze:
+
+```python
+from bot.services.archive_service import execute_playlist_archive_flow
+```
+
+W funkcji `handle_playlist_callback` dodaj dispatch:
+
+```python
+    if data.startswith("pl_zip_dl_"):
+        await _dispatch_archive_playlist(update, context, data)
+        return
+
+    if data.startswith("pl_dl_"):
+        await download_playlist(update, context, data)
+```
+
+(zastąp istniejące `if data.startswith("pl_dl_")` powyższą parą — kolejność istotna, bo `pl_zip_dl_` zaczyna się od `pl_zip_`, ale gdyby kiedyś `pl_dl_` weszło pierwsze przez `startswith`, wciąż by łapało; specyficzny prefix ma wyższy priorytet.)
+
+Dodaj nową funkcję na końcu pliku:
+
+```python
+async def _dispatch_archive_playlist(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    callback_data: str,
+) -> None:
+    chat_id = update.effective_chat.id
+    playlist = _get_session_value(context, chat_id, "playlist_data", user_playlist_data)
+    if not playlist:
+        await update.callback_query.edit_message_text(
+            "Sesja playlisty wygasła. Wyślij link ponownie."
+        )
+        return
+
+    from bot.services.playlist_service import parse_playlist_download_choice
+    choice = parse_playlist_download_choice(callback_data)
+
+    await execute_playlist_archive_flow(
+        update,
+        context,
+        chat_id=chat_id,
+        playlist=playlist,
+        media_type=choice.media_type,
+        format_choice=choice.format_choice,
+        executor=_executor,
+    )
+    _clear_session_value(context, chat_id, "playlist_data", user_playlist_data)
+```
+
+- [ ] **Step 11.4: Uruchomić — oczekiwany PASS**
+
+```bash
+pytest tests/test_playlist.py -v
+```
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add bot/handlers/playlist_callbacks.py tests/test_playlist.py
+git commit -m "Dispatch pl_zip_dl_* callbacks to archive_service playlist flow"
+```
+
+---
+
+## Task 12: Dispatch `arc_*` w `bot/handlers/download_callbacks.py` + fallback po pobraniu
+
+**Files:**
+- Modify: `bot/handlers/download_callbacks.py`
+- Test: `tests/test_callback_download_handlers.py` (extend)
+
+- [ ] **Step 12.1: Dodać failing testy**
+
+```python
+def test_oversized_single_file_offers_archive_choice(tmp_path, monkeypatch):
+    """File too big after download → user gets [Wyślij jako 7z][Anuluj]."""
+    from bot.handlers import download_callbacks
+    from bot.session_store import pending_archive_jobs, session_store
+
+    session_store.reset()
+    pretend = tmp_path / "big.mp4"
+    pretend.write_bytes(b"x")
+
+    captured = {}
+
+    async def fake_offer_archive(update, context, chat_id, file_path, title, media_type, format_choice, file_size_mb):
+        captured["called"] = True
+
+    monkeypatch.setattr(
+        download_callbacks, "_offer_archive_or_cancel", fake_offer_archive
+    )
+
+    import asyncio
+    asyncio.run(
+        download_callbacks._offer_archive_or_cancel(
+            mock.MagicMock(),
+            mock.MagicMock(),
+            chat_id=1,
+            file_path=str(pretend),
+            title="t",
+            media_type="video",
+            format_choice="best",
+            file_size_mb=999.0,
+        )
+    )
+    assert captured["called"] is True
+    session_store.reset()
+
+
+def test_arc_cancel_removes_file_immediately(tmp_path, monkeypatch):
+    from bot.handlers import download_callbacks
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+    from datetime import datetime
+    from pathlib import Path
+
+    session_store.reset()
+    src = tmp_path / "to_cancel.mp4"
+    src.write_bytes(b"x")
+    state = ArchiveJobState(
+        file_path=src,
+        title="x", media_type="video", format_choice="best",
+        file_size_mb=200.0, use_mtproto=False,
+        created_at=datetime(2026, 5, 2),
+    )
+    pending_archive_jobs[7] = {"tok": state}
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 7
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    import asyncio
+    asyncio.run(
+        download_callbacks.handle_archive_callback(
+            update, context, "arc_cancel_tok"
+        )
+    )
+
+    assert not src.exists()
+    assert pending_archive_jobs.get(7, {}).get("tok") is None
+    session_store.reset()
+
+
+def test_arc_split_dispatches_to_archive_service(tmp_path, monkeypatch):
+    from bot.handlers import download_callbacks
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+    from datetime import datetime
+
+    session_store.reset()
+    src = tmp_path / "x.mp4"
+    src.write_bytes(b"x")
+    pending_archive_jobs[7] = {"tok2": ArchiveJobState(
+        file_path=src, title="x", media_type="video", format_choice="best",
+        file_size_mb=200.0, use_mtproto=False,
+        created_at=datetime(2026, 5, 2),
+    )}
+
+    fake_flow = mock.AsyncMock()
+    monkeypatch.setattr(
+        download_callbacks, "execute_single_file_archive_flow", fake_flow
+    )
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 7
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    import asyncio
+    asyncio.run(
+        download_callbacks.handle_archive_callback(
+            update, context, "arc_split_tok2"
+        )
+    )
+
+    assert fake_flow.await_count == 1
+    kwargs = fake_flow.await_args.kwargs
+    assert kwargs["chat_id"] == 7
+    assert kwargs["token"] == "tok2"
+    session_store.reset()
+
+
+def test_arc_resend_calls_send_volumes_with_index(tmp_path, monkeypatch):
+    from bot.handlers import download_callbacks
+    from bot.session_store import (
+        ArchivedDeliveryState,
+        archived_deliveries,
+        session_store,
+    )
+    from datetime import datetime
+    from pathlib import Path
+
+    session_store.reset()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    v1 = workspace / "x.7z.001"
+    v1.write_bytes(b"a")
+    v2 = workspace / "x.7z.002"
+    v2.write_bytes(b"a")
+    archived_deliveries[5] = {"tk": ArchivedDeliveryState(
+        workspace=workspace, volumes=[v1, v2],
+        caption_prefix="X", use_mtproto=True,
+        created_at=datetime(2026, 5, 2),
+    )}
+
+    sent = mock.AsyncMock()
+    monkeypatch.setattr(download_callbacks, "send_volumes", sent)
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 5
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+    context.bot = mock.MagicMock()
+
+    import asyncio
+    asyncio.run(
+        download_callbacks.handle_archive_callback(
+            update, context, "arc_resend_tk_1"
+        )
+    )
+
+    assert sent.await_count == 1
+    assert sent.await_args.kwargs["start_index"] == 1
+    session_store.reset()
+
+
+def test_arc_purge_removes_workspace(tmp_path, monkeypatch):
+    from bot.handlers import download_callbacks
+    from bot.session_store import (
+        ArchivedDeliveryState,
+        archived_deliveries,
+        session_store,
+    )
+    from datetime import datetime
+
+    session_store.reset()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "x.7z.001").write_bytes(b"a")
+    archived_deliveries[5] = {"tk2": ArchivedDeliveryState(
+        workspace=workspace, volumes=[workspace / "x.7z.001"],
+        caption_prefix="X", use_mtproto=True,
+        created_at=datetime(2026, 5, 2),
+    )}
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 5
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    import asyncio
+    asyncio.run(
+        download_callbacks.handle_archive_callback(
+            update, context, "arc_purge_tk2"
+        )
+    )
+
+    assert not workspace.exists()
+    assert archived_deliveries.get(5, {}).get("tk2") is None
+    session_store.reset()
+```
+
+- [ ] **Step 12.2: Uruchomić — oczekiwany FAIL**
+
+```bash
+pytest tests/test_callback_download_handlers.py -v -k "arc_ or oversized"
+```
+
+- [ ] **Step 12.3: Implementacja w `bot/handlers/download_callbacks.py`**
+
+Dodaj na górze do importów:
+
+```python
+from datetime import datetime
+from pathlib import Path
+import shutil
+
+from bot.session_store import (
+    ArchiveJobState,
+    archived_deliveries,
+    pending_archive_jobs,
+)
+from bot.services.archive_service import (
+    execute_single_file_archive_flow,
+    register_pending_archive_job,
+    send_volumes,
+)
+from bot.archive import volume_size_for
+from bot.mtproto import mtproto_unavailability_reason
+```
+
+W funkcji `download_file` zmodyfikuj sekcję wysyłania (gałąź `else` po `transcribe`), zastępując bieżący blok `if use_mtproto: ... mtproto_unavailability_reason() ... raise RuntimeError`:
+
+Aktualnie (~linia 514):
+
+```python
+            use_mtproto = file_size_mb > TELEGRAM_UPLOAD_LIMIT_MB
+```
+
+zostaje. Dalej blok `if use_mtproto: ...` zastąp tak, żeby przed `raise RuntimeError` zaproponować fallback:
+
+```python
+            volume_size_mb = volume_size_for(use_mtproto=mtproto_unavailability_reason() is None)
+            if file_size_mb > volume_size_mb:
+                # File exceeds the practical Telegram limit even via the best
+                # available transport. Offer the 7z archive split instead of
+                # failing the whole download.
+                await _offer_archive_or_cancel(
+                    update,
+                    context,
+                    chat_id=chat_id,
+                    file_path=downloaded_file_path,
+                    title=title,
+                    media_type=media_type,
+                    format_choice=format,
+                    file_size_mb=file_size_mb,
+                )
+                # Skip cleanup — the archive flow owns the file from now on.
+                success_recorded = True
+                return
+```
+
+(Wstaw ten blok PRZED istniejącą logiką `if use_mtproto: ... else: ...`. Stary kod pozostaje jako szybka ścieżka dla plików ≤ volume_size_mb.)
+
+Dodaj na końcu pliku:
+
+```python
+async def _offer_archive_or_cancel(
+    update,
+    context,
+    *,
+    chat_id: int,
+    file_path: str,
+    title: str,
+    media_type: str,
+    format_choice: str,
+    file_size_mb: float,
+) -> None:
+    """Register a pending archive job and present [Wyślij jako 7z]/[Anuluj]."""
+
+    use_mtproto = mtproto_unavailability_reason() is None
+    volume_size_mb = volume_size_for(use_mtproto)
+    state = ArchiveJobState(
+        file_path=Path(file_path),
+        title=title,
+        media_type=media_type,
+        format_choice=format_choice,
+        file_size_mb=file_size_mb,
+        use_mtproto=use_mtproto,
+        created_at=datetime.now(),
+    )
+    token = register_pending_archive_job(chat_id, state)
+
+    from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+    keyboard = InlineKeyboardMarkup([
+        [InlineKeyboardButton("Wyślij jako 7z", callback_data=f"arc_split_{token}")],
+        [InlineKeyboardButton("Anuluj", callback_data=f"arc_cancel_{token}")],
+    ])
+    text = (
+        f"Plik za duży dla Telegrama: {file_size_mb:.0f} MB > limit {volume_size_mb} MB.\n"
+        f"Mogę spakować go w wolumeny 7z (po {volume_size_mb} MB) i wysłać paczki."
+    )
+    try:
+        await update.callback_query.edit_message_text(text, reply_markup=keyboard)
+    except Exception as exc:
+        logging.debug("offer-archive edit failed: %s", exc)
+
+
+async def handle_archive_callback(update, context, data: str) -> None:
+    """Dispatch arc_split_/arc_cancel_/arc_resend_/arc_purge_ callbacks."""
+
+    chat_id = update.effective_chat.id
+
+    if data.startswith("arc_split_"):
+        token = data[len("arc_split_"):]
+        await execute_single_file_archive_flow(
+            update, context, chat_id=chat_id, token=token,
+        )
+        return
+
+    if data.startswith("arc_cancel_"):
+        token = data[len("arc_cancel_"):]
+        await _handle_arc_cancel(update, chat_id, token)
+        return
+
+    if data.startswith("arc_resend_"):
+        await _handle_arc_resend(update, context, chat_id, data)
+        return
+
+    if data.startswith("arc_purge_"):
+        token = data[len("arc_purge_"):]
+        await _handle_arc_purge(update, chat_id, token)
+        return
+
+
+async def _handle_arc_cancel(update, chat_id: int, token: str) -> None:
+    bucket = pending_archive_jobs.get(chat_id) or {}
+    state = bucket.pop(token, None)
+    if not bucket:
+        pending_archive_jobs.pop(chat_id, None)
+    else:
+        pending_archive_jobs[chat_id] = bucket
+    if state is not None:
+        try:
+            os.remove(str(state.file_path))
+        except OSError:
+            pass
+    try:
+        await update.callback_query.edit_message_text("Anulowano. Plik usunięty.")
+    except Exception as exc:
+        logging.debug("arc_cancel edit failed: %s", exc)
+
+
+async def _handle_arc_resend(update, context, chat_id: int, data: str) -> None:
+    rest = data[len("arc_resend_"):]
+    if "_" not in rest:
+        return
+    token, idx_str = rest.rsplit("_", 1)
+    try:
+        start_index = int(idx_str)
+    except ValueError:
+        return
+
+    bucket = archived_deliveries.get(chat_id) or {}
+    state = bucket.get(token)
+    if state is None:
+        try:
+            await update.callback_query.edit_message_text("Sesja wygasła.")
+        except Exception:
+            pass
+        return
+
+    async def status(text: str) -> None:
+        try:
+            await update.callback_query.edit_message_text(text)
+        except Exception:
+            pass
+
+    try:
+        await send_volumes(
+            context.bot,
+            chat_id=chat_id,
+            volumes=state.volumes,
+            caption_prefix=state.caption_prefix,
+            use_mtproto=state.use_mtproto,
+            start_index=start_index,
+            status_cb=status,
+        )
+        await status(f"Wysłano paczki od [{start_index + 1}/{len(state.volumes)}].")
+    except Exception as exc:
+        await status(f"Wysyłka nadal nie powiodła się: {exc}")
+
+
+async def _handle_arc_purge(update, chat_id: int, token: str) -> None:
+    bucket = archived_deliveries.get(chat_id) or {}
+    state = bucket.pop(token, None)
+    if not bucket:
+        archived_deliveries.pop(chat_id, None)
+    else:
+        archived_deliveries[chat_id] = bucket
+    if state is not None and state.workspace.exists():
+        shutil.rmtree(state.workspace, ignore_errors=True)
+    try:
+        await update.callback_query.edit_message_text("Folder usunięty.")
+    except Exception as exc:
+        logging.debug("arc_purge edit failed: %s", exc)
+```
+
+- [ ] **Step 12.4: Podpiąć dispatcher do głównego callback-routera**
+
+W miejscu, gdzie router rozpoznaje callback prefixy (najprawdopodobniej w `bot/handlers/download_callbacks.py` lub wyżej w `telegram_callbacks.py` — sprawdź `if data.startswith(...)` ladder), dodaj gałąź:
+
+```python
+    if data.startswith("arc_"):
+        await handle_archive_callback(update, context, data)
+        return
+```
+
+Jeśli router znajduje się w innym pliku (np. `bot/telegram_callbacks.py`), import też tam:
+
+```python
+from bot.handlers.download_callbacks import handle_archive_callback
+```
+
+- [ ] **Step 12.5: Uruchomić — oczekiwany PASS**
+
+```bash
+pytest tests/test_callback_download_handlers.py -v
+```
+
+- [ ] **Step 12.6: Commit**
+
+```bash
+git add bot/handlers/download_callbacks.py bot/telegram_callbacks.py tests/test_callback_download_handlers.py
+git commit -m "Add arc_* dispatching and oversized-file 7z fallback in single-file flow"
+```
+
+(Jeśli `bot/telegram_callbacks.py` nie wymagał zmian, dodaj tylko zmienione pliki.)
+
+---
+
+## Task 13: Flag `archive_available` w `bot/runtime.py` + przekazanie do menu
+
+**Files:**
+- Modify: `bot/runtime.py`
+- Modify: `bot/handlers/playlist_callbacks.py` (przekazać flag do `build_playlist_message`)
+- Test: `tests/test_runtime.py` (extend)
+
+- [ ] **Step 13.1: Dodać failing test w `tests/test_runtime.py`**
+
+```python
+def test_app_runtime_includes_archive_available_flag(monkeypatch):
+    from bot import runtime as runtime_module
+
+    monkeypatch.setattr("bot.archive.is_7z_available", lambda: True)
+    rt = runtime_module.build_app_runtime()
+    assert rt.archive_available is True
+
+    monkeypatch.setattr("bot.archive.is_7z_available", lambda: False)
+    rt = runtime_module.build_app_runtime()
+    assert rt.archive_available is False
+```
+
+- [ ] **Step 13.2: Uruchomić — oczekiwany FAIL (`archive_available` brak)**
+
+```bash
+pytest tests/test_runtime.py -v -k archive
+```
+
+- [ ] **Step 13.3: Modyfikacja `bot/runtime.py`**
+
+W `AppRuntime` (frozen dataclass) dodaj pole:
+
+```python
+@dataclass(frozen=True)
+class AppRuntime:
+    config: dict[str, Any]
+    session_store: Any
+    security_store: Any
+    services: Any
+    authorized_users_repository: Any
+    download_history_repository: Any
+    authorized_users_set: set[int]
+    archive_available: bool = False
+```
+
+W `build_app_runtime` dodaj wywołanie:
+
+```python
+def build_app_runtime() -> AppRuntime:
+    from bot.archive import is_7z_available
+
+    return AppRuntime(
+        config=get_runtime_config(),
+        session_store=session_store,
+        security_store=security_store,
+        services=get_runtime_services(),
+        authorized_users_repository=get_authorized_users_repository(),
+        download_history_repository=get_download_history_repository(),
+        authorized_users_set=get_runtime_authorized_users(),
+        archive_available=is_7z_available(),
+    )
+```
+
+W `bot/handlers/playlist_callbacks.py` w funkcji `handle_playlist_callback` przy budowaniu `build_playlist_message`:
+
+```python
+        from bot.runtime import get_app_runtime
+        runtime = get_app_runtime(context)
+        archive_available = runtime.archive_available if runtime is not None else False
+        msg, reply_markup = build_playlist_message(
+            playlist_info, archive_available=archive_available,
+        )
+```
+
+(Zastąp dwa wywołania `build_playlist_message(playlist_info)` w `pl_full` i `pl_more` powyższym wzorcem.)
+
+- [ ] **Step 13.4: Uruchomić — oczekiwany PASS**
+
+```bash
+pytest tests/test_runtime.py tests/test_playlist.py -v
+```
+
+- [ ] **Step 13.5: Commit**
+
+```bash
+git add bot/runtime.py bot/handlers/playlist_callbacks.py tests/test_runtime.py
+git commit -m "Expose archive_available flag in AppRuntime and propagate to playlist menu"
+```
+
+---
+
+## Task 14: Cleanup workspace’ów + pending jobs w `bot/cleanup.py`
+
+**Files:**
+- Modify: `bot/cleanup.py`
+- Test: `tests/test_cleanup.py` (extend)
+
+- [ ] **Step 14.1: Dodać failing testy**
+
+```python
+import os
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest import mock
+
+
+def test_purge_archive_workspaces_removes_old_pl_dirs(tmp_path, monkeypatch):
+    from bot import cleanup
+
+    chat_dir = tmp_path / "111"
+    chat_dir.mkdir()
+    old_ws = chat_dir / "pl_oldslug_20260102-080000"
+    old_ws.mkdir()
+    (old_ws / "x.7z.001").write_bytes(b"x")
+    # Set mtime to 2 hours ago.
+    old_time = time.time() - 2 * 3600
+    os.utime(old_ws, (old_time, old_time))
+
+    cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
+
+    assert not old_ws.exists()
+
+
+def test_purge_archive_workspaces_keeps_recent_dirs(tmp_path):
+    from bot import cleanup
+
+    chat_dir = tmp_path / "222"
+    chat_dir.mkdir()
+    fresh_ws = chat_dir / "pl_fresh_20260502-080000"
+    fresh_ws.mkdir()
+    # Default mtime is "now", which is well under 60 min.
+    cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
+    assert fresh_ws.exists()
+
+
+def test_purge_archive_workspaces_respects_lock_when_recent(tmp_path):
+    from bot import cleanup
+
+    chat_dir = tmp_path / "333"
+    chat_dir.mkdir()
+    ws = chat_dir / "pl_locked_20260502-080000"
+    ws.mkdir()
+    (ws / ".lock").touch()
+    # Make the workspace look 30 min old (under the 60 min retention).
+    age = time.time() - 30 * 60
+    os.utime(ws, (age, age))
+
+    cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
+
+    assert ws.exists()
+
+
+def test_purge_archive_workspaces_ignores_non_archive_dirs(tmp_path):
+    from bot import cleanup
+
+    chat_dir = tmp_path / "444"
+    chat_dir.mkdir()
+    other = chat_dir / "downloads_subfolder"
+    other.mkdir()
+    age = time.time() - 7200
+    os.utime(other, (age, age))
+
+    cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
+    assert other.exists()
+
+
+def test_purge_pending_archive_jobs_removes_old_jobs(tmp_path):
+    from bot import cleanup
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+
+    session_store.reset()
+    src = tmp_path / "x.mp4"
+    src.write_bytes(b"x")
+    old_state = ArchiveJobState(
+        file_path=src, title="x", media_type="video", format_choice="best",
+        file_size_mb=1.0, use_mtproto=False,
+        created_at=datetime.now() - timedelta(hours=2),
+    )
+    pending_archive_jobs[1] = {"old": old_state}
+
+    cleanup._purge_pending_archive_jobs(retention_min=60)
+
+    assert pending_archive_jobs.get(1, {}).get("old") is None
+    assert not src.exists()
+    session_store.reset()
+```
+
+- [ ] **Step 14.2: Uruchomić — oczekiwany FAIL**
+
+```bash
+pytest tests/test_cleanup.py -v -k "purge"
+```
+
+- [ ] **Step 14.3: Implementacja w `bot/cleanup.py`**
+
+Dopisz na początku pliku:
+
+```python
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from bot.security_limits import PLAYLIST_ARCHIVE_RETENTION_MIN
+```
+
+Dodaj funkcje przed `periodic_cleanup`:
+
+```python
+_ARCHIVE_PREFIXES = ("pl_", "big_")
+
+
+def _purge_archive_workspaces(chat_dir: Path, retention_min: int) -> int:
+    """Remove archive workspaces older than retention_min, unless locked.
+
+    Workspaces are subdirectories named ``pl_*`` or ``big_*``. A
+    ``.lock`` file inside a young workspace blocks deletion (used during
+    pack/send operations). After 24h workspaces are removed regardless
+    of the lock — the long-running cleanup acts as a safety net.
+    """
+
+    if not chat_dir.exists():
+        return 0
+
+    now = time.time()
+    threshold = retention_min * 60
+    safety_net = 24 * 3600
+    removed = 0
+
+    for entry in chat_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        if not any(entry.name.startswith(p) for p in _ARCHIVE_PREFIXES):
+            continue
+        try:
+            age = now - entry.stat().st_mtime
+        except OSError as exc:
+            logging.warning("Could not stat %s: %s", entry, exc)
+            continue
+
+        lock = entry / ".lock"
+        if age <= threshold:
+            continue
+        if lock.exists() and age <= safety_net:
+            continue
+
+        try:
+            shutil.rmtree(entry)
+            removed += 1
+            logging.info("Removed stale archive workspace: %s (age %.1f h)",
+                         entry, age / 3600)
+        except OSError as exc:
+            logging.error("Failed to remove %s: %s", entry, exc)
+
+    return removed
+
+
+def _purge_pending_archive_jobs(retention_min: int) -> int:
+    """Drop pending_archive_jobs entries older than retention_min and delete files."""
+
+    from bot.session_store import pending_archive_jobs, session_store
+
+    cutoff = datetime.now() - timedelta(minutes=retention_min)
+    removed = 0
+    for chat_id in list(pending_archive_jobs):
+        bucket = pending_archive_jobs.get(chat_id) or {}
+        for token in list(bucket):
+            state = bucket[token]
+            if state.created_at >= cutoff:
+                continue
+            bucket.pop(token, None)
+            try:
+                os.remove(str(state.file_path))
+            except OSError:
+                pass
+            removed += 1
+        if not bucket:
+            pending_archive_jobs.pop(chat_id, None)
+        else:
+            pending_archive_jobs[chat_id] = bucket
+    return removed
+```
+
+W `periodic_cleanup` (na końcu pętli) dopisz:
+
+```python
+            for chat_dir in Path(DOWNLOAD_PATH).iterdir():
+                if chat_dir.is_dir():
+                    _purge_archive_workspaces(chat_dir, PLAYLIST_ARCHIVE_RETENTION_MIN)
+            _purge_pending_archive_jobs(PLAYLIST_ARCHIVE_RETENTION_MIN)
+```
+
+- [ ] **Step 14.4: Uruchomić — oczekiwany PASS**
+
+```bash
+pytest tests/test_cleanup.py -v
+```
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add bot/cleanup.py tests/test_cleanup.py
+git commit -m "Add cleanup of archive workspaces and pending jobs based on retention"
+```
+
+---
+
+## Task 15: Integracja end-to-end (manual checklist)
+
+Ten task nie ma testów automatycznych — to lista kontrolna ręczna do wykonania zanim PR `develop` → `main` zostanie utworzony. Zapisz wynik checklisty w komentarzu PR-a.
+
+- [ ] **Step 15.1: Środowisko**
+
+```bash
+source /home/pi/venv/bin/activate
+cd /mnt/c/code/ytdown
+python main.py
+```
+
+Sprawdź w logach: `archive_available=True` przy starcie (lub stosowny log). Przyciski "… jako 7z" muszą się pojawiać w menu playlisty.
+
+- [ ] **Step 15.2: Pobranie playlisty 5×audio_mp3 jako 7z**
+
+Telegram: wyślij URL playlisty z 5 piosenkami → klik „Pobierz wszystkie — Audio MP3 jako 7z". Oczekiwane:
+- jedna paczka `<title>_audio_mp3_<ts>.7z.001` w czacie,
+- summary z `Pobrano: 5/5`, `Wysłano: 1/1`,
+- przyciski `[Wyślij wszystkie paczki ponownie] [Usuń teraz]`.
+
+- [ ] **Step 15.3: Pobranie playlisty 30×video_720p jako 7z**
+
+Wyślij URL playlisty 30-elementowej → klik „Pobierz wszystkie — Video 720p jako 7z". Oczekiwane:
+- kilka paczek `.7z.001`, `.002`, …, sumaryczny rozmiar > 1900 MB,
+- po wszystkich paczkach summary OK.
+
+- [ ] **Step 15.4: Sztuczne wymuszenie braku MTProto**
+
+Tymczasowo zakomentuj `TELEGRAM_API_ID`/`HASH` w `api_key.md`, restart bota. Powtórz krok 15.2. Oczekiwane: paczki ≤ 49 MB, więcej wolumenów, status mówi że transport = Bot API.
+
+- [ ] **Step 15.5: Recovery wysyłki**
+
+W trakcie wysyłki kroku 15.3 wyłącz sieć na ~30 s tak żeby paczka `.003` failowała. Oczekiwane:
+- status pokaże `Błąd wysyłki paczki [3/M]`,
+- przycisk `[Ponów od [3/M]]` po włączeniu sieci dokończy wysyłkę bez ponownego pobierania.
+
+- [ ] **Step 15.6: Cleanup po retencji**
+
+Pozostaw workspace `pl_*` z poprzedniego kroku. Sprawdź `ls downloads/<chat_id>/` po 65 min — folder powinien zniknąć (lub wymuś `cleanup.periodic_cleanup` przez krótki `time.sleep` w testach manualnych).
+
+- [ ] **Step 15.7: Single-file > limit**
+
+Tymczasowo zmień w `bot/security_limits.py`: `MAX_FILE_SIZE_MB = 200`. Wymuś tryb Bot API (krok 15.4). Pobierz video YouTube ~250 MB. Oczekiwane:
+- przyciski `[Wyślij jako 7z] [Anuluj]`,
+- klik „Wyślij jako 7z" → 5–6 paczek po 49 MB,
+- klik „Anuluj" → plik usunięty natychmiast.
+
+Po teście przywróć `MAX_FILE_SIZE_MB = 1000` i odkomentuj `TELEGRAM_API_*`.
+
+- [ ] **Step 15.8: Commit checklisty (jeśli były poprawki)**
+
+Jeśli w trakcie testów coś poprawiałeś w kodzie — commituj punktowo. W przeciwnym razie żaden commit nie jest potrzebny.
+
+---
+
+## Self-review (dla autora planu)
+
+1. **Spec coverage:**
+   - Sekcja 2 (decyzje) — Tasks 1, 10, 12, 13.
+   - Sekcja 3 (architektura) — Tasks 2, 3, 4, 5, 6.
+   - Sekcja 4 (flow playlisty) — Tasks 7, 8, 9, 10, 11, 13.
+   - Sekcja 5 (single-file fallback) — Tasks 9, 12.
+   - Sekcja 6 (konfiguracja, cleanup, error handling) — Tasks 1, 4, 14.
+   - Sekcja 7 (testy) — wszystkie testowe kroki w odpowiednich taskach.
+   - Sekcja 8 (poza scope) — niezaadresowane (zgodnie z założeniem).
+
+2. **Placeholder scan:** Po przejrzeniu nie ma „TBD"/„TODO"/„similar to". Komentarz „(usuń `_placeholder` i `shutil_module := ...` z bloku — to było pomyłkowe…)" w Task 3 jest instrukcją, nie placeholderem; zostawione celowo dla człowieka wykonującego plan.
+
+3. **Type consistency:** `ArchiveJobState`, `ArchivedDeliveryState`, `pending_archive_jobs`, `archived_deliveries`, `pack_to_volumes`, `send_volumes`, `register_pending_archive_job`, `register_archived_delivery`, `volume_size_for`, `transliterate_to_ascii`, `compute_archive_basename`, `is_7z_available` — używane spójnie w taskach 5–14.
+
+4. **Kolejność:** archive (T2,T3) przed archive_service (T6–T9); session_store (T5) przed archive_service (T6); archive_service przed handlers (T11, T12); runtime (T13) po handlers (potrzebuje `build_playlist_message` z parametrem). OK.
+
+---
+
+## Wybór trybu wykonania
+
+Plan kompletny, zapisany w `docs/superpowers/plans/2026-05-02-playlist-zip-download-plan.md`. Dwie opcje wykonania:
+
+1. **Subagent-driven (rekomendowane)** — dispatcher dispatches świeży subagent per task, review między taskami, szybka iteracja. Wymagany sub-skill: `superpowers:subagent-driven-development`.
+
+2. **Inline execution** — wykonujemy taski sekwencyjnie w obecnej sesji z checkpointami. Wymagany sub-skill: `superpowers:executing-plans`.
+
+Który tryb wybierasz?

--- a/docs/superpowers/plans/2026-05-03-cancel-operations-plan.md
+++ b/docs/superpowers/plans/2026-05-03-cancel-operations-plan.md
@@ -1,0 +1,3242 @@
+# Plan implementacji: Komenda `/stop` — anulowanie długotrwałych operacji
+
+> **Dla agentic worker:** WYMAGANY SUB-SKILL — `superpowers:subagent-driven-development` (rekomendowany) lub `superpowers:executing-plans`. Kroki używają składni checkbox `- [ ]`.
+
+**Cel:** Dodać komendę `/stop` która listuje aktywne długotrwałe operacje per chat (playlisty, single-file, transkrypcja, 7z pack/send, MTProto upload, summary) i pozwala je anulować — pojedynczo lub wszystkie naraz — bez restartu bota.
+
+**Architektura:** Nowy moduł `bot/jobs.py` z `JobRegistry` (globalny singleton) wystawia `JobCancellation` per zadanie. Cancel-handle łączy 3 mechanizmy: `asyncio.Event` (sprawdzane przez async pętle), opcjonalny `asyncio.subprocess.Process` (terminate→kill dla 7z) i opcjonalny `asyncio.Task` (cancel dla pyrogram/Anthropic SDK). Każda warstwa konsumuje cancellation w sposób natywny.
+
+**Tech Stack:** Python 3.11+, `asyncio`, `asyncio.subprocess`, `pyrogram`, `python-telegram-bot`, `pytest` + `pytest-asyncio`. 7z (p7zip-full) już zainstalowany.
+
+**Gałąź:** `develop` — wszystkie commity bezpośrednio na `develop` (zgodnie z polityką repo).
+
+**Spec referencyjny:** `docs/superpowers/specs/2026-05-03-cancel-operations-design.md` (commit `efe05fa`).
+
+---
+
+## Mapa plików
+
+| Plik | Akcja | Odpowiedzialność |
+|---|---|---|
+| `bot/security_limits.py` | modify | Stałe `JOB_DEAD_AGE_HOURS`, `JOB_TERMINATE_GRACE_SEC`. |
+| `bot/jobs.py` | **create** | `JobCancellation`, `JobDescriptor`, `JobRegistry`, globalny `job_registry`. |
+| `bot/session_store.py` | modify | `ArchivePartialState` dataclass + `partial_archive_workspaces` field map. |
+| `bot/archive.py` | modify | `pack_to_volumes` przyjmuje `cancellation`, terminate→kill subprocess. |
+| `bot/services/download_service.py` | modify | `execute_download` przyjmuje `cancellation`, progress hook raise. |
+| `bot/services/archive_service.py` | modify | `download_playlist_into`, `send_volumes`, `execute_*_archive_flow` przyjmują cancellation. Nowa `execute_partial_archive_flow`. |
+| `bot/handlers/playlist_callbacks.py` | modify | Legacy `download_playlist` register/unregister job. Callback `arc_pack_partial_*`. |
+| `bot/handlers/download_callbacks.py` | modify | `download_file` register/unregister job. |
+| `bot/transcription_pipeline.py` | modify | Pętla po chunkach sprawdza `cancellation.event`. |
+| `bot/transcription_providers.py` | modify | `generate_summary` opakowane w cancellable task. |
+| `bot/mtproto.py` | modify | `send_*_mtproto` attach pyrogram task do cancellation. |
+| `bot/telegram_commands.py` | modify | Nowy handler `/stop` + callbacks `stop_*`. |
+| `bot/telegram_callbacks.py` | modify | Router rozpoznaje prefix `stop_`. |
+| `bot/cleanup.py` | modify | `purge_dead(6h)` + `_purge_partial_archive_workspaces`. |
+| `tests/test_jobs.py` | **create** | Unit dla `JobRegistry`, `JobCancellation`. |
+| `tests/test_archive.py` | modify | Cancel terminate test. |
+| `tests/test_archive_service.py` | modify | Cancel testy dla download_playlist_into, send_volumes, flow. |
+| `tests/test_download_service.py` | modify | Cancel test dla execute_download progress hook. |
+| `tests/test_telegram_commands.py` | modify | `/stop` handler + callbacks. |
+| `tests/test_cleanup.py` | modify | `purge_dead` + partial workspaces test. |
+| `tests/test_mtproto.py` | modify | `send_*_mtproto` attaches task. |
+| `tests/test_session_store.py` | modify | `ArchivePartialState` + `partial_archive_workspaces`. |
+
+---
+
+## Task 1: Stałe w `bot/security_limits.py`
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/security_limits.py`
+- Test: `/mnt/c/code/ytdown/tests/test_security_unit.py`
+
+- [ ] **Step 1.1: Failing test**
+
+Dopisz na końcu `tests/test_security_unit.py`:
+
+```python
+def test_job_dead_age_constant_defined():
+    from bot import security_limits
+
+    assert security_limits.JOB_DEAD_AGE_HOURS == 6
+    assert security_limits.JOB_DEAD_AGE_HOURS > 0
+
+
+def test_job_terminate_grace_constant_defined():
+    from bot import security_limits
+
+    assert security_limits.JOB_TERMINATE_GRACE_SEC == 1.0
+    assert 0 < security_limits.JOB_TERMINATE_GRACE_SEC <= 5.0
+```
+
+- [ ] **Step 1.2: Run test, expect FAIL**
+
+```bash
+source /home/pi/venv/bin/activate
+cd /mnt/c/code/ytdown
+pytest tests/test_security_unit.py -v -k "JOB_"
+```
+
+Expected: `AttributeError: module 'bot.security_limits' has no attribute 'JOB_DEAD_AGE_HOURS'`.
+
+- [ ] **Step 1.3: Add constants**
+
+Append to `bot/security_limits.py` (after the existing archive-related constants):
+
+```python
+# Cleanup of stale (zombie) entries in JobRegistry. Defends /stop list
+# against operations that never unregistered due to bugs or crashes.
+JOB_DEAD_AGE_HOURS = 6
+
+# Grace between SIGTERM and SIGKILL when terminating a 7z subprocess
+# attached to a JobCancellation. Long enough for 7z to finish writing
+# its current 1 MiB block, short enough to not block /stop UX.
+JOB_TERMINATE_GRACE_SEC = 1.0
+```
+
+- [ ] **Step 1.4: Run tests, expect PASS**
+
+```bash
+pytest tests/test_security_unit.py -v
+```
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add bot/security_limits.py tests/test_security_unit.py
+git commit -m "Add JOB_DEAD_AGE_HOURS and JOB_TERMINATE_GRACE_SEC constants"
+```
+
+---
+
+## Task 2: `bot/jobs.py` — `JobCancellation`, `JobDescriptor`, `JobRegistry` (rejestracja, listowanie, unregister)
+
+**Files:**
+- Create: `/mnt/c/code/ytdown/bot/jobs.py`
+- Test: `/mnt/c/code/ytdown/tests/test_jobs.py` (create)
+
+- [ ] **Step 2.1: Failing tests**
+
+Create `tests/test_jobs.py`:
+
+```python
+"""Unit tests for bot.jobs registry."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from unittest import mock
+
+import pytest
+
+
+def _descriptor(chat_id=42, kind="single_dl", label="t"):
+    from bot.jobs import JobDescriptor
+    return JobDescriptor(
+        job_id="",  # will be set by registry
+        chat_id=chat_id,
+        kind=kind,
+        label=label,
+        started_at=datetime.now(),
+    )
+
+
+def test_register_returns_unique_job_id():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c1 = registry.register(1, _descriptor())
+    c2 = registry.register(1, _descriptor())
+
+    assert c1.job_id != c2.job_id
+    assert len(c1.job_id) >= 8
+
+
+def test_register_creates_unset_event():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    cancellation = registry.register(1, _descriptor())
+
+    assert isinstance(cancellation.event, asyncio.Event)
+    assert cancellation.event.is_set() is False
+    assert cancellation.process is None
+    assert cancellation.pyrogram_task is None
+    assert cancellation.cancelled_reason is None
+
+
+def test_get_returns_registered_cancellation():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c1 = registry.register(1, _descriptor())
+
+    assert registry.get(c1.job_id) is c1
+    assert registry.get("nonexistent") is None
+
+
+def test_list_for_chat_returns_descriptors():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c1 = registry.register(7, _descriptor(chat_id=7, label="A"))
+    c2 = registry.register(7, _descriptor(chat_id=7, label="B"))
+
+    descriptors = registry.list_for_chat(7)
+    labels = [d.label for d in descriptors]
+
+    assert sorted(labels) == ["A", "B"]
+    assert all(d.chat_id == 7 for d in descriptors)
+
+
+def test_list_for_chat_excludes_other_chats():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    registry.register(1, _descriptor(chat_id=1, label="A"))
+    registry.register(2, _descriptor(chat_id=2, label="B"))
+
+    assert [d.label for d in registry.list_for_chat(1)] == ["A"]
+    assert [d.label for d in registry.list_for_chat(2)] == ["B"]
+
+
+def test_update_label_changes_descriptor():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor(label="initial"))
+
+    registry.update_label(c.job_id, "updated [3/5]")
+    descriptors = registry.list_for_chat(1)
+
+    assert descriptors[0].label == "updated [3/5]"
+
+
+def test_update_label_silently_ignores_unknown_job():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    registry.update_label("nonexistent", "x")  # must not raise
+
+
+def test_unregister_removes_descriptor():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    registry.unregister(c.job_id)
+
+    assert registry.get(c.job_id) is None
+    assert registry.list_for_chat(1) == []
+
+
+def test_unregister_unknown_is_noop():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    registry.unregister("nonexistent")  # must not raise
+
+
+def test_global_singleton_is_jobregistry():
+    from bot.jobs import JobRegistry, job_registry
+
+    assert isinstance(job_registry, JobRegistry)
+```
+
+- [ ] **Step 2.2: Run tests, expect FAIL**
+
+```bash
+pytest tests/test_jobs.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'bot.jobs'`.
+
+- [ ] **Step 2.3: Create `bot/jobs.py`**
+
+```python
+"""In-memory registry of long-running jobs that can be cancelled.
+
+Boundaries:
+- Knows nothing about Telegram, sessions, downloads, or 7z.
+- Consumers (handlers, services) import JobRegistry/JobCancellation and
+  attach process/pyrogram_task references on their own.
+- The global ``job_registry`` singleton is the canonical instance — tests
+  build their own JobRegistry() to stay isolated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from threading import RLock
+from typing import Literal
+
+
+JobKind = Literal[
+    "playlist_legacy",
+    "playlist_zip",
+    "single_dl",
+    "transcription",
+    "summary",
+    "archive_pack",
+    "archive_send",
+]
+
+
+@dataclass
+class JobCancellation:
+    """Cancellation handle shared across async/threadpool/subprocess layers.
+
+    The single Event is the primary signal — every long-running loop
+    polls it. ``process`` and ``pyrogram_task`` are optional resources
+    that JobRegistry.cancel() will tear down at signal time.
+    """
+
+    job_id: str
+    event: asyncio.Event
+    process: asyncio.subprocess.Process | None = None
+    pyrogram_task: asyncio.Task | None = None
+    cancelled_reason: str | None = None
+
+
+@dataclass
+class JobDescriptor:
+    """User-facing description of a job, listed by /stop."""
+
+    job_id: str
+    chat_id: int
+    kind: JobKind
+    label: str
+    started_at: datetime
+
+
+class JobRegistry:
+    """Thread-safe registry of running JobCancellation handles."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._descriptors: dict[str, JobDescriptor] = {}
+        self._cancellations: dict[str, JobCancellation] = {}
+
+    def register(self, chat_id: int, descriptor: JobDescriptor) -> JobCancellation:
+        """Register a new job for ``chat_id`` and return its cancellation handle."""
+
+        job_id = secrets.token_hex(4)
+        with self._lock:
+            descriptor.job_id = job_id
+            descriptor.chat_id = chat_id
+            self._descriptors[job_id] = descriptor
+            cancellation = JobCancellation(job_id=job_id, event=asyncio.Event())
+            self._cancellations[job_id] = cancellation
+        logging.info(
+            "job register: chat=%d kind=%s id=%s label=%r",
+            chat_id, descriptor.kind, job_id, descriptor.label,
+        )
+        return cancellation
+
+    def get(self, job_id: str) -> JobCancellation | None:
+        """Return the cancellation handle, or None if unknown / already finished."""
+
+        with self._lock:
+            return self._cancellations.get(job_id)
+
+    def list_for_chat(self, chat_id: int) -> list[JobDescriptor]:
+        """Return descriptors for jobs running in ``chat_id`` (sorted by start)."""
+
+        with self._lock:
+            descriptors = [
+                d for d in self._descriptors.values() if d.chat_id == chat_id
+            ]
+        descriptors.sort(key=lambda d: d.started_at)
+        return descriptors
+
+    def update_label(self, job_id: str, label: str) -> None:
+        """Change the displayed label of a running job. No-op when unknown."""
+
+        with self._lock:
+            descriptor = self._descriptors.get(job_id)
+            if descriptor is not None:
+                descriptor.label = label
+
+    def unregister(self, job_id: str) -> None:
+        """Drop a finished job. No-op when unknown."""
+
+        with self._lock:
+            descriptor = self._descriptors.pop(job_id, None)
+            self._cancellations.pop(job_id, None)
+        if descriptor is not None:
+            logging.info(
+                "job unregister: chat=%d kind=%s id=%s",
+                descriptor.chat_id, descriptor.kind, job_id,
+            )
+
+
+# Global singleton consumed by handlers/services.
+job_registry = JobRegistry()
+```
+
+- [ ] **Step 2.4: Run tests, expect PASS**
+
+```bash
+pytest tests/test_jobs.py -v
+```
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add bot/jobs.py tests/test_jobs.py
+git commit -m "Add JobRegistry with JobCancellation + JobDescriptor for /stop"
+```
+
+---
+
+## Task 3: `JobRegistry.cancel()` — sygnał + terminate subprocess + cancel pyrogram task
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/jobs.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_jobs.py`
+
+- [ ] **Step 3.1: Failing tests**
+
+Append to `tests/test_jobs.py`:
+
+```python
+def test_cancel_sets_event_and_returns_true():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    result = registry.cancel(c.job_id, reason="test")
+
+    assert result is True
+    assert c.event.is_set() is True
+    assert c.cancelled_reason == "test"
+
+
+def test_cancel_unknown_returns_false():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    result = registry.cancel("nonexistent")
+
+    assert result is False
+
+
+def test_cancel_terminates_attached_subprocess(monkeypatch):
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    fake_process = mock.MagicMock()
+    fake_process.terminate = mock.MagicMock()
+    fake_process.wait = mock.AsyncMock(return_value=0)
+    fake_process.returncode = None
+    fake_process.kill = mock.MagicMock()
+    c.process = fake_process
+
+    asyncio.run(registry.cancel_async(c.job_id, reason="t"))
+
+    fake_process.terminate.assert_called_once()
+    fake_process.kill.assert_not_called()
+
+
+def test_cancel_kills_subprocess_when_terminate_times_out():
+    from bot.jobs import JobRegistry
+    from bot.security_limits import JOB_TERMINATE_GRACE_SEC
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    fake_process = mock.MagicMock()
+    fake_process.terminate = mock.MagicMock()
+    fake_process.wait = mock.AsyncMock(side_effect=asyncio.TimeoutError())
+    fake_process.kill = mock.MagicMock()
+    c.process = fake_process
+
+    asyncio.run(registry.cancel_async(c.job_id, reason="t"))
+
+    fake_process.terminate.assert_called_once()
+    fake_process.kill.assert_called_once()
+
+
+def test_cancel_cancels_attached_pyrogram_task():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    fake_task = mock.MagicMock()
+    fake_task.done = mock.MagicMock(return_value=False)
+    fake_task.cancel = mock.MagicMock()
+    c.pyrogram_task = fake_task
+
+    asyncio.run(registry.cancel_async(c.job_id, reason="t"))
+
+    fake_task.cancel.assert_called_once()
+
+
+def test_cancel_skips_already_done_pyrogram_task():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    fake_task = mock.MagicMock()
+    fake_task.done = mock.MagicMock(return_value=True)
+    fake_task.cancel = mock.MagicMock()
+    c.pyrogram_task = fake_task
+
+    asyncio.run(registry.cancel_async(c.job_id, reason="t"))
+
+    fake_task.cancel.assert_not_called()
+
+
+def test_cancelled_reason_propagates():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    registry.cancel(c.job_id, reason="user via /stop")
+
+    assert c.cancelled_reason == "user via /stop"
+```
+
+- [ ] **Step 3.2: Run tests, expect FAIL**
+
+```bash
+pytest tests/test_jobs.py -v -k "cancel"
+```
+
+- [ ] **Step 3.3: Add `cancel` and `cancel_async` to `JobRegistry`**
+
+Insert these methods inside `class JobRegistry:` (after `unregister`):
+
+```python
+    def cancel(self, job_id: str, reason: str = "user via /stop") -> bool:
+        """Sync cancel: set the event + reason. Subprocess/task teardown happens
+        in cancel_async (called by the /stop handler which is async).
+
+        Returns True if the job was registered and signalled, False otherwise.
+        """
+
+        with self._lock:
+            cancellation = self._cancellations.get(job_id)
+            if cancellation is None:
+                return False
+            cancellation.cancelled_reason = reason
+            cancellation.event.set()
+        logging.info("job cancel: id=%s reason=%r", job_id, reason)
+        return True
+
+    async def cancel_async(self, job_id: str, reason: str = "user via /stop") -> bool:
+        """Async cancel: also terminates an attached subprocess and cancels an
+        attached pyrogram_task. Used by the /stop callback handler."""
+
+        from bot.security_limits import JOB_TERMINATE_GRACE_SEC
+
+        with self._lock:
+            cancellation = self._cancellations.get(job_id)
+            if cancellation is None:
+                return False
+            cancellation.cancelled_reason = reason
+            cancellation.event.set()
+            process = cancellation.process
+            task = cancellation.pyrogram_task
+
+        if process is not None:
+            try:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(
+                        process.wait(), timeout=JOB_TERMINATE_GRACE_SEC,
+                    )
+                except asyncio.TimeoutError:
+                    logging.warning(
+                        "job %s: SIGTERM grace expired, sending SIGKILL", job_id,
+                    )
+                    process.kill()
+            except ProcessLookupError:
+                # Already exited — nothing to do.
+                pass
+
+        if task is not None and not task.done():
+            task.cancel()
+
+        logging.info("job cancel_async done: id=%s reason=%r", job_id, reason)
+        return True
+```
+
+- [ ] **Step 3.4: Run tests, expect PASS**
+
+```bash
+pytest tests/test_jobs.py -v
+```
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add bot/jobs.py tests/test_jobs.py
+git commit -m "Add JobRegistry.cancel and cancel_async with subprocess/task teardown"
+```
+
+---
+
+## Task 4: `JobRegistry.purge_dead()` — usuwanie zombie joboów
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/jobs.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_jobs.py`
+
+- [ ] **Step 4.1: Failing tests**
+
+Append to `tests/test_jobs.py`:
+
+```python
+def test_purge_dead_removes_old_entries():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    old = _descriptor(label="old")
+    old.started_at = datetime.now() - timedelta(hours=7)
+    registry.register(1, old)
+    fresh = _descriptor(label="fresh")
+    registry.register(1, fresh)
+
+    removed = registry.purge_dead(threshold=timedelta(hours=6))
+
+    assert removed == 1
+    labels = [d.label for d in registry.list_for_chat(1)]
+    assert labels == ["fresh"]
+
+
+def test_purge_dead_returns_zero_when_all_fresh():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    registry.register(1, _descriptor(label="A"))
+    registry.register(1, _descriptor(label="B"))
+
+    removed = registry.purge_dead(threshold=timedelta(hours=6))
+
+    assert removed == 0
+    assert len(registry.list_for_chat(1)) == 2
+```
+
+- [ ] **Step 4.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_jobs.py -v -k "purge_dead"
+```
+
+- [ ] **Step 4.3: Add `purge_dead` to JobRegistry**
+
+Insert in `class JobRegistry:` after `cancel_async`:
+
+```python
+    def purge_dead(self, threshold: timedelta) -> int:
+        """Drop entries older than ``threshold``. Used by cleanup.py.
+
+        Returns the number of entries removed. Logs each as a warning —
+        a zombie job means a layer failed to call unregister in finally.
+        """
+
+        cutoff = datetime.now() - threshold
+        removed = 0
+        with self._lock:
+            for job_id in list(self._descriptors):
+                descriptor = self._descriptors[job_id]
+                if descriptor.started_at < cutoff:
+                    age_h = (datetime.now() - descriptor.started_at).total_seconds() / 3600
+                    logging.warning(
+                        "purge zombie job: id=%s kind=%s chat=%d age=%.1fh",
+                        job_id, descriptor.kind, descriptor.chat_id, age_h,
+                    )
+                    self._descriptors.pop(job_id, None)
+                    self._cancellations.pop(job_id, None)
+                    removed += 1
+        return removed
+```
+
+- [ ] **Step 4.4: Run, expect PASS**
+
+```bash
+pytest tests/test_jobs.py -v
+```
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add bot/jobs.py tests/test_jobs.py
+git commit -m "Add JobRegistry.purge_dead for zombie job cleanup"
+```
+
+---
+
+## Task 5: `ArchivePartialState` w `session_store.py`
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/session_store.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_session_store.py`
+
+- [ ] **Step 5.1: Failing test**
+
+Append to `tests/test_session_store.py`:
+
+```python
+def test_partial_archive_workspaces_field_holds_state():
+    from bot.session_store import (
+        ArchivePartialState,
+        partial_archive_workspaces,
+        session_store,
+    )
+    from datetime import datetime
+    from pathlib import Path
+
+    session_store.reset()
+    state = ArchivePartialState(
+        workspace=Path("/tmp/ws"),
+        downloaded=[Path("/tmp/ws/a.mp3"), Path("/tmp/ws/b.mp3")],
+        title="My playlist",
+        media_type="audio",
+        format_choice="mp3",
+        use_mtproto=True,
+        created_at=datetime(2026, 5, 3, 10, 0, 0),
+    )
+    partial_archive_workspaces[55] = {"tok-1": state}
+
+    assert partial_archive_workspaces[55] == {"tok-1": state}
+    session_store.reset()
+```
+
+- [ ] **Step 5.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_session_store.py -v -k "partial_archive"
+```
+
+- [ ] **Step 5.3: Add `ArchivePartialState` and field**
+
+In `bot/session_store.py`, locate `ArchivedDeliveryState` and add after it:
+
+```python
+@dataclass
+class ArchivePartialState:
+    """In-memory state for a cancelled-mid-flight playlist archive.
+
+    Captured by execute_playlist_archive_flow when a cancel signal arrives
+    after some entries downloaded; lets the user click [Spakuj co mam] to
+    package whatever was already pulled.
+    """
+
+    workspace: Any        # pathlib.Path
+    downloaded: list[Any] # list[Path]
+    title: str
+    media_type: str
+    format_choice: str
+    use_mtproto: bool
+    created_at: Any       # datetime
+```
+
+In `SessionState`, add field after `archived_deliveries`:
+
+```python
+    partial_archive_workspaces: dict[str, "ArchivePartialState"] | None = None
+```
+
+In `_cleanup_if_empty` predicate, add the new field to the conjunction:
+
+```python
+            and session.archived_deliveries is None
+            and session.partial_archive_workspaces is None
+```
+
+At the end of file (after `archived_deliveries = SessionFieldMap(...)`):
+
+```python
+partial_archive_workspaces = SessionFieldMap(session_store, "partial_archive_workspaces")
+```
+
+- [ ] **Step 5.4: Run, expect PASS**
+
+```bash
+pytest tests/test_session_store.py -v
+```
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add bot/session_store.py tests/test_session_store.py
+git commit -m "Add ArchivePartialState session field for /stop recovery flow"
+```
+
+---
+
+## Task 6: `pack_to_volumes` przyjmuje `cancellation`
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/archive.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_archive.py`
+
+- [ ] **Step 6.1: Failing tests**
+
+Append to `tests/test_archive.py`:
+
+```python
+def test_pack_to_volumes_attaches_process_to_cancellation(tmp_path, monkeypatch):
+    from bot import archive
+    from bot.jobs import JobCancellation
+    import asyncio
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+    dest = tmp_path / "out"
+
+    captured_cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+
+    completed = mock.AsyncMock()
+    completed.communicate = mock.AsyncMock(return_value=(b"", b""))
+    completed.returncode = 0
+
+    async def fake_exec(*args, **kwargs):
+        # Simulate completed pack with one volume.
+        (tmp_path / "out.7z.001").write_bytes(b"v")
+        return completed
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        asyncio.run(
+            archive.pack_to_volumes(
+                [src], dest, volume_size_mb=1, cancellation=captured_cancellation,
+            )
+        )
+
+    # During run cancellation.process was set to the subprocess.
+    # After completion, it does not need to be reset; verifying attach is sufficient.
+    assert captured_cancellation.process is completed
+
+
+def test_pack_to_volumes_terminates_on_cancel(tmp_path):
+    from bot import archive
+    from bot.jobs import JobCancellation
+    import asyncio
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+    dest = tmp_path / "out"
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+    cancellation.event.set()  # already cancelled
+
+    fake_proc = mock.MagicMock()
+    fake_proc.communicate = mock.AsyncMock(return_value=(b"", b""))
+    fake_proc.returncode = 0
+    fake_proc.terminate = mock.MagicMock()
+    fake_proc.kill = mock.MagicMock()
+    fake_proc.wait = mock.AsyncMock(return_value=0)
+    # Empty stdout so _stream_7z_progress exits quickly.
+    fake_proc.stdout = mock.MagicMock()
+    fake_proc.stdout.readline = mock.AsyncMock(return_value=b"")
+
+    async def fake_exec(*args, **kwargs):
+        return fake_proc
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        with pytest.raises(RuntimeError, match="cancelled"):
+            asyncio.run(
+                archive.pack_to_volumes(
+                    [src], dest, volume_size_mb=1, cancellation=cancellation,
+                )
+            )
+
+    fake_proc.terminate.assert_called_once()
+
+
+def test_pack_to_volumes_cleans_partial_volumes_on_cancel(tmp_path):
+    from bot import archive
+    from bot.jobs import JobCancellation
+    import asyncio
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+    dest = tmp_path / "playlist"
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+    cancellation.event.set()
+
+    fake_proc = mock.MagicMock()
+    fake_proc.communicate = mock.AsyncMock(return_value=(b"", b""))
+    fake_proc.returncode = 0
+    fake_proc.terminate = mock.MagicMock()
+    fake_proc.kill = mock.MagicMock()
+    fake_proc.wait = mock.AsyncMock(return_value=0)
+    fake_proc.stdout = mock.MagicMock()
+    fake_proc.stdout.readline = mock.AsyncMock(return_value=b"")
+
+    async def fake_exec(*args, **kwargs):
+        # Pretend two volumes started writing before terminate.
+        (tmp_path / "playlist.7z.001").write_bytes(b"a")
+        (tmp_path / "playlist.7z.002").write_bytes(b"b")
+        return fake_proc
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        with pytest.raises(RuntimeError, match="cancelled"):
+            asyncio.run(
+                archive.pack_to_volumes(
+                    [src], dest, volume_size_mb=1, cancellation=cancellation,
+                )
+            )
+
+    # Partial volumes must be cleaned up.
+    assert not (tmp_path / "playlist.7z.001").exists()
+    assert not (tmp_path / "playlist.7z.002").exists()
+```
+
+- [ ] **Step 6.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_archive.py -v -k "cancel"
+```
+
+- [ ] **Step 6.3: Modify `pack_to_volumes`**
+
+In `bot/archive.py`, change the signature and body:
+
+```python
+async def pack_to_volumes(
+    sources: Sequence[Path],
+    dest_basename: Path,
+    volume_size_mb: int,
+    *,
+    progress_cb: Callable[[str], Awaitable[None]] | None = None,
+    cancellation: "JobCancellation | None" = None,
+) -> list[Path]:
+    """Pack ``sources`` into a 7z multi-volume archive at ``dest_basename``.
+
+    When ``cancellation`` is provided, the spawned 7z process is attached
+    to it so a /stop signal can terminate it. On cancellation the partial
+    .7z.NNN volumes are removed and RuntimeError("cancelled") is raised.
+
+    Resulting volumes are named ``<dest_basename>.7z.001``, ``.002`` etc.
+    Returns the sorted list of created volume paths on success.
+    """
+
+    if not sources:
+        raise ValueError("empty sources")
+
+    archive_path = dest_basename.with_suffix(".7z")
+    args = [
+        "7z", "a", "-t7z", f"-v{volume_size_mb}m", "-mx0", "-mmt=on",
+        str(archive_path),
+        *[str(src) for src in sources],
+    ]
+
+    logging.info("Running 7z pack: %s", " ".join(args))
+    process = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    if cancellation is not None:
+        cancellation.process = process
+
+    try:
+        if progress_cb is not None:
+            await _stream_7z_progress(process, progress_cb, cancellation)
+
+        # If user cancelled before we started reading stdout, terminate now.
+        if cancellation is not None and cancellation.event.is_set():
+            await _terminate_with_grace(process)
+            _remove_partial_volumes(dest_basename)
+            raise RuntimeError("cancelled")
+
+        stdout, stderr = await process.communicate()
+        if process.returncode != 0:
+            err = stderr.decode("utf-8", errors="replace")[:200]
+            raise RuntimeError(f"7z failed (exit {process.returncode}): {err}")
+    except asyncio.CancelledError:
+        await _terminate_with_grace(process)
+        _remove_partial_volumes(dest_basename)
+        raise
+
+    parent = dest_basename.parent
+    prefix = f"{archive_path.name}."
+    volumes = sorted(
+        p for p in parent.iterdir()
+        if p.name.startswith(prefix) and p.name[len(prefix):].isdigit()
+    )
+    logging.info("7z packed %d volume(s) for %s", len(volumes), archive_path)
+    return volumes
+
+
+async def _terminate_with_grace(process: asyncio.subprocess.Process) -> None:
+    """SIGTERM → grace → SIGKILL fallback."""
+
+    from bot.security_limits import JOB_TERMINATE_GRACE_SEC
+
+    if process.returncode is not None:
+        return
+    try:
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=JOB_TERMINATE_GRACE_SEC)
+        except asyncio.TimeoutError:
+            logging.warning("7z SIGTERM grace expired, sending SIGKILL")
+            process.kill()
+            await process.wait()
+    except ProcessLookupError:
+        pass
+
+
+def _remove_partial_volumes(dest_basename: Path) -> None:
+    """Delete any <dest>.7z.NNN files left after a cancelled pack."""
+
+    archive_name = dest_basename.with_suffix(".7z").name
+    prefix = f"{archive_name}."
+    for entry in dest_basename.parent.iterdir():
+        if entry.name.startswith(prefix) and entry.name[len(prefix):].isdigit():
+            try:
+                entry.unlink()
+            except OSError as exc:
+                logging.warning("Could not remove partial volume %s: %s", entry, exc)
+```
+
+Update `_stream_7z_progress` signature to accept the optional cancellation and break on event:
+
+```python
+async def _stream_7z_progress(
+    process: asyncio.subprocess.Process,
+    progress_cb: Callable[[str], Awaitable[None]],
+    cancellation: "JobCancellation | None" = None,
+) -> None:
+    """Throttle 7z stdout updates to one progress_cb call every 2 seconds.
+
+    When ``cancellation`` is provided and its event becomes set, the loop
+    exits so the caller can terminate the subprocess.
+    """
+
+    if process.stdout is None:
+        return
+
+    last_update = 0.0
+    loop = asyncio.get_running_loop()
+    while True:
+        if cancellation is not None and cancellation.event.is_set():
+            return
+        line = await process.stdout.readline()
+        if not line:
+            break
+        now = loop.time()
+        if now - last_update < 2.0:
+            continue
+        decoded = line.decode("utf-8", errors="replace").strip()
+        if decoded:
+            try:
+                await progress_cb(decoded)
+            except Exception as exc:
+                logging.warning("Archive progress callback failed: %s", exc)
+            last_update = now
+```
+
+- [ ] **Step 6.4: Run, expect PASS**
+
+```bash
+pytest tests/test_archive.py -v
+```
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add bot/archive.py tests/test_archive.py
+git commit -m "Wire cancellation into pack_to_volumes (terminate + cleanup partials)"
+```
+
+---
+
+## Task 7: `execute_download` progress hook respects cancellation
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/services/download_service.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_download_service.py`
+
+- [ ] **Step 7.1: Failing test**
+
+Append to `tests/test_download_service.py`:
+
+```python
+def test_execute_download_progress_hook_raises_on_cancel(tmp_path, monkeypatch):
+    """When cancellation.event is set, the wrapped progress hook raises DownloadError."""
+    import asyncio
+    import yt_dlp
+
+    from bot.jobs import JobCancellation
+    from bot.services import download_service
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+
+    captured_hook = {}
+
+    def fake_progress_factory(_chat_id):
+        def real_hook(_data):
+            return None
+        return real_hook
+
+    # Capture the wrapped hook by patching create_progress_hook to return a
+    # known function that download_service then wraps.
+    plan = mock.MagicMock()
+    plan.url = "u"
+    plan.duration_str = "0:30"
+    plan.ydl_opts = {}
+    plan.chat_download_path = str(tmp_path)
+    plan.sanitized_title = "x"
+    plan.output_path = str(tmp_path / "x")
+
+    progress_state: dict = {}
+    state_after = {}
+
+    # Patch find_downloaded_file to keep things short.
+    monkeypatch.setattr(download_service, "find_downloaded_file", lambda p: None)
+
+    async def fake_download_call():
+        # Look up the wrapped hook attached to ydl_opts['progress_hooks'].
+        wrapped = plan.ydl_opts['progress_hooks'][0]
+        captured_hook["fn"] = wrapped
+        cancellation.event.set()
+        # Calling wrapped hook should raise.
+        with pytest.raises(yt_dlp.utils.DownloadError, match="cancelled"):
+            wrapped({"status": "downloading", "downloaded_bytes": 1})
+        raise FileNotFoundError("simulated finish")
+
+    with mock.patch("yt_dlp.YoutubeDL") as ydl_mock:
+        instance = ydl_mock.return_value
+        instance.download = lambda urls: asyncio.get_event_loop().run_until_complete(fake_download_call())
+
+        with pytest.raises(FileNotFoundError):
+            asyncio.run(
+                download_service.execute_download(
+                    plan,
+                    chat_id=1,
+                    executor=mock.MagicMock(submit=lambda fn: type("F", (), {
+                        "done": lambda self: True,
+                        "result": fn,
+                    })()),
+                    progress_hook_factory=fake_progress_factory,
+                    progress_state=progress_state,
+                    status_callback=mock.AsyncMock(),
+                    format_bytes=str,
+                    format_eta=str,
+                    cancellation=cancellation,
+                )
+            )
+
+    assert "fn" in captured_hook
+```
+
+(The test is intentionally narrow — it only verifies that when `execute_download` builds `ydl_opts['progress_hooks']`, the wrapped hook honors the cancellation event by raising `yt_dlp.utils.DownloadError`. The full download flow is heavier than needed here.)
+
+- [ ] **Step 7.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_download_service.py -v -k "cancel"
+```
+
+- [ ] **Step 7.3: Modify `execute_download`**
+
+In `bot/services/download_service.py`, change `execute_download` signature and add cancellation wrapping:
+
+```python
+async def execute_download(
+    plan: DownloadPlan,
+    *,
+    chat_id: int,
+    executor: Any,
+    progress_hook_factory: Callable[[int], Callable[[dict[str, Any]], None]],
+    progress_state: dict[int, dict[str, Any]],
+    status_callback: Callable[[str], Any],
+    format_bytes: Callable[[int | float | None], str],
+    format_eta: Callable[[int | float | None], str],
+    cancellation: "JobCancellation | None" = None,
+) -> DownloadResult:
+    """Run yt-dlp download and stream progress updates through a callback.
+
+    When ``cancellation`` is provided, the progress hook raises
+    yt_dlp.utils.DownloadError("cancelled") whenever the event is set.
+    yt-dlp catches that and cleans up the .part file automatically.
+    """
+
+    ydl_opts = plan.ydl_opts.copy()
+
+    base_hook = progress_hook_factory(chat_id)
+
+    def hook(d):
+        if cancellation is not None and cancellation.event.is_set():
+            import yt_dlp
+            raise yt_dlp.utils.DownloadError("cancelled by user")
+        base_hook(d)
+
+    ydl_opts['progress_hooks'] = [hook]
+    progress_state[chat_id] = {'status': 'starting', 'updated': time.time()}
+
+    loop = asyncio.get_event_loop()
+    future = loop.run_in_executor(
+        executor,
+        lambda: yt_dlp.YoutubeDL(ydl_opts).download([plan.url]),
+    )
+
+    last_update = ""
+    try:
+        while not future.done():
+            progress = progress_state.get(chat_id, {})
+            if progress.get('status') == 'downloading':
+                percent = progress.get('percent', '?%')
+                downloaded = format_bytes(progress.get('downloaded', 0))
+                total = format_bytes(progress.get('total', 0))
+                speed = (
+                    format_bytes(progress.get('speed', 0)) + "/s"
+                    if progress.get('speed') else "?"
+                )
+                eta = format_eta(progress.get('eta'))
+
+                status_text = (
+                    f"Pobieranie: {percent}\n\n"
+                    f"Pobrano: {downloaded} / {total}\n"
+                    f"Prędkość: {speed}\n"
+                    f"Pozostało: {eta}\n\n"
+                    f"Czas trwania: {plan.duration_str}"
+                )
+
+                if status_text != last_update:
+                    last_update = status_text
+                    await status_callback(status_text)
+
+            await asyncio.sleep(1)
+
+        await future
+    finally:
+        progress_state.pop(chat_id, None)
+
+    downloaded_file_path = find_downloaded_file(plan)
+    if not downloaded_file_path:
+        raise FileNotFoundError("downloaded file not found")
+
+    file_size_mb = os.path.getsize(downloaded_file_path) / (1024 * 1024)
+    return DownloadResult(file_path=downloaded_file_path, file_size_mb=file_size_mb)
+```
+
+- [ ] **Step 7.4: Run, expect PASS**
+
+```bash
+pytest tests/test_download_service.py -v
+```
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add bot/services/download_service.py tests/test_download_service.py
+git commit -m "Honor cancellation in execute_download progress hook"
+```
+
+---
+
+## Task 8: `download_playlist_into` respects cancellation
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/services/archive_service.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_archive_service.py`
+
+- [ ] **Step 8.1: Failing test**
+
+Append to `tests/test_archive_service.py`:
+
+```python
+def test_download_playlist_into_breaks_on_cancel(tmp_path, monkeypatch):
+    import asyncio
+    from bot.services import archive_service
+    from bot.jobs import JobCancellation
+
+    workspace = tmp_path / "pl_x"
+    workspace.mkdir()
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+    iter_count = {"n": 0}
+
+    async def fake_run(entry, workspace_path, **kwargs):
+        iter_count["n"] += 1
+        if iter_count["n"] == 2:
+            cancellation.event.set()
+        produced = workspace_path / f"{entry['title']}.bin"
+        produced.write_bytes(b"x")
+        return produced, 0.5
+
+    monkeypatch.setattr(archive_service, "_download_one_into_workspace", fake_run)
+
+    entries = [
+        {"url": "u1", "title": "first"},
+        {"url": "u2", "title": "second"},
+        {"url": "u3", "title": "third"},
+    ]
+
+    paths, failed = asyncio.run(
+        archive_service.download_playlist_into(
+            workspace, entries, media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(), status_cb=mock.AsyncMock(),
+            cancellation=cancellation,
+        )
+    )
+
+    assert {p.name for p in paths} == {"first.bin", "second.bin"}
+    assert any("anulowano" in t.lower() for t in failed)
+```
+
+- [ ] **Step 8.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_archive_service.py -v -k "breaks_on_cancel"
+```
+
+- [ ] **Step 8.3: Modify `download_playlist_into`**
+
+Change signature and add the event check at the top of the loop:
+
+```python
+async def download_playlist_into(
+    workspace: Path,
+    entries: list[dict],
+    *,
+    media_type: str,
+    format_choice: str,
+    executor: ThreadPoolExecutor,
+    status_cb: Callable[[str], Awaitable[None]],
+    cancellation: "JobCancellation | None" = None,
+) -> tuple[list[Path], list[str]]:
+    """Download every entry into workspace, keeping the files (no os.remove).
+
+    When ``cancellation.event`` becomes set, the loop breaks early; titles
+    of entries that didn't run get ``" (anulowano)"`` suffix in failed_titles.
+    """
+
+    downloaded: list[Path] = []
+    failed: list[str] = []
+    total = len(entries)
+
+    for idx, entry in enumerate(entries, 1):
+        title = entry.get("title", f"item_{idx}")
+        if cancellation is not None and cancellation.event.is_set():
+            for skipped in entries[idx - 1:]:
+                failed.append(f"{skipped.get('title', '?')} (anulowano)")
+            break
+        await status_cb(f"[{idx}/{total}] Pobieranie: {title}...")
+        try:
+            path, size = await _download_one_into_workspace(
+                entry,
+                workspace,
+                media_type=media_type,
+                format_choice=format_choice,
+                executor=executor,
+            )
+        except Exception as exc:
+            logging.error("Archive download failed for %s: %s", title, exc)
+            failed.append(title)
+            continue
+
+        if path is None:
+            mb_str = f"{size:.0f} MB" if size is not None else "?"
+            failed.append(f"{title} (za duzy: {mb_str})")
+            continue
+
+        downloaded.append(path)
+
+    return downloaded, failed
+```
+
+- [ ] **Step 8.4: Run, expect PASS**
+
+```bash
+pytest tests/test_archive_service.py -v
+```
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add bot/services/archive_service.py tests/test_archive_service.py
+git commit -m "Honor cancellation in download_playlist_into loop"
+```
+
+---
+
+## Task 9: `send_volumes` respects cancellation
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/services/archive_service.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_archive_service.py`
+
+- [ ] **Step 9.1: Failing test**
+
+Append to `tests/test_archive_service.py`:
+
+```python
+def test_send_volumes_breaks_on_cancel(tmp_path, monkeypatch):
+    import asyncio
+    from bot.services import archive_service
+    from bot.jobs import JobCancellation
+
+    volumes = []
+    for i in range(1, 6):
+        v = tmp_path / f"out.7z.00{i}"
+        v.write_bytes(b"x")
+        volumes.append(v)
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+
+    bot = mock.MagicMock()
+    sent = []
+
+    async def fake_send(**kwargs):
+        sent.append(kwargs["caption"])
+        if len(sent) == 2:
+            cancellation.event.set()
+
+    bot.send_document = fake_send
+
+    monkeypatch.setattr(
+        archive_service, "mtproto_unavailability_reason", lambda: "n/a",
+    )
+
+    asyncio.run(
+        archive_service.send_volumes(
+            bot, chat_id=1, volumes=volumes, caption_prefix="X",
+            use_mtproto=False, status_cb=mock.AsyncMock(),
+            cancellation=cancellation,
+        )
+    )
+
+    assert len(sent) == 2  # third volume was not sent
+```
+
+- [ ] **Step 9.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_archive_service.py -v -k "send_volumes_breaks"
+```
+
+- [ ] **Step 9.3: Modify `send_volumes`**
+
+```python
+async def send_volumes(
+    bot,
+    chat_id: int,
+    volumes: list[Path],
+    caption_prefix: str,
+    use_mtproto: bool,
+    *,
+    start_index: int = 0,
+    status_cb: Callable[[str], Awaitable[None]] | None = None,
+    cancellation: "JobCancellation | None" = None,
+) -> None:
+    """Send 7z volumes [start_index:] to ``chat_id`` as documents.
+
+    Volumes ≤ TELEGRAM_UPLOAD_LIMIT_MB go via Bot API; larger ones via
+    MTProto. When cancellation.event is set the loop breaks before the
+    next volume.
+    """
+
+    total = len(volumes)
+    for idx in range(start_index, total):
+        if cancellation is not None and cancellation.event.is_set():
+            return
+        volume = volumes[idx]
+        size_mb = volume.stat().st_size / (1024 * 1024)
+        caption = f"{caption_prefix} [{idx + 1}/{total}]"
+        if status_cb is not None:
+            await status_cb(f"Wysyłanie [{idx + 1}/{total}] ({size_mb:.0f} MB)...")
+
+        if size_mb <= TELEGRAM_UPLOAD_LIMIT_MB:
+            with open(volume, "rb") as handle:
+                await bot.send_document(
+                    chat_id=chat_id,
+                    document=handle,
+                    filename=volume.name,
+                    caption=caption,
+                    read_timeout=120,
+                    write_timeout=120,
+                )
+        else:
+            reason = mtproto_unavailability_reason()
+            if reason is not None:
+                raise RuntimeError(
+                    f"Wolumen {volume.name} przekracza Bot API ({size_mb:.0f} MB), "
+                    f"a MTProto jest niedostępny: {reason}"
+                )
+            ok = await send_document_mtproto(
+                chat_id=chat_id,
+                file_path=str(volume),
+                caption=caption,
+                file_name=volume.name,
+            )
+            if not ok:
+                raise RuntimeError(f"Wysyłka {volume.name} przez MTProto nie powiodła się.")
+
+        logging.info("Sent volume %d/%d: %s (%.1f MB)", idx + 1, total, volume.name, size_mb)
+```
+
+- [ ] **Step 9.4: Run, expect PASS**
+
+```bash
+pytest tests/test_archive_service.py -v
+```
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add bot/services/archive_service.py tests/test_archive_service.py
+git commit -m "Honor cancellation in send_volumes loop"
+```
+
+---
+
+## Task 10: `execute_playlist_archive_flow` rejestruje job, captures partial state
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/services/archive_service.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_archive_service.py`
+
+- [ ] **Step 10.1: Failing tests**
+
+Append to `tests/test_archive_service.py`:
+
+```python
+def test_execute_playlist_archive_flow_registers_and_unregisters(tmp_path, monkeypatch):
+    import asyncio
+    from bot.services import archive_service
+    from bot.jobs import JobRegistry
+    from bot.session_store import session_store
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    test_registry = JobRegistry()
+    monkeypatch.setattr(archive_service, "job_registry", test_registry)
+
+    job_seen_during_run = {}
+
+    async def fake_download_into(workspace, entries, **kwargs):
+        # Snapshot job listing while the flow is in-flight.
+        job_seen_during_run["count"] = len(test_registry.list_for_chat(99))
+        path = workspace / "a.mp3"
+        path.write_bytes(b"x")
+        return [path], []
+
+    async def fake_pack(sources, dest_basename, volume_size_mb, **kwargs):
+        produced = dest_basename.parent / f"{dest_basename.with_suffix('.7z').name}.001"
+        produced.write_bytes(b"v")
+        return [produced]
+
+    async def fake_send(*a, **kw):
+        return None
+
+    monkeypatch.setattr(archive_service, "download_playlist_into", fake_download_into)
+    monkeypatch.setattr(archive_service, "pack_to_volumes", fake_pack)
+    monkeypatch.setattr(archive_service, "send_volumes", fake_send)
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: None)
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    asyncio.run(
+        archive_service.execute_playlist_archive_flow(
+            update, context, chat_id=99,
+            playlist={"title": "Hits", "entries": [{"url": "u", "title": "a"}]},
+            media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(),
+        )
+    )
+
+    assert job_seen_during_run["count"] == 1
+    # Unregistered after success.
+    assert test_registry.list_for_chat(99) == []
+    session_store.reset()
+
+
+def test_execute_playlist_archive_flow_captures_partial_state_on_cancel(tmp_path, monkeypatch):
+    import asyncio
+    from bot.services import archive_service
+    from bot.jobs import JobRegistry
+    from bot.session_store import partial_archive_workspaces, session_store
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    test_registry = JobRegistry()
+    monkeypatch.setattr(archive_service, "job_registry", test_registry)
+
+    async def fake_download_into(workspace, entries, *, cancellation=None, **kwargs):
+        # Simulate two entries downloaded, then cancellation.
+        p1 = workspace / "a.mp3"; p1.write_bytes(b"x")
+        p2 = workspace / "b.mp3"; p2.write_bytes(b"x")
+        cancellation.event.set()
+        return [p1, p2], ["c (anulowano)"]
+
+    pack_called = mock.AsyncMock()
+    send_called = mock.AsyncMock()
+    monkeypatch.setattr(archive_service, "download_playlist_into", fake_download_into)
+    monkeypatch.setattr(archive_service, "pack_to_volumes", pack_called)
+    monkeypatch.setattr(archive_service, "send_volumes", send_called)
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: None)
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    asyncio.run(
+        archive_service.execute_playlist_archive_flow(
+            update, context, chat_id=99,
+            playlist={"title": "Hits", "entries": [
+                {"url": "u1", "title": "a"},
+                {"url": "u2", "title": "b"},
+                {"url": "u3", "title": "c"},
+            ]},
+            media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(),
+        )
+    )
+
+    # Pack and send must NOT have been called.
+    assert pack_called.await_count == 0
+    assert send_called.await_count == 0
+    # Partial state captured.
+    bucket = partial_archive_workspaces.get(99) or {}
+    assert len(bucket) == 1
+    state = next(iter(bucket.values()))
+    assert len(state.downloaded) == 2
+    assert state.title == "Hits"
+    session_store.reset()
+```
+
+- [ ] **Step 10.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_archive_service.py -v -k "execute_playlist_archive_flow"
+```
+
+- [ ] **Step 10.3: Modify `execute_playlist_archive_flow`**
+
+In `bot/services/archive_service.py`, add imports near the top:
+
+```python
+from datetime import datetime as _datetime  # alias to avoid shadow
+from bot.jobs import JobDescriptor, job_registry
+from bot.session_store import (
+    ArchivePartialState,
+    ArchivedDeliveryState,
+    archived_deliveries,
+    partial_archive_workspaces,
+    pending_archive_jobs,
+)
+```
+
+(Adjust existing imports — `partial_archive_workspaces` and `ArchivePartialState` are new.)
+
+Wrap `execute_playlist_archive_flow` body in a try/finally that registers/unregisters the job, propagates cancellation, and captures partial state on cancel. Replace the existing function body with:
+
+```python
+async def execute_playlist_archive_flow(
+    update,
+    context,
+    *,
+    chat_id: int,
+    playlist: dict[str, Any],
+    media_type: str,
+    format_choice: str,
+    executor: ThreadPoolExecutor,
+) -> None:
+    """End-to-end: workspace → download all → pack to 7z → send volumes.
+
+    Registers a job with job_registry so /stop can cancel mid-flight.
+    On cancel during download phase, saves an ArchivePartialState so the
+    user can click [Spakuj co mam] from the cancel-status message.
+    """
+
+    if not is_7z_available():
+        await _safe_status_edit(
+            update,
+            "Funkcja 7z niedostępna — administrator nie zainstalował p7zip-full.",
+        )
+        return
+
+    use_mtproto = mtproto_unavailability_reason() is None
+    volume_size_mb = volume_size_for(use_mtproto)
+
+    title = playlist.get("title", "Playlista")
+    entries = playlist.get("entries") or []
+    total = len(entries)
+
+    descriptor = JobDescriptor(
+        job_id="",  # filled by registry
+        chat_id=chat_id,
+        kind="playlist_zip",
+        label=f"Playlist 7z ({media_type} {format_choice}) — start",
+        started_at=datetime.now(),
+    )
+    cancellation = job_registry.register(chat_id, descriptor)
+
+    workspace = prepare_playlist_workspace(chat_id, title, prefix="pl")
+    lock_path = workspace / ".lock"
+    lock_path.touch()
+
+    async def status(text: str) -> None:
+        await _safe_status_edit(update, text)
+
+    await status(
+        f"Playlista → 7z ({media_type} {format_choice})\n"
+        f"[0/{total}] Pobieranie..."
+    )
+
+    downloaded: list[Path] = []
+    failed: list[str] = []
+    try:
+        job_registry.update_label(
+            cancellation.job_id,
+            f"Playlist 7z ({media_type} {format_choice}) — pobieranie [0/{total}]",
+        )
+        downloaded, failed = await download_playlist_into(
+            workspace,
+            entries,
+            media_type=media_type,
+            format_choice=format_choice,
+            executor=executor,
+            status_cb=status,
+            cancellation=cancellation,
+        )
+
+        if cancellation.event.is_set():
+            await _save_partial_state_after_cancel(
+                update, chat_id, workspace, downloaded, title,
+                media_type, format_choice, use_mtproto, total,
+            )
+            return
+
+        if not downloaded:
+            shutil.rmtree(workspace, ignore_errors=True)
+            await status("Nie udało się pobrać żadnego elementu.")
+            return
+
+        job_registry.update_label(
+            cancellation.job_id,
+            f"Playlist 7z ({media_type} {format_choice}) — pakowanie",
+        )
+        await status(f"Pakowanie do 7z (vol_size={volume_size_mb} MB)...")
+        slug = _build_slug(title)
+        dest_basename = workspace / compute_archive_basename(
+            f"{slug}_{media_type}_{format_choice}", datetime.now()
+        )
+        volumes = await pack_to_volumes(
+            downloaded, dest_basename, volume_size_mb,
+            cancellation=cancellation,
+        )
+
+        if cancellation.event.is_set():
+            # User cancelled during pack — pack_to_volumes already cleaned partials.
+            await _save_partial_state_after_cancel(
+                update, chat_id, workspace, downloaded, title,
+                media_type, format_choice, use_mtproto, total,
+            )
+            return
+
+        caption_prefix = f"{title} ({media_type} {format_choice})"
+        job_registry.update_label(
+            cancellation.job_id,
+            f"Playlist 7z ({media_type} {format_choice}) — wysyłka [0/{len(volumes)}]",
+        )
+        await status(f"Pakowanie OK: {len(volumes)} paczek. Wysyłanie...")
+        await send_volumes(
+            context.bot,
+            chat_id=chat_id,
+            volumes=volumes,
+            caption_prefix=caption_prefix,
+            use_mtproto=use_mtproto,
+            status_cb=status,
+            cancellation=cancellation,
+        )
+
+        delivery = ArchivedDeliveryState(
+            workspace=workspace,
+            volumes=volumes,
+            caption_prefix=caption_prefix,
+            use_mtproto=use_mtproto,
+            created_at=datetime.now(),
+        )
+        token = register_archived_delivery(chat_id, delivery)
+
+        summary_lines = [
+            "Playlista zakończona.",
+            f"Pobrano: {len(downloaded)}/{total}",
+            f"Spakowano: {len(downloaded)} plików → {len(volumes)} paczek 7z",
+            f"Wysłano: {len(volumes)}/{len(volumes)}"
+            if not cancellation.event.is_set()
+            else f"Wysłano: <{len(volumes)} (anulowano)",
+            f"Folder zostanie usunięty po {PLAYLIST_ARCHIVE_RETENTION_MIN} min.",
+        ]
+        if failed:
+            summary_lines.append("")
+            summary_lines.append("Nieudane elementy:")
+            for title_ in failed[:5]:
+                summary_lines.append(f"  - {title_[:60]}")
+
+        keyboard = InlineKeyboardMarkup([
+            [InlineKeyboardButton(
+                "Wyślij wszystkie paczki ponownie",
+                callback_data=f"arc_resend_{token}_0",
+            )],
+            [InlineKeyboardButton("Usuń teraz", callback_data=f"arc_purge_{token}")],
+        ])
+        try:
+            await update.callback_query.edit_message_text(
+                "\n".join(summary_lines), reply_markup=keyboard,
+            )
+        except Exception as exc:
+            logging.debug("summary edit failed: %s", exc)
+    except Exception as exc:
+        logging.error("Playlist archive flow failed: %s", exc)
+        await status(f"Pakowanie/wysyłka nie powiodły się: {exc}")
+    finally:
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass
+        job_registry.unregister(cancellation.job_id)
+
+
+async def _save_partial_state_after_cancel(
+    update,
+    chat_id: int,
+    workspace: Path,
+    downloaded: list[Path],
+    title: str,
+    media_type: str,
+    format_choice: str,
+    use_mtproto: bool,
+    total: int,
+) -> None:
+    """Persist ArchivePartialState and edit the status message with recovery buttons."""
+
+    if not downloaded:
+        # Nothing to recover — drop the workspace.
+        shutil.rmtree(workspace, ignore_errors=True)
+        try:
+            await update.callback_query.edit_message_text(
+                "⏹ Zatrzymano. Nie pobrano żadnego elementu."
+            )
+        except Exception:
+            pass
+        return
+
+    state = ArchivePartialState(
+        workspace=workspace,
+        downloaded=list(downloaded),
+        title=title,
+        media_type=media_type,
+        format_choice=format_choice,
+        use_mtproto=use_mtproto,
+        created_at=datetime.now(),
+    )
+    bucket = partial_archive_workspaces.get(chat_id) or {}
+    token = secrets.token_hex(4)
+    bucket[token] = state
+    partial_archive_workspaces[chat_id] = bucket
+
+    keyboard = InlineKeyboardMarkup([
+        [InlineKeyboardButton(
+            "Spakuj co mam", callback_data=f"arc_pack_partial_{token}",
+        )],
+        [InlineKeyboardButton(
+            "Usuń teraz", callback_data=f"arc_purge_partial_{token}",
+        )],
+    ])
+    try:
+        await update.callback_query.edit_message_text(
+            f"⏹ Zatrzymano. Pobrano {len(downloaded)}/{total} plików.\n"
+            f"Workspace zostanie usunięty po {PLAYLIST_ARCHIVE_RETENTION_MIN} min.",
+            reply_markup=keyboard,
+        )
+    except Exception as exc:
+        logging.debug("partial-state edit failed: %s", exc)
+```
+
+Make sure `secrets` is imported at the top of the file (it already is for `register_pending_archive_job`).
+
+- [ ] **Step 10.4: Run, expect PASS**
+
+```bash
+pytest tests/test_archive_service.py -v
+```
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add bot/services/archive_service.py tests/test_archive_service.py
+git commit -m "Register playlist archive flow as job; capture partial state on cancel"
+```
+
+---
+
+## Task 11: `execute_partial_archive_flow` + callbacks `arc_pack_partial_*` / `arc_purge_partial_*`
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/services/archive_service.py`
+- Modify: `/mnt/c/code/ytdown/bot/handlers/download_callbacks.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_archive_service.py`
+
+- [ ] **Step 11.1: Failing test**
+
+Append to `tests/test_archive_service.py`:
+
+```python
+def test_execute_partial_archive_flow_packs_remaining(tmp_path, monkeypatch):
+    import asyncio
+    from datetime import datetime
+    from pathlib import Path
+    from bot.services import archive_service
+    from bot.session_store import (
+        ArchivePartialState,
+        partial_archive_workspaces,
+        session_store,
+    )
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    p1 = workspace / "a.mp3"; p1.write_bytes(b"x")
+    p2 = workspace / "b.mp3"; p2.write_bytes(b"x")
+
+    state = ArchivePartialState(
+        workspace=workspace, downloaded=[p1, p2],
+        title="Hits", media_type="audio", format_choice="mp3",
+        use_mtproto=False,
+        created_at=datetime(2026, 5, 3),
+    )
+    partial_archive_workspaces[44] = {"tok": state}
+
+    pack_called = mock.AsyncMock(return_value=[workspace / "out.7z.001"])
+    send_called = mock.AsyncMock()
+    monkeypatch.setattr(archive_service, "pack_to_volumes", pack_called)
+    monkeypatch.setattr(archive_service, "send_volumes", send_called)
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: "n/a")
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+    context.bot = mock.MagicMock()
+
+    asyncio.run(
+        archive_service.execute_partial_archive_flow(
+            update, context, chat_id=44, token="tok",
+        )
+    )
+
+    pack_called.assert_awaited_once()
+    send_called.assert_awaited_once()
+    # Partial state consumed.
+    assert partial_archive_workspaces.get(44, {}).get("tok") is None
+    session_store.reset()
+```
+
+- [ ] **Step 11.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_archive_service.py -v -k "execute_partial_archive_flow"
+```
+
+- [ ] **Step 11.3: Add `execute_partial_archive_flow` to `bot/services/archive_service.py`**
+
+```python
+async def execute_partial_archive_flow(
+    update,
+    context,
+    *,
+    chat_id: int,
+    token: str,
+) -> None:
+    """Pack and send a previously-cancelled playlist's downloaded files.
+
+    Triggered by the [Spakuj co mam] button on a cancel-status message.
+    Reads ArchivePartialState from session_store, registers a fresh
+    archive_pack job, and runs pack_to_volumes + send_volumes.
+    """
+
+    bucket = partial_archive_workspaces.get(chat_id) or {}
+    state = bucket.get(token)
+    if state is None:
+        await _safe_status_edit(update, "Sesja wygasła.")
+        return
+
+    if not is_7z_available():
+        await _safe_status_edit(
+            update,
+            "Funkcja 7z niedostępna — administrator nie zainstalował p7zip-full.",
+        )
+        return
+
+    use_mtproto = mtproto_unavailability_reason() is None
+    volume_size_mb = volume_size_for(use_mtproto)
+
+    descriptor = JobDescriptor(
+        job_id="", chat_id=chat_id, kind="archive_pack",
+        label=f"Pakowanie częściowej playlisty ({state.title})",
+        started_at=datetime.now(),
+    )
+    cancellation = job_registry.register(chat_id, descriptor)
+
+    async def status(text: str) -> None:
+        await _safe_status_edit(update, text)
+
+    try:
+        await status(f"Pakowanie do 7z (vol_size={volume_size_mb} MB)...")
+        slug = _build_slug(state.title)
+        dest_basename = state.workspace / compute_archive_basename(
+            f"{slug}_{state.media_type}_{state.format_choice}", datetime.now()
+        )
+        volumes = await pack_to_volumes(
+            state.downloaded, dest_basename, volume_size_mb,
+            cancellation=cancellation,
+        )
+
+        if cancellation.event.is_set():
+            await status("⏹ Zatrzymano w trakcie pakowania.")
+            return
+
+        caption_prefix = f"{state.title} ({state.media_type} {state.format_choice})"
+        job_registry.update_label(
+            cancellation.job_id,
+            f"Wysyłka częściowej playlisty [0/{len(volumes)}]",
+        )
+        await status(f"Pakowanie OK: {len(volumes)} paczek. Wysyłanie...")
+        await send_volumes(
+            context.bot, chat_id=chat_id, volumes=volumes,
+            caption_prefix=caption_prefix, use_mtproto=use_mtproto,
+            status_cb=status, cancellation=cancellation,
+        )
+
+        delivery = ArchivedDeliveryState(
+            workspace=state.workspace, volumes=volumes,
+            caption_prefix=caption_prefix, use_mtproto=use_mtproto,
+            created_at=datetime.now(),
+        )
+        delivery_token = register_archived_delivery(chat_id, delivery)
+
+        keyboard = InlineKeyboardMarkup([
+            [InlineKeyboardButton(
+                "Wyślij wszystkie paczki ponownie",
+                callback_data=f"arc_resend_{delivery_token}_0",
+            )],
+            [InlineKeyboardButton(
+                "Usuń teraz",
+                callback_data=f"arc_purge_{delivery_token}",
+            )],
+        ])
+        await update.callback_query.edit_message_text(
+            f"Częściowa playlista wysłana w {len(volumes)} paczkach.",
+            reply_markup=keyboard,
+        )
+    except Exception as exc:
+        logging.error("Partial archive flow failed: %s", exc)
+        await status(f"Pakowanie/wysyłka nie powiodły się: {exc}")
+    finally:
+        # Consume partial state regardless of outcome.
+        bucket.pop(token, None)
+        if not bucket:
+            partial_archive_workspaces.pop(chat_id, None)
+        else:
+            partial_archive_workspaces[chat_id] = bucket
+        job_registry.unregister(cancellation.job_id)
+```
+
+- [ ] **Step 11.4: Wire `arc_pack_partial_*` and `arc_purge_partial_*` in `bot/handlers/download_callbacks.py`**
+
+Inside `handle_archive_callback`, before the existing `arc_resend_` branch, add:
+
+```python
+    if data.startswith("arc_pack_partial_"):
+        token = data[len("arc_pack_partial_"):]
+        from bot.services.archive_service import execute_partial_archive_flow
+        await execute_partial_archive_flow(
+            update, context, chat_id=chat_id, token=token,
+        )
+        return
+
+    if data.startswith("arc_purge_partial_"):
+        token = data[len("arc_purge_partial_"):]
+        await _handle_arc_purge_partial(update, chat_id, token)
+        return
+```
+
+Add the helper:
+
+```python
+async def _handle_arc_purge_partial(update, chat_id: int, token: str) -> None:
+    from bot.session_store import partial_archive_workspaces
+
+    bucket = partial_archive_workspaces.get(chat_id) or {}
+    state = bucket.pop(token, None)
+    if not bucket:
+        partial_archive_workspaces.pop(chat_id, None)
+    else:
+        partial_archive_workspaces[chat_id] = bucket
+    if state is None:
+        try:
+            await update.callback_query.edit_message_text("Sesja wygasła.")
+        except Exception:
+            pass
+        return
+    if state.workspace.exists():
+        shutil.rmtree(state.workspace, ignore_errors=True)
+    try:
+        await update.callback_query.edit_message_text("Folder usunięty.")
+    except Exception as exc:
+        logging.debug("arc_purge_partial edit failed: %s", exc)
+```
+
+- [ ] **Step 11.5: Run, expect PASS**
+
+```bash
+pytest tests/test_archive_service.py tests/test_callback_download_handlers.py -v
+```
+
+- [ ] **Step 11.6: Commit**
+
+```bash
+git add bot/services/archive_service.py bot/handlers/download_callbacks.py tests/test_archive_service.py
+git commit -m "Add execute_partial_archive_flow and arc_pack_partial_/purge_partial_ callbacks"
+```
+
+---
+
+## Task 12: Legacy `download_playlist` (per-item-send) registers job
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/handlers/playlist_callbacks.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_playlist.py`
+
+- [ ] **Step 12.1: Failing test**
+
+Append to `tests/test_playlist.py`:
+
+```python
+def test_legacy_download_playlist_breaks_on_cancel(monkeypatch):
+    import asyncio
+    from bot.handlers import playlist_callbacks
+    from bot.jobs import JobRegistry
+    from bot.session_store import session_store, user_playlist_data
+
+    session_store.reset()
+    user_playlist_data[42] = {
+        "title": "Pl",
+        "entries": [
+            {"url": "u1", "title": "a"},
+            {"url": "u2", "title": "b"},
+            {"url": "u3", "title": "c"},
+        ],
+    }
+    test_registry = JobRegistry()
+    monkeypatch.setattr(playlist_callbacks, "job_registry", test_registry)
+
+    iter_count = {"n": 0}
+
+    async def fake_dl(*args, **kwargs):
+        iter_count["n"] += 1
+        if iter_count["n"] == 2:
+            # Cancel after 2nd iteration starts.
+            jobs = test_registry.list_for_chat(42)
+            test_registry.cancel(jobs[0].job_id, reason="t")
+
+    monkeypatch.setattr(
+        playlist_callbacks, "_download_single_playlist_item", fake_dl,
+    )
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 42
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+    context.bot.send_message = mock.AsyncMock()
+
+    asyncio.run(
+        playlist_callbacks.download_playlist(
+            update, context, "pl_dl_audio_mp3",
+        )
+    )
+
+    # Job unregistered.
+    assert test_registry.list_for_chat(42) == []
+    # Loop broke after 2nd iteration; 3rd not invoked.
+    assert iter_count["n"] == 2
+    session_store.reset()
+```
+
+- [ ] **Step 12.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_playlist.py -v -k "legacy_download_playlist_breaks_on_cancel"
+```
+
+- [ ] **Step 12.3: Modify `download_playlist`**
+
+Add at top of `bot/handlers/playlist_callbacks.py`:
+
+```python
+from datetime import datetime
+from bot.jobs import JobDescriptor, job_registry
+```
+
+In `download_playlist`, wrap the existing loop with register/unregister:
+
+```python
+async def download_playlist(update: Update, context: ContextTypes.DEFAULT_TYPE, callback_data: str):
+    query = update.callback_query
+    chat_id = update.effective_chat.id
+
+    playlist = _get_session_value(context, chat_id, "playlist_data", user_playlist_data)
+    if not playlist:
+        await query.edit_message_text("Sesja playlisty wygasła. Wyślij link ponownie.")
+        return
+
+    entries = playlist["entries"]
+    choice = parse_playlist_download_choice(callback_data)
+    media_type = choice.media_type
+    format_choice = choice.format_choice
+
+    total = len(entries)
+    succeeded = 0
+    failed_titles = []
+
+    descriptor = JobDescriptor(
+        job_id="",
+        chat_id=chat_id,
+        kind="playlist_legacy",
+        label=f"Playlist ({media_type} {format_choice}) [0/{total}]",
+        started_at=datetime.now(),
+    )
+    cancellation = job_registry.register(chat_id, descriptor)
+
+    await query.edit_message_text(
+        f"Rozpoczynam pobieranie playlisty ({total} filmów)...\n"
+        f"Format: {media_type} {format_choice}"
+    )
+
+    try:
+        for i, entry in enumerate(entries, 1):
+            if cancellation.event.is_set():
+                break
+            entry_url = entry["url"]
+            entry_title = entry.get("title", f"Film {i}")
+            job_registry.update_label(
+                cancellation.job_id,
+                f"Playlist ({media_type} {format_choice}) [{i}/{total}]",
+            )
+
+            try:
+                status_msg = await context.bot.send_message(
+                    chat_id=chat_id,
+                    text=f"[{i}/{total}] Pobieranie: {entry_title}...",
+                )
+                await _download_single_playlist_item(
+                    context, chat_id, entry_url, entry_title,
+                    media_type, format_choice, status_msg,
+                )
+                succeeded += 1
+            except Exception as exc:
+                failed_titles.append(entry_title)
+                logging.error("Playlist item %d/%d failed: %s", i, total, exc)
+                try:
+                    await status_msg.edit_text(
+                        f"[{i}/{total}] Błąd: {entry_title}\n{str(exc)[:100]}"
+                    )
+                except Exception:
+                    pass
+
+            if i < total and not cancellation.event.is_set():
+                await asyncio.sleep(1)
+
+        failed = len(failed_titles)
+        if cancellation.event.is_set():
+            summary = (
+                f"⏹ Zatrzymano playlistę. Pobrano {succeeded}/{total} "
+                f"(pliki usunięte).\n"
+            )
+        else:
+            summary = f"Playlista zakończona!\n\nPobrano: {succeeded}/{total}\n"
+        if failed:
+            summary += f"Błędy: {failed}\n"
+            for title in failed_titles[:5]:
+                summary += f"  - {title[:40]}\n"
+
+        await context.bot.send_message(chat_id=chat_id, text=summary)
+        _clear_session_value(context, chat_id, "playlist_data", user_playlist_data)
+    finally:
+        job_registry.unregister(cancellation.job_id)
+```
+
+- [ ] **Step 12.4: Run, expect PASS**
+
+```bash
+pytest tests/test_playlist.py -v
+```
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+git add bot/handlers/playlist_callbacks.py tests/test_playlist.py
+git commit -m "Register legacy download_playlist as job and respect cancellation"
+```
+
+---
+
+## Task 13: `download_file` registers job and propagates cancellation
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/handlers/download_callbacks.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_callback_download_handlers.py`
+
+- [ ] **Step 13.1: Failing test**
+
+Append to `tests/test_callback_download_handlers.py`:
+
+```python
+def test_download_file_registers_and_unregisters_job(tmp_path, monkeypatch):
+    import asyncio
+    from bot.handlers import download_callbacks
+    from bot.jobs import JobRegistry
+    from bot.session_store import session_store
+
+    session_store.reset()
+    test_registry = JobRegistry()
+    monkeypatch.setattr(download_callbacks, "job_registry", test_registry)
+
+    seen_during = {}
+
+    async def fake_status(*args, **kwargs):
+        seen_during["count"] = len(test_registry.list_for_chat(7))
+
+    # Patch prepare_download_plan to short-circuit by returning None.
+    monkeypatch.setattr(
+        download_callbacks, "prepare_download_plan", lambda **kw: None,
+    )
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = fake_status
+    update.effective_chat.id = 7
+    context = mock.MagicMock()
+
+    asyncio.run(
+        download_callbacks.download_file(
+            update, context,
+            type="video", format="best", url="https://x",
+        )
+    )
+
+    # Even on early-exit path the job should register and unregister.
+    assert test_registry.list_for_chat(7) == []
+    session_store.reset()
+```
+
+- [ ] **Step 13.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_callback_download_handlers.py -v -k "download_file_registers"
+```
+
+- [ ] **Step 13.3: Modify `download_file`**
+
+Import at top of `bot/handlers/download_callbacks.py`:
+
+```python
+from bot.jobs import JobDescriptor, job_registry
+```
+
+In `download_file`, register the job before any work and wrap entire body in `try/finally`:
+
+Find:
+```python
+async def download_file(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    type,
+    format,
+    url,
+    transcribe=False,
+    summary=False,
+    summary_type=None,
+    use_format_id=False,
+    audio_quality="192",
+):
+    media_type = type
+    query = update.callback_query
+    chat_id = update.effective_chat.id
+    title = "Unknown"
+    success_recorded = False
+```
+
+Replace with (everything below up to the function's existing logic continues; here we wrap):
+
+```python
+async def download_file(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    type,
+    format,
+    url,
+    transcribe=False,
+    summary=False,
+    summary_type=None,
+    use_format_id=False,
+    audio_quality="192",
+):
+    media_type = type
+    query = update.callback_query
+    chat_id = update.effective_chat.id
+    title = "Unknown"
+    success_recorded = False
+
+    descriptor = JobDescriptor(
+        job_id="",
+        chat_id=chat_id,
+        kind="single_dl",
+        label=f"Pojedynczy plik ({media_type} {format}) — pobieranie",
+        started_at=datetime.now(),
+    )
+    cancellation = job_registry.register(chat_id, descriptor)
+
+    try:
+        # ... existing body of download_file unchanged ...
+    finally:
+        job_registry.unregister(cancellation.job_id)
+```
+
+The body of `download_file` is large; the change is mechanical — wrap the existing body in `try:` after the new `register` call and add `finally: job_registry.unregister(...)` at the very end.
+
+Pass `cancellation=cancellation` to:
+- `await execute_download(..., cancellation=cancellation)` — TWO call sites if any.
+
+- [ ] **Step 13.4: Run, expect PASS**
+
+```bash
+pytest tests/test_callback_download_handlers.py -v
+```
+
+- [ ] **Step 13.5: Commit**
+
+```bash
+git add bot/handlers/download_callbacks.py tests/test_callback_download_handlers.py
+git commit -m "Register single-file download_file as job and propagate cancellation"
+```
+
+---
+
+## Task 14: Transcription pipeline + summary respect cancellation
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/transcription_pipeline.py`
+- Modify: `/mnt/c/code/ytdown/bot/transcription_providers.py`
+- Modify: `/mnt/c/code/ytdown/bot/services/transcription_service.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_transcription.py`
+
+- [ ] **Step 14.1: Failing test**
+
+Append to `tests/test_transcription.py` (or whichever module covers `transcribe_mp3_file`):
+
+```python
+def test_transcribe_mp3_file_breaks_on_cancel(tmp_path, monkeypatch):
+    """When cancellation event is set between chunks, no further chunks process."""
+
+    import asyncio
+    from bot import transcription_pipeline
+    from bot.jobs import JobCancellation
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+    cancellation.event.set()
+
+    monkeypatch.setattr(
+        transcription_pipeline, "split_mp3", lambda *a, **kw: [tmp_path / "p1.mp3"]
+    )
+    monkeypatch.setattr(
+        transcription_pipeline, "transcribe_audio",
+        lambda *a, **kw: pytest.fail("must not call API after cancel"),
+    )
+
+    result = transcription_pipeline.transcribe_mp3_file(
+        str(tmp_path / "src.mp3"),
+        api_key="x",
+        output_dir=str(tmp_path),
+        cancellation=cancellation,
+    )
+
+    assert result is None or "anulowano" in str(result).lower()
+```
+
+- [ ] **Step 14.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_transcription.py -v -k "breaks_on_cancel"
+```
+
+- [ ] **Step 14.3: Modify `transcribe_mp3_file`**
+
+In `bot/transcription_pipeline.py`, add `cancellation` to the signature of `transcribe_mp3_file` and check the event at the top of the loop:
+
+```python
+def transcribe_mp3_file(
+    file_path,
+    api_key,
+    output_dir=None,
+    language=None,
+    prompt=None,
+    *,
+    cancellation: "JobCancellation | None" = None,
+):
+    """... existing docstring ..."""
+
+    # ... existing setup ...
+
+    for index, part_path in enumerate(part_files):
+        if cancellation is not None and cancellation.event.is_set():
+            logging.info("Transcription cancelled before part %s", index + 1)
+            return None
+        # ... existing per-part logic ...
+```
+
+In `bot/services/transcription_service.py`, the wrapper `run_transcription_with_progress` accepts `cancellation` and forwards it:
+
+```python
+async def run_transcription_with_progress(
+    *,
+    source_path: str,
+    output_dir: str,
+    executor: Any,
+    status_callback: Callable[[str], Any],
+    cancellation: "JobCancellation | None" = None,
+) -> str | None:
+    """... existing docstring ..."""
+
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        executor,
+        lambda: transcribe_mp3_file(
+            source_path,
+            api_key=...,        # existing
+            output_dir=output_dir,
+            cancellation=cancellation,
+        ),
+    )
+```
+
+In `bot/transcription_providers.py`, `generate_summary` is sync (HTTP call to Anthropic). Wrap call site in `download_callbacks` so it can be cancelled at task level — Task 13 already wraps `download_file` in registration; we just pass `cancellation` through `generate_summary_artifact` like:
+
+```python
+async def generate_summary_artifact(
+    *,
+    transcript_text: str,
+    summary_type: str,
+    title: str,
+    sanitized_title: str,
+    output_dir: str,
+    executor: Any,
+    cancellation: "JobCancellation | None" = None,
+):
+    """... existing ..."""
+
+    if cancellation is not None and cancellation.event.is_set():
+        return None
+
+    loop = asyncio.get_event_loop()
+    fut = loop.run_in_executor(executor, _do_summary, ...)
+    if cancellation is not None:
+        cancellation.pyrogram_task = asyncio.ensure_future(fut)
+        try:
+            return await cancellation.pyrogram_task
+        except asyncio.CancelledError:
+            return None
+    return await fut
+```
+
+(Use `pyrogram_task` slot generically — it's a `asyncio.Task` reference.)
+
+- [ ] **Step 14.4: Run, expect PASS**
+
+```bash
+pytest tests/test_transcription.py -v
+```
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add bot/transcription_pipeline.py bot/transcription_providers.py bot/services/transcription_service.py tests/test_transcription.py
+git commit -m "Propagate cancellation through transcription pipeline and summary"
+```
+
+---
+
+## Task 15: MTProto upload tasks attach to `cancellation.pyrogram_task`
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/mtproto.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_mtproto.py`
+
+- [ ] **Step 15.1: Failing test**
+
+Append to `tests/test_mtproto.py`:
+
+```python
+def test_send_video_mtproto_attaches_task_to_cancellation(tmp_path, monkeypatch):
+    import asyncio
+    from bot import mtproto
+    from bot.jobs import JobCancellation
+
+    src = tmp_path / "vid.mp4"
+    src.write_bytes(b"x" * 1024)
+
+    values = {
+        "TELEGRAM_API_ID": "12345",
+        "TELEGRAM_API_HASH": "abc",
+        "TELEGRAM_BOT_TOKEN": "token",
+    }
+    monkeypatch.setattr(
+        mtproto, "get_runtime_value",
+        lambda key, default="": values.get(key, default),
+    )
+
+    captured = {}
+
+    class FakeClient:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def send_video(self, **kwargs):
+            # Snapshot cancellation.pyrogram_task during upload.
+            captured["task"] = cancellation.pyrogram_task
+
+    monkeypatch.setattr(mtproto, "_build_client", lambda *a, **kw: FakeClient())
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+
+    asyncio.run(
+        mtproto.send_video_mtproto(
+            chat_id=42, file_path=str(src), caption="x",
+            cancellation=cancellation,
+        )
+    )
+
+    assert captured["task"] is not None
+    assert isinstance(captured["task"], asyncio.Task)
+```
+
+- [ ] **Step 15.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_mtproto.py -v -k "attaches_task"
+```
+
+- [ ] **Step 15.3: Modify `send_video_mtproto` (and analogously `send_audio_mtproto`, `send_document_mtproto`)**
+
+In `bot/mtproto.py`, change each `send_*_mtproto` to accept `cancellation` and wrap the `await client.send_*` in `asyncio.ensure_future` attached to cancellation:
+
+```python
+async def send_video_mtproto(
+    chat_id: int,
+    file_path: str,
+    caption: str | None = None,
+    thumb_path: str | None = None,
+    *,
+    cancellation: "JobCancellation | None" = None,
+) -> bool:
+    """Send a video file via MTProto (up to 2 GB).
+
+    When cancellation is provided, the underlying upload task is attached
+    so /stop can cancel it.
+    """
+
+    try:
+        from pyrogram import Client  # noqa: F401
+    except ImportError:
+        logging.error("pyrogram not installed — cannot send large video")
+        return False
+
+    api_id = get_runtime_value("TELEGRAM_API_ID", "")
+    api_hash = get_runtime_value("TELEGRAM_API_HASH", "")
+    if not api_id or not api_hash:
+        logging.error("TELEGRAM_API_ID/TELEGRAM_API_HASH not configured")
+        return False
+
+    api_id_int = _parse_api_id(api_id)
+    if api_id_int is None:
+        return False
+
+    client = _build_client(chat_id, "send_video", api_id_int, api_hash)
+
+    try:
+        async with client:
+            coro = client.send_video(
+                chat_id=chat_id,
+                video=file_path,
+                caption=caption,
+                thumb=thumb_path,
+            )
+            if cancellation is not None:
+                task = asyncio.ensure_future(coro)
+                cancellation.pyrogram_task = task
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    return False
+            else:
+                await coro
+            file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
+            logging.info(
+                "MTProto send_video OK: %s (%.1f MB) to chat %d",
+                os.path.basename(file_path), file_size_mb, chat_id,
+            )
+            return True
+    except Exception as e:
+        logging.error("MTProto send_video failed: %s", e)
+        return False
+```
+
+Repeat the same wrapper in `send_audio_mtproto` and `send_document_mtproto`.
+
+- [ ] **Step 15.4: Run, expect PASS**
+
+```bash
+pytest tests/test_mtproto.py -v
+```
+
+- [ ] **Step 15.5: Commit**
+
+```bash
+git add bot/mtproto.py tests/test_mtproto.py
+git commit -m "Attach pyrogram upload task to cancellation in MTProto senders"
+```
+
+---
+
+## Task 16: Komenda `/stop` + callbacks
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/telegram_commands.py`
+- Modify: `/mnt/c/code/ytdown/bot/telegram_callbacks.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_telegram_commands.py`
+
+- [ ] **Step 16.1: Failing tests**
+
+Append to `tests/test_telegram_commands.py`:
+
+```python
+def test_stop_command_returns_empty_message_when_no_jobs():
+    import asyncio
+    from bot import telegram_commands
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    update = mock.MagicMock()
+    update.effective_chat.id = 1
+    update.effective_message.reply_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    with mock.patch("bot.telegram_commands.job_registry", registry):
+        asyncio.run(telegram_commands.stop_command(update, context))
+
+    update.effective_message.reply_text.assert_awaited_once()
+    text = update.effective_message.reply_text.await_args.args[0]
+    assert "Brak aktywnych operacji" in text
+
+
+def test_stop_command_lists_active_jobs():
+    import asyncio
+    from datetime import datetime
+    from bot import telegram_commands
+    from bot.jobs import JobDescriptor, JobRegistry
+
+    registry = JobRegistry()
+    registry.register(7, JobDescriptor(
+        job_id="", chat_id=7, kind="playlist_zip",
+        label="Playlist 7z (mp3) — [12/30]",
+        started_at=datetime.now(),
+    ))
+    registry.register(7, JobDescriptor(
+        job_id="", chat_id=7, kind="single_dl",
+        label="Pojedynczy plik (best)",
+        started_at=datetime.now(),
+    ))
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 7
+    update.effective_message.reply_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    with mock.patch("bot.telegram_commands.job_registry", registry):
+        asyncio.run(telegram_commands.stop_command(update, context))
+
+    text = update.effective_message.reply_text.await_args.args[0]
+    assert "Aktywne operacje (2)" in text
+    assert "Playlist 7z" in text
+    assert "Pojedynczy plik" in text
+    keyboard = update.effective_message.reply_text.await_args.kwargs["reply_markup"]
+    callback_data = [
+        btn.callback_data for row in keyboard.inline_keyboard for btn in row
+    ]
+    assert any(cb.startswith("stop_") for cb in callback_data)
+    assert "stop_all" in callback_data
+
+
+def test_stop_callback_cancels_specific_job():
+    import asyncio
+    from datetime import datetime
+    from bot import telegram_callbacks
+    from bot.jobs import JobDescriptor, JobRegistry
+
+    registry = JobRegistry()
+    cancellation = registry.register(5, JobDescriptor(
+        job_id="", chat_id=5, kind="single_dl",
+        label="x", started_at=datetime.now(),
+    ))
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 5
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    with mock.patch("bot.telegram_commands.job_registry", registry):
+        from bot.telegram_commands import handle_stop_callback
+        asyncio.run(handle_stop_callback(update, context, f"stop_{cancellation.job_id}"))
+
+    assert cancellation.event.is_set()
+
+
+def test_stop_all_callback_cancels_every_job_in_chat():
+    import asyncio
+    from datetime import datetime
+    from bot.jobs import JobDescriptor, JobRegistry
+
+    registry = JobRegistry()
+    c1 = registry.register(8, JobDescriptor(
+        job_id="", chat_id=8, kind="single_dl",
+        label="A", started_at=datetime.now(),
+    ))
+    c2 = registry.register(8, JobDescriptor(
+        job_id="", chat_id=8, kind="playlist_zip",
+        label="B", started_at=datetime.now(),
+    ))
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 8
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    with mock.patch("bot.telegram_commands.job_registry", registry):
+        from bot.telegram_commands import handle_stop_callback
+        asyncio.run(handle_stop_callback(update, context, "stop_all"))
+
+    assert c1.event.is_set()
+    assert c2.event.is_set()
+```
+
+- [ ] **Step 16.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_telegram_commands.py -v -k "stop"
+```
+
+- [ ] **Step 16.3: Add `/stop` to `bot/telegram_commands.py`**
+
+Add imports:
+
+```python
+from datetime import datetime
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from bot.jobs import job_registry
+```
+
+Add command + callback handler:
+
+```python
+async def stop_command(update, context) -> None:
+    """List running jobs in this chat with cancel buttons."""
+
+    chat_id = update.effective_chat.id
+    descriptors = job_registry.list_for_chat(chat_id)
+
+    if not descriptors:
+        await update.effective_message.reply_text("Brak aktywnych operacji.")
+        return
+
+    lines = [f"Aktywne operacje ({len(descriptors)}):", ""]
+    keyboard_rows: list[list[InlineKeyboardButton]] = []
+    for idx, descriptor in enumerate(descriptors, 1):
+        age_min = max(
+            0,
+            int((datetime.now() - descriptor.started_at).total_seconds() // 60),
+        )
+        lines.append(f"{idx}. {descriptor.label} ({age_min} min)")
+        keyboard_rows.append([InlineKeyboardButton(
+            f"Zatrzymaj {idx}", callback_data=f"stop_{descriptor.job_id}",
+        )])
+    keyboard_rows.append([InlineKeyboardButton(
+        "Zatrzymaj wszystkie", callback_data="stop_all",
+    )])
+    keyboard_rows.append([
+        InlineKeyboardButton("Odśwież", callback_data="stop_refresh"),
+        InlineKeyboardButton("Anuluj listę", callback_data="stop_dismiss"),
+    ])
+
+    await update.effective_message.reply_text(
+        "\n".join(lines),
+        reply_markup=InlineKeyboardMarkup(keyboard_rows),
+    )
+
+
+async def handle_stop_callback(update, context, data: str) -> None:
+    """Dispatch stop_<id>, stop_all, stop_refresh, stop_dismiss."""
+
+    chat_id = update.effective_chat.id
+
+    if data == "stop_all":
+        descriptors = job_registry.list_for_chat(chat_id)
+        cancelled = 0
+        for descriptor in descriptors:
+            if await job_registry.cancel_async(descriptor.job_id, "user via /stop"):
+                cancelled += 1
+        try:
+            await update.callback_query.edit_message_text(
+                f"Wysłano sygnał zatrzymania do {cancelled} operacji."
+            )
+        except Exception:
+            pass
+        return
+
+    if data == "stop_refresh":
+        # Re-render the list message with current state.
+        descriptors = job_registry.list_for_chat(chat_id)
+        if not descriptors:
+            try:
+                await update.callback_query.edit_message_text("Brak aktywnych operacji.")
+            except Exception:
+                pass
+            return
+        # Reuse stop_command rendering by editing instead of reply.
+        lines = [f"Aktywne operacje ({len(descriptors)}):", ""]
+        keyboard_rows: list[list[InlineKeyboardButton]] = []
+        for idx, descriptor in enumerate(descriptors, 1):
+            age_min = max(
+                0,
+                int((datetime.now() - descriptor.started_at).total_seconds() // 60),
+            )
+            lines.append(f"{idx}. {descriptor.label} ({age_min} min)")
+            keyboard_rows.append([InlineKeyboardButton(
+                f"Zatrzymaj {idx}", callback_data=f"stop_{descriptor.job_id}",
+            )])
+        keyboard_rows.append([InlineKeyboardButton(
+            "Zatrzymaj wszystkie", callback_data="stop_all",
+        )])
+        keyboard_rows.append([
+            InlineKeyboardButton("Odśwież", callback_data="stop_refresh"),
+            InlineKeyboardButton("Anuluj listę", callback_data="stop_dismiss"),
+        ])
+        try:
+            await update.callback_query.edit_message_text(
+                "\n".join(lines),
+                reply_markup=InlineKeyboardMarkup(keyboard_rows),
+            )
+        except Exception:
+            pass
+        return
+
+    if data == "stop_dismiss":
+        try:
+            await update.callback_query.edit_message_text("Lista zamknięta.")
+        except Exception:
+            pass
+        return
+
+    if data.startswith("stop_"):
+        job_id = data[len("stop_"):]
+        ok = await job_registry.cancel_async(job_id, reason="user via /stop")
+        text = (
+            "Wysłano sygnał zatrzymania. Czekam na potwierdzenie..."
+            if ok else "Operacja już zakończona."
+        )
+        try:
+            await update.callback_query.edit_message_text(text)
+        except Exception:
+            pass
+```
+
+Register the `/stop` command handler in the bot bootstrap. Find the function that wires `application.add_handler(CommandHandler(...))` (in `bot/telegram_commands.py` or wherever bootstrap lives) and add:
+
+```python
+application.add_handler(CommandHandler("stop", stop_command))
+```
+
+In `bot/telegram_callbacks.py`, in the main router (after `arc_*`), add:
+
+```python
+    if data.startswith("stop_") or data == "stop_all":
+        from bot.telegram_commands import handle_stop_callback
+        await handle_stop_callback(update, context, data)
+        return
+```
+
+- [ ] **Step 16.4: Run, expect PASS**
+
+```bash
+pytest tests/test_telegram_commands.py tests/test_telegram_integration.py -v
+```
+
+- [ ] **Step 16.5: Commit**
+
+```bash
+git add bot/telegram_commands.py bot/telegram_callbacks.py tests/test_telegram_commands.py
+git commit -m "Add /stop command and stop_* callbacks"
+```
+
+---
+
+## Task 17: `cleanup.py` purges dead jobs and partial workspaces
+
+**Files:**
+- Modify: `/mnt/c/code/ytdown/bot/cleanup.py`
+- Modify: `/mnt/c/code/ytdown/tests/test_cleanup.py`
+
+- [ ] **Step 17.1: Failing tests**
+
+Append to `tests/test_cleanup.py`:
+
+```python
+def test_purge_dead_jobs_called_in_periodic_cleanup(monkeypatch):
+    """periodic_cleanup invokes job_registry.purge_dead with 6h threshold."""
+
+    from datetime import timedelta
+    from bot import cleanup
+    from bot.jobs import JobRegistry
+
+    test_registry = JobRegistry()
+    monkeypatch.setattr(cleanup, "job_registry", test_registry)
+    captured = {}
+
+    def fake_purge(threshold):
+        captured["threshold"] = threshold
+        return 0
+
+    monkeypatch.setattr(test_registry, "purge_dead", fake_purge)
+
+    # Drive one iteration of the loop body without sleeping for an hour.
+    cleanup._purge_dead_jobs(retention_hours=6)
+
+    assert captured["threshold"] == timedelta(hours=6)
+
+
+def test_purge_partial_archive_workspaces_removes_old(tmp_path, monkeypatch):
+    from datetime import datetime, timedelta
+    from pathlib import Path
+    from bot import cleanup
+    from bot.session_store import (
+        ArchivePartialState,
+        partial_archive_workspaces,
+        session_store,
+    )
+
+    session_store.reset()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    state = ArchivePartialState(
+        workspace=workspace, downloaded=[], title="x",
+        media_type="audio", format_choice="mp3", use_mtproto=False,
+        created_at=datetime.now() - timedelta(hours=2),
+    )
+    partial_archive_workspaces[1] = {"old": state}
+
+    cleanup._purge_partial_archive_workspaces(retention_min=60)
+
+    assert partial_archive_workspaces.get(1, {}).get("old") is None
+    session_store.reset()
+```
+
+- [ ] **Step 17.2: Run, expect FAIL**
+
+```bash
+pytest tests/test_cleanup.py -v -k "purge"
+```
+
+- [ ] **Step 17.3: Add to `bot/cleanup.py`**
+
+Add imports near the top:
+
+```python
+from bot.jobs import job_registry
+from bot.security_limits import JOB_DEAD_AGE_HOURS, PLAYLIST_ARCHIVE_RETENTION_MIN
+```
+
+Add helper functions (place near the existing `_purge_archive_workspaces`):
+
+```python
+def _purge_dead_jobs(retention_hours: int) -> int:
+    """Remove zombie entries from JobRegistry. Logs each as warning."""
+
+    return job_registry.purge_dead(timedelta(hours=retention_hours))
+
+
+def _purge_partial_archive_workspaces(retention_min: int) -> int:
+    """Drop partial_archive_workspaces entries older than retention_min."""
+
+    from bot.session_store import partial_archive_workspaces
+
+    cutoff = datetime.now() - timedelta(minutes=retention_min)
+    removed = 0
+    for chat_id in list(partial_archive_workspaces):
+        bucket = partial_archive_workspaces.get(chat_id) or {}
+        for token in list(bucket):
+            state = bucket[token]
+            if state.created_at >= cutoff:
+                continue
+            bucket.pop(token, None)
+            removed += 1
+        if not bucket:
+            partial_archive_workspaces.pop(chat_id, None)
+        else:
+            partial_archive_workspaces[chat_id] = bucket
+    return removed
+```
+
+In `periodic_cleanup`, after the existing `_purge_archived_deliveries(...)` call, add:
+
+```python
+            _purge_dead_jobs(JOB_DEAD_AGE_HOURS)
+            _purge_partial_archive_workspaces(PLAYLIST_ARCHIVE_RETENTION_MIN)
+```
+
+- [ ] **Step 17.4: Run, expect PASS**
+
+```bash
+pytest tests/test_cleanup.py -v
+```
+
+- [ ] **Step 17.5: Commit**
+
+```bash
+git add bot/cleanup.py tests/test_cleanup.py
+git commit -m "Periodically purge dead jobs and partial archive workspaces"
+```
+
+---
+
+## Task 18: Manual E2E checklist
+
+Ten task nie ma testów automatycznych — ręczna lista kontrolna do wykonania przed PR.
+
+- [ ] **Step 18.1: Środowisko + start bota**
+
+```bash
+source /home/pi/venv/bin/activate
+cd /mnt/c/code/ytdown
+python main.py
+```
+
+Sprawdź w logach `archive_available=True` i brak crash przy starcie.
+
+- [ ] **Step 18.2: `/stop` przy braku operacji**
+
+Wyślij `/stop` w czacie → odpowiedź `"Brak aktywnych operacji."`.
+
+- [ ] **Step 18.3: Cancel playlisty 7z w trakcie pobierania**
+
+Wyślij URL playlisty 30 elementów → klik `Pobierz wszystkie — Audio MP3 jako 7z` → po 5 elementach `/stop` → `[Zatrzymaj 1]`. Oczekiwane:
+- Status edytuje się na `"⏹ Zatrzymano. Pobrano 5/30..."` z przyciskami `[Spakuj co mam]` i `[Usuń teraz]`.
+- Klik `[Spakuj co mam]` pakuje 5 plików w 7z i wysyła paczki.
+
+- [ ] **Step 18.4: Cancel pakowania 7z**
+
+Playlist z plikami sumarycznie ~2 GB, klik 7z. Czekaj aż status zmieni się na `"Pakowanie..."`. `/stop` → `[Zatrzymaj 1]`. Oczekiwane:
+- Status `"⏹ Zatrzymano w trakcie pakowania."`.
+- Brak plików `.7z.001` w `downloads/<chat_id>/pl_*/`.
+- Source files (z fazy pobierania) zachowane do retencji 60 min.
+
+- [ ] **Step 18.5: Cancel wysyłki wolumenów**
+
+Playlist która produkuje 8 wolumenów MTProto. `/stop` po wysłaniu 3 → klik. Oczekiwane:
+- 3 wolumeny w czacie pozostają.
+- Status z przyciskiem `[Wznów od 4]` (wykorzystuje istniejący `arc_resend_<token>_3`).
+
+- [ ] **Step 18.6: Cancel transkrypcji**
+
+Wyślij audio 30+ min, klik `Transkrybuj`. Czekaj na pierwszą iterację. `/stop` → `[Zatrzymaj 1]`. Oczekiwane:
+- Po dokończeniu bieżącego chunku (~30 s) bot edytuje status na `"⏹ Zatrzymano transkrypcję."`.
+
+- [ ] **Step 18.7: Cancel summary**
+
+Wyślij audio z transkrypcją + summary, klik. Po ukończeniu transkrypcji, gdy status pokazuje `"Generuję podsumowanie..."` → `/stop` → klik. Oczekiwane:
+- Status `"⏹ Zatrzymano podsumowanie. Transkrypcja jest dostępna."`.
+
+- [ ] **Step 18.8: `/stop` z dwoma równoległymi jobami**
+
+Puść playlistę i drugi single-file. `/stop` listuje oba. `[Zatrzymaj wszystkie]` → oba zatrzymane.
+
+- [ ] **Step 18.9: Zombie cleanup**
+
+Żaden test sieciowy — tylko sprawdzenie logiki. Manualnie wywołaj w shell-u Python:
+```python
+from bot.jobs import job_registry, JobDescriptor
+from datetime import datetime, timedelta
+descriptor = JobDescriptor(job_id="", chat_id=0, kind="single_dl",
+                            label="z", started_at=datetime.now() - timedelta(hours=7))
+job_registry.register(0, descriptor)
+from bot.cleanup import _purge_dead_jobs
+removed = _purge_dead_jobs(retention_hours=6)
+print(removed)  # expected: 1
+```
+
+- [ ] **Step 18.10: Pull request**
+
+Po wszystkich krokach pozytywnych:
+
+```bash
+git push origin develop
+gh pr create --base main --head develop --title "Cancel command (/stop) for long-running operations" --body "..."
+```
+
+---
+
+## Self-review (autora planu)
+
+1. **Spec coverage:**
+   - Sekcja 2 (decyzje produktowe) — Tasks 1, 2, 3, 16.
+   - Sekcja 3 (architektura) — Tasks 2, 3, 4, 5.
+   - Sekcja 4 (flow) — Tasks 10, 11, 16.
+   - Sekcja 5 (konfiguracja, error handling) — Tasks 1, 6, 17.
+   - Sekcja 6 (testy) — testy w każdym z tasków.
+   - Sekcja 7 (poza scope) — niezaadresowane (zgodnie z założeniem).
+
+2. **Placeholder scan:** Brak "TBD"/"TODO". Komentarz w Task 13.3 mówi "everything below up to the function's existing logic continues; here we wrap" — to instrukcja dla wykonawcy, nie placeholder. Zostawione celowo.
+
+3. **Type consistency:** `JobCancellation`, `JobDescriptor`, `JobRegistry`, `ArchivePartialState`, `partial_archive_workspaces`, `job_registry`, kind values (`"playlist_legacy"`, `"playlist_zip"`, `"single_dl"`, `"transcription"`, `"summary"`, `"archive_pack"`, `"archive_send"`) używane spójnie.
+
+4. **Kolejność:** Task 2/3/4 (jobs.py) przed 6/7/8/9/10/11 (konsumenty). Task 5 (session_store) przed 10/11 (gdzie `ArchivePartialState` jest używane). Task 16 (`/stop` handler) po wszystkich konsumentach. Task 17 (cleanup) po jobs i session_store. Spójne.
+
+---
+
+## Wybór trybu wykonania
+
+Plan kompletny, zapisany w `docs/superpowers/plans/2026-05-03-cancel-operations-plan.md`. Dwie opcje wykonania:
+
+1. **Subagent-driven (rekomendowane)** — dispatcher świeżego subagenta per task, dwustopniowy review, szybka iteracja. Wymagany sub-skill: `superpowers:subagent-driven-development`.
+
+2. **Inline execution** — wykonujemy taski w obecnej sesji z checkpointami. Wymagany sub-skill: `superpowers:executing-plans`.
+
+Który tryb wybierasz?

--- a/docs/superpowers/specs/2026-05-02-playlist-zip-download-design.md
+++ b/docs/superpowers/specs/2026-05-02-playlist-zip-download-design.md
@@ -1,0 +1,413 @@
+# Spec: Tryb „pobierz playlistę / duży plik jako 7z"
+
+- **Data:** 2026-05-02
+- **Gałąź:** `develop`
+- **Status:** zaakceptowany do implementacji
+
+## 1. Cel i kontekst
+
+Bot udostępnia dziś dwie ścieżki:
+- pobranie pojedynczego pliku z YouTube/Spotify/Instagram i wysłanie go do Telegrama,
+- pobranie playlisty YouTube w pętli — każdy element trafia do Telegrama jako osobna wiadomość, a po wysłaniu plik źródłowy jest natychmiast usuwany z dysku.
+
+Dla użytkownika końcowego (Telegram Desktop na Windows 11) oznacza to, że przy długiej playliście trzeba ręcznie pobrać każdy element z Telegrama osobno. Specyfikacja dodaje **drugi tryb pobierania całej playlisty**, w którym bot zatrzymuje pliki na dysku, pakuje je do 7z multi-volume i wysyła użytkownikowi tylko paczki (`<title>.7z.001`, `.002`, …).
+
+Ta sama logika jest fallbackiem dla **pojedynczego pliku przekraczającego limit wysyłki Telegrama**: zamiast „za duży, nie wyślę", bot proponuje wybór „Anuluj / Wyślij jako 7z".
+
+## 2. Decyzje produktowe (przyjęte w brainstormingu)
+
+| Pytanie | Decyzja |
+|---|---|
+| Limit wysyłki Telegrama | Hybrydowo: auto-detekcja MTProto. Z MTProto wolumen 7z = ~1900 MB, bez MTProto = ~49 MB. |
+| Format kontenera | 7z multi-volume (`-t7z -v<size>m -mx0`). 7-Zip 26 jest zainstalowany na hoście (`p7zip-full`). Brak natywnego wsparcia w Windows Explorer jest akceptowanym kompromisem. |
+| UX trybu playlisty | Wariant **C**: w menu playlisty dochodzi 4 dodatkowe przyciski „… jako 7z" obok obecnych 4. Stary tryb (każdy plik osobno) zostaje bez zmian. |
+| Trigger fallbacku dla pojedynczego pliku | Wariant **A**: tylko gdy estymowany rozmiar pliku przekracza limit Telegrama w aktualnej konfiguracji. `MAX_FILE_SIZE_MB = 1000` zostaje (chroni dysk dla single-file flow). |
+| Limit per-element w trybie 7z (playlist) | Nowa stała `MAX_ARCHIVE_ITEM_SIZE_MB = 10240` (10 GB). Pozwala wrzucić do playlist-7z duże filmy 4K, których single-file flow nie zaakceptowałby. |
+| Lokalizacja plików tymczasowych | Per-playlist subfolder `downloads/<chat_id>/pl_<slug>_<timestamp>/`. Dla pojedynczego pliku w trybie 7z analogiczny `big_<slug>_<timestamp>/`. |
+| Retencja po sukcesie | 60 minut, integrowane z istniejącym `bot/cleanup.py`. Stała `PLAYLIST_ARCHIVE_RETENTION_MIN = 60`. Pliki źródłowe + wolumeny zostają w katalogu, żeby umożliwić retry wysyłki bez ponownego pobierania. |
+| Implementacja pakowania | System binary `7z` przez `asyncio.create_subprocess_exec`. Brak fallbacku do `py7zr`. Jeśli `7z` nie jest w `PATH` przy starcie, przyciski „… jako 7z" się nie pojawiają. |
+| Anuluj single-file 7z | Plik usuwany natychmiast. |
+| Przyciski po sukcesie | `[Wyślij wszystkie paczki ponownie]` + `[Usuń teraz]` zostają. |
+| Nazewnictwo wolumenów | Czytelne (z tytułem), polskie znaki transliterowane do ASCII (`unicodedata.normalize('NFKD', ...)`). |
+
+## 3. Architektura
+
+### 3.1 Nowy moduł `bot/archive.py`
+
+Niskopoziomowy, czysto funkcyjny wrapper na `7z` CLI. Brak zależności od warstwy Telegrama. ~120 linii.
+
+API:
+
+```python
+def volume_size_for(use_mtproto: bool) -> int:
+    """Zwraca MTPROTO_VOLUME_SIZE_MB albo BOTAPI_VOLUME_SIZE_MB."""
+
+def transliterate_to_ascii(text: str) -> str:
+    """Translit polskich znaków do ASCII przez NFKD. Zachowuje spacje, myślniki, cyfry."""
+
+def compute_archive_basename(slug: str, ts: datetime) -> str:
+    """Deterministyczny prefix wolumenów: <slug>_<YYYYMMDD-HHMMSS>."""
+
+async def pack_to_volumes(
+    sources: list[Path],
+    dest_basename: Path,
+    volume_size_mb: int,
+    *,
+    progress_cb: Callable[[str], Awaitable[None]] | None = None,
+) -> list[Path]:
+    """Uruchamia `7z a -t7z -v<size>m -mx0 -mmt=on dest.7z <sources...>`.
+    Zwraca posortowaną listę utworzonych wolumenów (.7z.001, .002, ...).
+    Raises RuntimeError przy non-zero exit, ValueError przy pustym sources.
+    Raportuje progres przez progress_cb (parsing stdout 7z, throttle 2 s)."""
+
+def is_7z_available() -> bool:
+    """shutil.which('7z') is not None."""
+```
+
+### 3.2 Nowy moduł `bot/services/archive_service.py`
+
+Orkiestracja end-to-end. Zawiera całą logikę wspólną dla playlist-flow i single-file-fallback. ~200 linii.
+
+API:
+
+```python
+@dataclass
+class ArchiveJobState:
+    """Persystencja in-memory pendingowego zadania 7z (single-file)."""
+    file_path: Path
+    title: str
+    media_type: str
+    format_choice: str
+    file_size_mb: float
+    use_mtproto: bool
+    created_at: datetime
+
+@dataclass
+class ArchivedDeliveryState:
+    """Persystencja in-memory wysłanej paczki (do retry/purge)."""
+    workspace: Path
+    volumes: list[Path]
+    caption_prefix: str
+    use_mtproto: bool
+    created_at: datetime
+
+def prepare_playlist_workspace(chat_id: int, playlist_title: str, *, prefix: str = "pl") -> Path
+async def download_playlist_into(
+    workspace: Path,
+    entries: list[dict],
+    media_type: str,
+    format_choice: str,
+    executor: ThreadPoolExecutor,
+    status_cb: Callable[[str], Awaitable[None]],
+) -> tuple[list[Path], list[str]]:
+    """Pobiera każdy item do workspace bez wysyłki. Sprawdza MAX_ARCHIVE_ITEM_SIZE_MB.
+    Zwraca (downloaded_paths, failed_titles)."""
+
+async def send_volumes(
+    bot,
+    chat_id: int,
+    volumes: list[Path],
+    caption_prefix: str,
+    use_mtproto: bool,
+    *,
+    start_index: int = 0,
+    status_cb: Callable[[str], Awaitable[None]] | None = None,
+) -> None:
+    """Wysyła wolumeny [start_index:] jako document (Bot API ≤49 MB lub MTProto)."""
+
+async def execute_playlist_archive_flow(
+    update,
+    context,
+    chat_id: int,
+    playlist: dict,
+    media_type: str,
+    format_choice: str,
+    executor: ThreadPoolExecutor,
+) -> None:
+    """End-to-end: prepare workspace → download all → pack → send volumes → status."""
+
+async def execute_single_file_archive_flow(
+    update,
+    context,
+    chat_id: int,
+    token: str,
+) -> None:
+    """End-to-end dla single-file fallback. Pobiera ArchiveJobState po tokenie z
+    pending_archive_jobs[chat_id], przenosi plik do workspace 'big_*', pakuje, wysyła."""
+
+def schedule_workspace_for_cleanup(workspace: Path) -> None
+def register_pending_archive_job(chat_id: int, state: ArchiveJobState) -> str
+def register_archived_delivery(chat_id: int, state: ArchivedDeliveryState) -> str
+```
+
+### 3.3 Modyfikacje istniejących modułów
+
+| Plik | Zmiana |
+|---|---|
+| `bot/security_limits.py` | Dodać `MAX_ARCHIVE_ITEM_SIZE_MB`, `MTPROTO_VOLUME_SIZE_MB`, `BOTAPI_VOLUME_SIZE_MB`, `PLAYLIST_ARCHIVE_RETENTION_MIN`. |
+| `bot/services/playlist_service.py` | `PlaylistDownloadChoice.as_archive: bool`. `parse_playlist_download_choice` rozpoznaje prefix `pl_zip_dl_`. `build_playlist_message` wstawia 4 dodatkowe przyciski gdy `archive_available=True`. |
+| `bot/handlers/playlist_callbacks.py` | Gałąź dla `as_archive=True` deleguje do `archive_service.execute_playlist_archive_flow`. Stary `download_playlist` (per-item send) zostaje bez zmian dla `as_archive=False`. |
+| `bot/handlers/download_callbacks.py` | W `download_file`, gdy `file_size_mb > volume_size_for(use_mtproto)`: zarejestruj `ArchiveJobState`, pokaż wybór `[Wyślij jako 7z] [Anuluj]`. Dodać dispatching dla `arc_split_*`, `arc_cancel_*`, `arc_resend_*`, `arc_purge_*`. |
+| `bot/mtproto.py` | Dodać `send_document_mtproto(chat_id, file_path, caption, file_name)`. Wzorowane na `send_video_mtproto`, ale wywołuje `client.send_document(...)`. |
+| `bot/cleanup.py` | Helper `_purge_archive_workspaces(chat_dir, retention_min)`: skanuje katalogi pasujące do `pl_*` / `big_*`, sprawdza `mtime` i obecność `.lock`, usuwa po przekroczeniu retencji. Sprzątanie `pending_archive_jobs` po `created_at`. |
+| `bot/session_store.py` | `pending_archive_jobs: dict[int, dict[str, ArchiveJobState]]`. `archived_deliveries: dict[int, dict[str, ArchivedDeliveryState]]`. |
+| `bot/runtime.py` | Przy starcie: `archive_available = is_7z_available()`. Wystawić jako `get_runtime_value("archive_available")` lub atrybut `RuntimeServices`. |
+
+## 4. Flow: playlista → 7z
+
+### 4.1 Rozszerzone menu playlisty
+
+`build_playlist_message` po zmianie:
+
+```
+Pobierz wszystkie — Audio MP3              (pl_dl_audio_mp3)
+Pobierz wszystkie — Audio MP3 jako 7z      (pl_zip_dl_audio_mp3)    [tylko gdy archive_available]
+Pobierz wszystkie — Audio M4A              (pl_dl_audio_m4a)
+Pobierz wszystkie — Audio M4A jako 7z      (pl_zip_dl_audio_m4a)
+Pobierz wszystkie — Video (najlepsza)      (pl_dl_video_best)
+Pobierz wszystkie — Video (najlepsza) 7z   (pl_zip_dl_video_best)
+Pobierz wszystkie — Video 720p             (pl_dl_video_720p)
+Pobierz wszystkie — Video 720p jako 7z     (pl_zip_dl_video_720p)
+[Pokaż więcej…]
+[Anuluj]
+```
+
+Callback prefix `pl_zip_dl_` (10 znaków + `audio_mp3` = 19, mieści się w limicie 64 B).
+
+### 4.2 Sekwencja zdarzeń (po kliknięciu `pl_zip_dl_audio_mp3`)
+
+1. `archive_service.prepare_playlist_workspace(chat_id, playlist_title, prefix="pl")` →
+   `downloads/<chat_id>/pl_<slug>_<YYYYMMDD-HHMMSS>/`. `<slug>` = `sanitize_filename(transliterate_to_ascii(playlist_title))[:60]` — najpierw translit polskich znaków do ASCII, potem usunięcie znaków niedozwolonych systemowo.
+2. Detekcja transportu: `use_mtproto = mtproto_unavailability_reason() is None`.
+   `volume_size_mb = volume_size_for(use_mtproto)`.
+3. Inicjalny status (jedna wiadomość, edytowana w pętli):
+   `Playlista → 7z (audio mp3)\n[0/N] Pobieranie...`
+4. Pętla po `entries`:
+   - Pobranie itemu **do workspace** (`chat_download_path=workspace`), bez wysyłki, bez `os.remove`.
+   - Wczesna walidacja: `estimate_download_size(plan)` > `MAX_ARCHIVE_ITEM_SIZE_MB` → item pominięty, tytuł na `failed_titles`.
+   - Status: `[i/N] Pobieranie: <title>...`
+5. Po pętli:
+   - `len(failed) == N` → `shutil.rmtree(workspace)`, status `Nie udało się pobrać żadnego elementu.`. Koniec.
+   - W przeciwnym razie tworzymy lock-file `<workspace>/.lock`.
+6. Status: `Pakowanie do 7z (vol_size=<N> MB)...` →
+   `archive.pack_to_volumes(downloaded_paths, workspace / "<slug>_<format>", volume_size_mb, progress_cb=...)`.
+   Progress edytuje status co 2 s (parsing stdout 7z dla procentu i nazwy aktualnego pliku).
+7. Status: `Pakowanie OK: M paczek. Wysyłanie...`
+8. `archive_service.send_volumes(bot, chat_id, volumes, caption_prefix=f"{playlist_title} ({format})", use_mtproto, status_cb=...)`.
+   Per-wolumen status: `Wysyłanie [j/M] (<size> MB)...`
+   Caption per-wolumen: `<playlist_title> [j/M] (<format>)`.
+   Każdy wolumen jako osobna wiadomość-dokument.
+9. Po sukcesie:
+   - Usuwamy `.lock`. Rejestrujemy `ArchivedDeliveryState` w `archived_deliveries[chat_id][token]`.
+   - Status końcowy:
+     ```
+     Playlista zakończona.
+     Pobrano: K/N
+     Spakowano: K plików → M paczek 7z
+     Wysłano: M/M
+     Folder zostanie usunięty po 60 min.
+     ```
+     plus przyciski `[Wyślij wszystkie paczki ponownie]` (`arc_resend_<token>_0`), `[Usuń teraz]` (`arc_purge_<token>`),
+     plus pierwsze 5 `failed_titles` jeśli były.
+   - `schedule_workspace_for_cleanup(workspace)` — wpisanie do `cleanup.py`'s tracking.
+
+### 4.3 Recovery przy błędzie wysyłki wolumenu
+
+- Wysyłka stop, status:
+  `Błąd wysyłki paczki [3/M]: <error>. Folder zachowany.`
+  + przyciski `[Ponów od [3/M]]` (`arc_resend_<token>_2`, indeksowane od 0), `[Anuluj]` (`arc_purge_<token>`).
+- Token wskazuje na `archived_deliveries[chat_id][token]`. `arc_resend_<token>_<from>` wywołuje
+  `send_volumes(..., start_index=from)`.
+
+## 5. Flow: pojedynczy plik > limit Telegrama → 7z
+
+Trigger w `bot/handlers/download_callbacks.download_file` (linie ~514–533 obecnego kodu): gałąź `use_mtproto = file_size_mb > TELEGRAM_UPLOAD_LIMIT_MB`, w której dziś `mtproto_unavailability_reason() is not None` rzuca `RuntimeError`. Tam podstawiamy fallback 7z. Warunek precyzyjnie: **plik został pobrany i `file_size_mb > volume_size_for(use_mtproto)`** (z MTProto: `file_size_mb > 1900` — w obecnym configu blokowane wcześniej przez `MAX_FILE_SIZE_MB=1000`, więc praktycznie nieosiągalne; bez MTProto: `file_size_mb > 49` — częsty przypadek). Wtedy:
+
+1. Generujemy `token` (8 znaków hex).
+2. Zapisujemy `pending_archive_jobs[chat_id][token] = ArchiveJobState(...)`.
+3. Status:
+   ```
+   Plik za duży dla Telegrama: <X> MB > limit <Y> MB.
+   Mogę spakować go w wolumeny 7z (po <Y> MB) i wysłać paczki.
+   ```
+   + przyciski `[Wyślij jako 7z]` (`arc_split_<token>`), `[Anuluj]` (`arc_cancel_<token>`).
+4. **`arc_cancel_<token>`** → `os.remove(file_path)`, `pending_archive_jobs[chat_id].pop(token, None)`,
+   status: `Anulowano. Plik usunięty.`
+5. **`arc_split_<token>`** → `archive_service.execute_single_file_archive_flow`:
+   - Tworzymy workspace `downloads/<chat_id>/big_<slug>_<ts>/`, przenosimy `file_path` do środka.
+   - Tworzymy `<workspace>/.lock`.
+   - Status: `Pakowanie do 7z (vol_size=<Y> MB)...` → `archive.pack_to_volumes`.
+   - Status: `Pakowanie OK: M paczek. Wysyłanie...` → `send_volumes`.
+   - Po sukcesie: rejestrujemy `ArchivedDeliveryState`, usuwamy `.lock`, status końcowy z
+     `[Wyślij wszystkie paczki ponownie] [Usuń teraz]`.
+6. **TTL pendingowego joba**: `cleanup.py` co cykl sprawdza `pending_archive_jobs`; gdy
+   `created_at + PLAYLIST_ARCHIVE_RETENTION_MIN < now` → kasuje plik i usuwa wpis.
+
+Spójność z playlistą: ten sam `pack_to_volumes`, ten sam `send_volumes`, ten sam mechanizm tokenów.
+Single-file to przypadek brzegowy `sources` o długości 1.
+
+## 6. Konfiguracja, transport, error handling
+
+### 6.1 Stałe w `bot/security_limits.py`
+
+```python
+MAX_FILE_SIZE_MB = 1000               # bez zmian (single-file flow, poza fallbackiem 7z)
+MAX_ARCHIVE_ITEM_SIZE_MB = 10240      # NOWE — per-element w trybie playlist 7z
+TELEGRAM_UPLOAD_LIMIT_MB = 50         # bez zmian (Bot API)
+MTPROTO_VOLUME_SIZE_MB = 1900         # NOWE
+BOTAPI_VOLUME_SIZE_MB = 49            # NOWE
+PLAYLIST_ARCHIVE_RETENTION_MIN = 60   # NOWE
+```
+
+### 6.2 Transport per-wolumen
+
+`send_volumes` decyduje per-wolumen na podstawie rozmiaru: `≤ TELEGRAM_UPLOAD_LIMIT_MB` (49 MB)
+→ `context.bot.send_document(...)`, większy → `send_document_mtproto(...)`. W praktyce:
+- z MTProto: wszystkie wolumeny = 1900 MB → wszystkie idą MTProto;
+- bez MTProto: wszystkie wolumeny = 49 MB → wszystkie idą Bot API.
+Sprawdzenie `mtproto_unavailability_reason()` dla wolumenu > 49 MB bez MTProto → `RuntimeError`.
+
+### 6.3 `send_document_mtproto`
+
+Nowa funkcja w `bot/mtproto.py`:
+
+```python
+async def send_document_mtproto(
+    chat_id: int,
+    file_path: str,
+    caption: str | None = None,
+    file_name: str | None = None,
+) -> bool:
+    """Send a document file via MTProto (up to 2 GB)."""
+```
+
+Implementacyjnie analogiczna do `send_video_mtproto`, ale z `client.send_document(...)`.
+`file_name` (opcjonalne) wymusza nazwę widoczną w Telegramie (np. `playlist_audio_mp3.7z.001`).
+
+### 6.4 Cleanup w `bot/cleanup.py`
+
+Nowy helper:
+
+```python
+def _purge_archive_workspaces(chat_dir: Path, retention_min: int) -> int:
+    """Iteruje po podkatalogach pasujących do pl_*/big_*. Pomija jeśli istnieje .lock.
+    Usuwa shutil.rmtree gdy wiek katalogu (mtime) > retention_min minut.
+    Zwraca liczbę usuniętych katalogów."""
+```
+
+Wywołane razem z istniejącym 24h cleanupem w tym samym scheduler-thread.
+
+Sprzątanie `pending_archive_jobs`:
+
+```python
+def _purge_pending_archive_jobs(retention_min: int) -> None:
+    """Iteruje pending_archive_jobs, usuwa wpisy z created_at + retention < now,
+    kasuje powiązany plik z dysku."""
+```
+
+### 6.5 Error handling
+
+| Sytuacja | Obsługa |
+|---|---|
+| `7z` exit != 0 | `pack_to_volumes` raises `RuntimeError("7z failed: <stderr[:200]>")`. `archive_service` w `except` usuwa workspace, edytuje status: `Pakowanie nie powiodło się: <err>`. |
+| `7z` brak w `PATH` (start bota) | `archive_available = False`. Przyciski 7z nie pojawiają się w menu playlisty. Single-file fallback pokazuje `Funkcja 7z niedostępna — administrator nie zainstalował p7zip-full.` z przyciskiem `[Anuluj]`. |
+| Pobranie itemu playlisty fails | Tytuł na `failed_titles`, pętla kontynuuje. `len(failed) == N` → cleanup workspace + status. |
+| Item playlisty > `MAX_ARCHIVE_ITEM_SIZE_MB` | Pominięty, na `failed_titles` z notatką `(za duży: X MB)`. |
+| Wysyłka wolumenu fails | Mechanizm `[Ponów od [j/M]]` (sekcja 4.3). Workspace zostaje, retencja 60 min. |
+| `arc_cancel` single-file | `os.remove(file_path)`, czyść state, status `Anulowano. Plik usunięty.`. |
+| Restart bota w trakcie pakowania | `pending_archive_jobs` jest in-memory (zgodne z istniejącym wzorcem `user_urls`). Workspace z `.lock` zostaje, ale po 60 min `cleanup.py` go usunie (sprawdzenie `.lock` blokuje cleanup tylko gdy katalog jest młody; po 24h każdy katalog idzie do kasacji niezależnie od `.lock`, jako safety net). |
+| Disk full przy pakowaniu | `7z` exit != 0, łapane jak wyżej. Przed startem pakowania logujemy `shutil.disk_usage` informacyjnie. |
+
+### 6.6 Logowanie
+
+`logging.info` na: workspace utworzony, pobranie itemu OK, pakowanie start, pakowanie OK (M wolumenów),
+wysyłka wolumenu OK. `logging.error` na: pobranie itemu fail, pakowanie fail, wysyłka wolumenu fail,
+cleanup fail. Spójne z `bot/mtproto.py`.
+
+## 7. Plan testów
+
+### 7.1 Nowe pliki
+
+**`tests/test_archive.py`** (~150 linii):
+- `test_volume_size_for_mtproto_returns_1900`
+- `test_volume_size_for_botapi_returns_49`
+- `test_transliterate_to_ascii_polish_letters`
+- `test_transliterate_preserves_safe_chars`
+- `test_pack_to_volumes_invokes_7z_with_correct_args` (mock subprocess)
+- `test_pack_to_volumes_returns_sorted_volume_paths`
+- `test_pack_to_volumes_raises_when_7z_exits_nonzero`
+- `test_pack_to_volumes_raises_on_empty_sources`
+- `test_pack_to_volumes_real_7z_small_volumes` (integration; skip gdy `not is_7z_available()`)
+
+**`tests/test_archive_service.py`** (~200 linii):
+- `test_prepare_workspace_creates_pl_prefix_dir`
+- `test_prepare_workspace_uses_transliterated_slug`
+- `test_download_playlist_into_keeps_files_after_download`
+- `test_download_playlist_into_returns_empty_when_all_fail`
+- `test_download_playlist_into_returns_failed_titles_on_partial`
+- `test_download_playlist_into_respects_max_archive_item_size`
+- `test_send_volumes_uses_botapi_for_small_volumes`
+- `test_send_volumes_uses_mtproto_for_large_volumes`
+- `test_send_volumes_raises_when_volume_too_large_and_no_mtproto`
+- `test_send_volumes_caption_format`
+- `test_send_volumes_resumes_from_start_index`
+- `test_pending_archive_job_token_is_unique`
+- `test_archive_lock_file_blocks_cleanup`
+
+### 7.2 Modyfikacje istniejących
+
+**`tests/test_playlist_service.py`**:
+- `test_build_playlist_message_includes_zip_buttons_when_archive_available`
+- `test_build_playlist_message_hides_zip_buttons_when_archive_unavailable`
+- `test_parse_playlist_download_choice_recognizes_zip_prefix`
+- `test_parse_playlist_download_choice_legacy_prefix_unchanged`
+
+**`tests/test_callback_download_handlers.py`**:
+- `test_oversized_single_file_offers_archive_choice`
+- `test_arc_cancel_removes_file_immediately`
+- `test_arc_split_dispatches_to_archive_service`
+- `test_arc_resend_starts_from_given_index`
+- `test_arc_purge_immediately_removes_workspace`
+
+**`tests/test_playlist.py`** (handler-level):
+- `test_handle_playlist_callback_pl_zip_dl_dispatches_to_archive_flow`
+
+**`tests/test_cleanup.py`**:
+- `test_purge_archive_workspaces_removes_old_pl_dirs`
+- `test_purge_archive_workspaces_keeps_recent_dirs`
+- `test_purge_archive_workspaces_respects_lock_file`
+- `test_purge_archive_workspaces_cleans_pending_jobs`
+
+**`tests/test_mtproto.py`**:
+- `test_send_document_mtproto_invokes_send_document`
+- `test_send_document_mtproto_returns_false_without_pyrogram`
+- `test_send_document_mtproto_returns_false_without_credentials`
+- `test_send_document_mtproto_returns_false_on_invalid_api_id`
+
+### 7.3 Manualna checklist E2E
+
+1. Pobranie playlisty 5×audio_mp3 jako 7z → 1 wolumen `<plist>_audio_mp3.7z.001`, otwiera się w 7-Zip Windows.
+2. Pobranie playlisty 30×video_720p jako 7z → kilka wolumenów, sumarycznie > 1900 MB.
+3. Sztuczne wymuszenie braku MTProto → wolumeny po 49 MB, wszystkie wysłane przez Bot API.
+4. Ubicie sieci podczas wysyłki wolumenu `.003` → przycisk `[Ponów od [3/M]]` ponawia bez ponownego pobierania.
+5. Pozostawienie workspace przez 65 min → `cleanup.py` usuwa folder.
+6. Single-file > limit (np. testowo `MAX_FILE_SIZE_MB=200` + plik 250 MB w Bot API mode) → przyciski `[Wyślij jako 7z] [Anuluj]`.
+
+### 7.4 Cele pokrycia
+
+- `bot/archive.py` — > 95 %
+- `bot/services/archive_service.py` — > 90 %
+- Modyfikacje w istniejących plikach — istniejące pokrycie nie spada.
+
+## 8. Poza scope
+
+- Migracja istniejącego trybu „każdy plik osobno" do trybu 7z.
+- Persystencja `pending_archive_jobs` / `archived_deliveries` na crash bota.
+- Konfiguracja per-user rozmiaru wolumenu.
+- Wsparcie innych formatów archiwum (ZIP split, RAR, tar.gz).
+- Inkrementalne wysyłanie wolumenów w trakcie pakowania (streaming) — pakujemy wszystko, dopiero potem wysyłamy.
+- Hashowanie / sumy kontrolne wolumenów.
+
+## 9. Aktualizacje
+
+- 2026-05-02: spec zaakceptowany w brainstormingu.

--- a/docs/superpowers/specs/2026-05-03-cancel-operations-design.md
+++ b/docs/superpowers/specs/2026-05-03-cancel-operations-design.md
@@ -1,0 +1,282 @@
+# Spec: Komenda `/stop` — anulowanie długotrwałych operacji
+
+- **Data:** 2026-05-03
+- **Gałąź:** `develop`
+- **Status:** zaakceptowany do implementacji
+
+## 1. Cel i kontekst
+
+Bot uruchamia kilka długotrwałych operacji, których użytkownik nie może w tej chwili przerwać bez restartu procesu:
+- pobieranie playlisty (legacy per-item-send oraz nowy 7z flow),
+- pobieranie pojedynczego pliku (yt-dlp + opcjonalnie MTProto upload),
+- pakowanie 7z multi-volume,
+- wysyłka kolejnych wolumenów,
+- transkrypcja audio (Groq) i podsumowanie (Claude).
+
+Specyfikacja dodaje **komendę `/stop`** — jedyny trigger anulowania — z listą aktywnych operacji per chat. Każdą operację można zatrzymać indywidualnie lub wszystkie naraz. Po anulowaniu workspace playlist (jeśli dotyczy) zostaje zachowany zgodnie z istniejącą retencją 60 minut, więc użytkownik może odzyskać częściową robotę przez przyciski recovery (`[Spakuj co mam]`, `[Wznów od X+1]`).
+
+## 2. Decyzje produktowe (z brainstormingu)
+
+| Pytanie | Decyzja |
+|---|---|
+| Scope cancela | Wszystko: playlisty (legacy + 7z), single-file download, 7z pack, send volumes, transkrypcja, podsumowanie, MTProto upload. |
+| UX trigger | **Tylko** komenda `/stop`. Brak per-message przycisku. |
+| Granularność | `/stop` listuje aktywne joby z osobnymi przyciskami `[Zatrzymaj N]` plus `[Zatrzymaj wszystkie]` i `[Anuluj listę]`. |
+| Behaviour po cancel (pliki) | Workspace playlist zostaje przy istniejącej retencji 60 min; status pokazuje `[Spakuj co mam] [Usuń]` dla recovery. Single-file: yt-dlp posprząta `.part` automatycznie. |
+| Mechanizm techniczny | Single shared `JobCancellation` (asyncio.Event + opcjonalny subprocess + opcjonalny pyrogram task), per-warstwa konsumpcja w sposób natywny dla danego kontekstu. |
+| 6h zombie cleanup | TAK, log jako WARNING. |
+| `cancelled_reason` w descriptorze | TAK (telemetria/diagnostyka). |
+
+## 3. Architektura
+
+### 3.1 Nowy moduł `bot/jobs.py` (~150 linii)
+
+Wystawia `JobRegistry` (singleton) i typy stanu cancela. Brak zależności od `bot.handlers.*` ani `bot.services.*`.
+
+```python
+@dataclass
+class JobCancellation:
+    """Cancellation handle shared across async/threadpool/subprocess layers."""
+    job_id: str
+    event: asyncio.Event
+    process: asyncio.subprocess.Process | None = None
+    pyrogram_task: asyncio.Task | None = None
+    cancelled_reason: str | None = None
+
+@dataclass
+class JobDescriptor:
+    """User-facing description of a running job, listed by /stop."""
+    job_id: str
+    chat_id: int
+    kind: Literal[
+        "playlist_legacy", "playlist_zip", "single_dl",
+        "transcription", "summary", "archive_pack", "archive_send",
+    ]
+    label: str
+    started_at: datetime
+
+class JobRegistry:
+    """Thread-safe per-chat registry; in-memory only."""
+    def register(chat_id: int, descriptor: JobDescriptor) -> JobCancellation
+    def get(job_id: str) -> JobCancellation | None
+    def list_for_chat(chat_id: int) -> list[JobDescriptor]
+    def update_label(job_id: str, label: str) -> None
+    def cancel(job_id: str, reason: str = "user via /stop") -> bool
+    def unregister(job_id: str) -> None
+    def purge_dead(threshold: timedelta) -> int    # called by cleanup.py
+```
+
+Importy dozwolone: stdlib (`asyncio`, `dataclasses`, `datetime`, `threading`, `secrets`, `logging`, `typing`).
+
+### 3.2 Komenda `/stop` w `bot/telegram_commands.py`
+
+Nowy handler + 4 callback handlery (`stop_<job_id>`, `stop_all`, `stop_dismiss`, `stop_refresh`).
+
+```
+/stop                        → list active jobs (or "brak aktywnych operacji.")
+stop_<job_id>                → cancel single job
+stop_all                     → cancel every job in this chat
+stop_refresh                 → re-render the list (label/state changes)
+stop_dismiss                 → delete the list message
+```
+
+Wiadomość:
+```
+Aktywne operacje (2):
+
+1. Playlist 7z (audio mp3) — pobieranie [12/30] (5 min)
+2. Pojedynczy plik (video best) — pakowanie 7z (2 min)
+
+[Zatrzymaj 1]   [Zatrzymaj 2]
+[Zatrzymaj wszystkie]
+[Odśwież]      [Anuluj listę]
+```
+
+Wiek (`(N min)`) liczony z `descriptor.started_at` na każdym renderze listy.
+
+### 3.3 Modyfikacje istniejących modułów
+
+| Plik | Zmiana |
+|---|---|
+| `bot/security_limits.py` | Dodać `JOB_DEAD_AGE_HOURS = 6`, `JOB_TERMINATE_GRACE_SEC = 1.0`. |
+| `bot/services/archive_service.py` | `download_playlist_into`, `send_volumes`, `execute_playlist_archive_flow`, `execute_single_file_archive_flow` przyjmują `cancellation: JobCancellation`. Pętle sprawdzają `event.is_set()` per iteration. Wrapper-y rejestrują/unregisterują job w `try/finally`. |
+| `bot/archive.py` | `pack_to_volumes(..., cancellation=None)`. Zapisuje `process` po spawn. `_stream_7z_progress` sprawdza event w pętli readline. Po cancel: `process.terminate()` → grace 1s → `process.kill()`. Cleanup `.7z.NNN` w `except`. |
+| `bot/services/download_service.py` | `execute_download(..., cancellation=None)`. Progress hook raise `yt_dlp.utils.DownloadError("cancelled")` gdy event set. |
+| `bot/handlers/playlist_callbacks.py` | Legacy `download_playlist`: rejestruje job, pętla sprawdza event, na cancel kasuje workspace (legacy nie zachowuje plików). |
+| `bot/handlers/download_callbacks.py` | `download_file` rejestruje job. Cancellation propagowane do `execute_download`, transcription pipeline, MTProto. |
+| `bot/transcription_pipeline.py` | Pętla po chunkach sprawdza event przed każdym Groq call. |
+| `bot/transcription_providers.py` | `generate_summary` zarejestrowany jako `cancellation.pyrogram_task` (slot generic dla async tasków); cancellation propaguje `CancelledError`. |
+| `bot/mtproto.py` | `send_*_mtproto` zapisuje wewnętrzny task w `cancellation.pyrogram_task`. |
+| `bot/session_store.py` | Dodać `ArchivePartialState` dataclass (workspace, downloaded files, title, media_type, format_choice, use_mtproto, created_at) + `partial_archive_workspaces: SessionFieldMap` i analogicznie pole w `SessionState`. |
+| `bot/cleanup.py` | Co cykl wywołuje `job_registry.purge_dead(timedelta(hours=JOB_DEAD_AGE_HOURS))` (log warning) plus `_purge_partial_archive_workspaces(PLAYLIST_ARCHIVE_RETENTION_MIN)` analogicznie do istniejących cleanupów. |
+| `bot/runtime.py` | Brak zmian (registry to globalny singleton, jak `session_store`). |
+
+## 4. Flow
+
+### 4.1 Sekwencja `/stop` → `[Zatrzymaj 1]`
+
+1. Handler odbiera callback `stop_<job_id>`.
+2. `cancellation = job_registry.get(job_id)` → jeśli `None`, edit wiadomości listy: `"Operacja już zakończona."`. Return.
+3. `job_registry.cancel(job_id, reason="user via /stop")`:
+   a. `cancellation.cancelled_reason = reason`
+   b. `cancellation.event.set()`
+   c. Jeśli `cancellation.process`: `process.terminate()` → `await asyncio.wait_for(process.wait(), JOB_TERMINATE_GRACE_SEC)` → na timeout `process.kill()`.
+   d. Jeśli `cancellation.pyrogram_task`: `task.cancel()`.
+4. Edit wiadomości listy: `"Wysłano sygnał zatrzymania dla operacji 1. Czekam na potwierdzenie..."` + przycisk `[Odśwież]`.
+5. Sama operacja, po wykryciu event/sygnału, edytuje swoją wiadomość statusową na `⏹` + przyciski recovery (per kind, sekcja 4.2). W `finally` wywołuje `job_registry.unregister(job_id)`.
+
+### 4.2 Statusy końcowe per kind
+
+| Kind | Status po cancel | Przyciski recovery |
+|---|---|---|
+| `playlist_legacy` | `"⏹ Zatrzymano playlistę. Pobrano N/M (pliki usunięte)."` | brak (legacy nie zachowuje) |
+| `playlist_zip` | `"⏹ Zatrzymano. Pobrano N/M plików."` | `[Spakuj co mam]` (`arc_pack_partial_<token>`), `[Usuń teraz]` (`arc_purge_<token>`) |
+| `single_dl` | `"⏹ Zatrzymano pobieranie. Plik usunięty."` | brak |
+| `transcription` | `"⏹ Zatrzymano transkrypcję."` | brak (audio source idzie do retencji `cleanup_old_files`) |
+| `summary` | `"⏹ Zatrzymano podsumowanie. Transkrypcja jest dostępna."` | brak (transkrypcja już wysłana wcześniej) |
+| `archive_pack` | `"⏹ Zatrzymano w trakcie pakowania. Wolumeny usunięte."` | brak (workspace zostaje 60 min, użytkownik może puścić to samo zadanie ponownie) |
+| `archive_send` | `"⏹ Zatrzymano wysyłkę. Wysłano X/Y paczek."` | `[Wznów od X+1]` (`arc_resend_<token>_<X>`), `[Usuń teraz]` |
+
+### 4.3 `[Spakuj co mam]` po cancelu playlist_zip
+
+Nowa dataclass i mapa w `bot/session_store.py`:
+
+```python
+@dataclass
+class ArchivePartialState:
+    """Workspace state captured at cancel time, for [Spakuj co mam] retry."""
+    workspace: Path
+    downloaded: list[Path]
+    title: str
+    media_type: str
+    format_choice: str
+    use_mtproto: bool
+    created_at: datetime
+
+partial_archive_workspaces = SessionFieldMap(session_store, "partial_archive_workspaces")
+```
+
+Nowy callback `arc_pack_partial_<token>`:
+1. Po cancel `download_playlist_into` zwraca już-pobrane pliki, `execute_playlist_archive_flow` zapisuje `ArchivePartialState` i pokazuje przycisk z tokenem.
+2. Klik wywołuje `archive_service.execute_partial_archive_flow(update, context, chat_id, token)`:
+   - Czyta `ArchivePartialState` z `partial_archive_workspaces`.
+   - Pakuje `pack_to_volumes(state.downloaded, ...)` (z nową `JobCancellation` zarejestrowaną w registry).
+   - Wysyła `send_volumes(...)`.
+   - Rejestruje `ArchivedDeliveryState` jak normalny sukces, czyści `partial_archive_workspaces[chat_id][token]`.
+
+`partial_archive_workspaces` sprzątane w `cleanup.py` razem z `pending_archive_jobs` i `archived_deliveries` (ten sam retention `PLAYLIST_ARCHIVE_RETENTION_MIN`).
+
+## 5. Konfiguracja, transport, error handling
+
+### 5.1 Stałe w `bot/security_limits.py`
+
+```python
+# Cleanup of stale (zombie) entries in JobRegistry. Defends /stop list
+# against operations that never unregistered due to bugs or crashes.
+JOB_DEAD_AGE_HOURS = 6
+
+# Grace between SIGTERM and SIGKILL when terminating a 7z subprocess
+# attached to a JobCancellation. Long enough for 7z to finish writing
+# its current 1 MiB block, short enough to not block /stop UX.
+JOB_TERMINATE_GRACE_SEC = 1.0
+```
+
+### 5.2 Race conditions (rozważone)
+
+| ID | Sytuacja | Mitigacja |
+|---|---|---|
+| R1 | Cancel między `create_subprocess_exec` a `cancellation.process = process` | `pack_to_volumes` przypisuje `process` przed pierwszym `await readline()`; latencja akceptowalna (~1-2 s). |
+| R2 | Cancel zaraz po normalnym `unregister` | `cancel()` zwraca `bool`; handler `stop_<id>` na `False` edytuje "Operacja już zakończona." |
+| R3 | Stale job w liście | `try/finally unregister` w każdej warstwie + cykliczny `purge_dead(6h)` w `cleanup.py` (log warning). |
+| R4 | Dwa równoległe `/stop` na ten sam job | Idempotentne: event set, terminate na zakończonym procesie to no-op. |
+| R5 | `/stop` w grupie / od innego usera | Bot operuje per chat, nie per user — zgodne z istniejącym modelem `pl_cancel`. |
+
+### 5.3 Cleanup półprodukcji
+
+- **yt-dlp**: `.part` plik usuwany automatycznie po `DownloadError`.
+- **7z**: `pack_to_volumes` w `except`/`finally` po terminate kasuje wszystkie `<basename>.7z.NNN` z workspace (mogą być corrupted).
+- **Workspace playlist**: zachowany dla recovery (60 min retencja `cleanup.py:_purge_archive_workspaces`).
+- **Workspace single-file `big_*`**: jak dotychczas.
+- **Audio dla transkrypcji**: zachowany w `downloads/<chat_id>/`, idzie do 24h retencji `cleanup_old_files`.
+
+### 5.4 Logowanie
+
+- `logging.info` na: `register`, `cancel(reason=...)`, `unregister`.
+- `logging.warning` na: SIGTERM → SIGKILL fallback, `purge_dead` zombie usunięty.
+- Spójne z resztą bota (`bot/mtproto.py`, `bot/cleanup.py`).
+
+## 6. Plan testów
+
+### 6.1 Nowe pliki
+
+**`tests/test_jobs.py`** (~200 linii):
+- `test_register_returns_unique_job_id`
+- `test_register_creates_unset_event`
+- `test_list_for_chat_returns_active_descriptors`
+- `test_list_for_chat_excludes_other_chats`
+- `test_cancel_sets_event_and_returns_true`
+- `test_cancel_unknown_job_returns_false`
+- `test_cancel_terminates_attached_subprocess`
+- `test_cancel_kills_subprocess_when_terminate_times_out`
+- `test_cancel_cancels_attached_pyrogram_task`
+- `test_unregister_removes_descriptor`
+- `test_update_label_changes_descriptor_label`
+- `test_registry_is_thread_safe`
+- `test_purge_dead_jobs_removes_old_entries`
+- `test_cancelled_reason_propagates_to_descriptor`
+
+### 6.2 Modyfikacje istniejących
+
+**`tests/test_archive_service.py`**:
+- `test_download_playlist_into_breaks_on_cancel`
+- `test_send_volumes_breaks_on_cancel`
+- `test_execute_playlist_archive_flow_registers_and_unregisters`
+
+**`tests/test_archive.py`**:
+- `test_pack_to_volumes_terminates_subprocess_on_cancel`
+- `test_pack_to_volumes_kills_when_terminate_times_out`
+- `test_pack_to_volumes_cleans_partial_volumes_on_cancel`
+
+**`tests/test_download_service.py`**:
+- `test_execute_download_progress_hook_raises_on_cancel`
+
+**`tests/test_telegram_commands.py`**:
+- `test_stop_command_lists_active_jobs`
+- `test_stop_command_empty_message_when_no_jobs`
+- `test_stop_callback_cancels_job`
+- `test_stop_all_callback_cancels_every_job_in_chat`
+- `test_stop_callback_handles_already_finished_job`
+
+**`tests/test_cleanup.py`**:
+- `test_purge_dead_jobs_removes_after_threshold`
+
+**`tests/test_mtproto.py`**:
+- `test_send_video_mtproto_attaches_task_to_cancellation`
+
+### 6.3 Manualna checklist E2E
+
+1. Pobranie playlisty 30×, `/stop` po 5 → workspace ma 5 plików, status z `[Spakuj co mam]`, klik → wysyła paczki.
+2. Pakowanie 7z dla playlisty 1 GB+, `/stop` w trakcie → status `⏹`, brak `.7z.001` w workspace, retencja zachowuje resztę.
+3. Wysyłka 8 wolumenów MTProto, `/stop` po 3 → 3 wolumeny w czacie, status z `[Wznów od 4]`, klik → reszta idzie.
+4. Transkrypcja 1h podcast, `/stop` w połowie → audio kasowane, status `⏹`.
+5. Dwa równoległe joby (playlist + transkrypcja), `/stop` listuje oba, klik `[Zatrzymaj wszystkie]` → oba zatrzymane.
+6. `/stop` gdy żadnej operacji → "Brak aktywnych operacji."
+7. Stale job (manualne wywołanie `purge_dead` z `started_at = now - 7h`) → znika z listy, log warning.
+
+### 6.4 Cele pokrycia
+
+- `bot/jobs.py` — > 95 %
+- Modyfikacje w istniejących plikach — istniejące pokrycie nie spada.
+- E2E manual checklist (pkt 7.4) wykonywany przez użytkownika.
+
+## 7. Poza scope
+
+- Per-message przyciski `[⏹]` (świadome odrzucenie — wybrano tylko `/stop`).
+- Persystencja `JobRegistry` na crash bota (in-memory zgodnie z istniejącym wzorcem `SessionStore`).
+- Cancel pojedynczego API-call w trakcie request HTTP do Groq — pojedynczy chunk (~30 s) dokończy się.
+- Cancel reklamacji częściowo zuploadowanych plików w Telegramie (Telegram sam usuwa po ~24 h).
+- Per-user permissions dla `/stop` w grupach (per-chat zachowanie zgodne z istniejącym modelem `pl_cancel`).
+
+## 8. Aktualizacje
+
+- 2026-05-03: spec zaakceptowany w brainstormingu.

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ from bot.handlers.inbound_media import (
     handle_video_upload,
 )
 from bot.telegram_callbacks import handle_callback
+from bot.telegram_commands import stop_command
 
 # Configure logging
 logging.basicConfig(
@@ -102,6 +103,7 @@ def register_handlers(application) -> None:
     application.add_handler(CommandHandler("cleanup", cleanup_command))
     application.add_handler(CommandHandler("users", users_command))
     application.add_handler(CommandHandler("logout", logout_command))
+    application.add_handler(CommandHandler("stop", stop_command))
 
     # Handler for text messages (including PIN and links)
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_youtube_link))

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -213,3 +213,109 @@ def test_pack_to_volumes_real_7z_small_volumes(tmp_path):
     assert len(result) >= 3
     assert all(p.exists() for p in result)
     assert all(p.name.startswith("intg.7z.") for p in result)
+
+
+def test_pack_to_volumes_attaches_process_to_cancellation(tmp_path, monkeypatch):
+    from bot import archive
+    from bot.jobs import JobCancellation
+    import asyncio
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+    dest = tmp_path / "out"
+
+    captured_cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+
+    completed = mock.AsyncMock()
+    completed.communicate = mock.AsyncMock(return_value=(b"", b""))
+    completed.returncode = 0
+
+    async def fake_exec(*args, **kwargs):
+        # Simulate completed pack with one volume.
+        (tmp_path / "out.7z.001").write_bytes(b"v")
+        return completed
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        asyncio.run(
+            archive.pack_to_volumes(
+                [src], dest, volume_size_mb=1, cancellation=captured_cancellation,
+            )
+        )
+
+    # During run cancellation.process was set to the subprocess.
+    assert captured_cancellation.process is completed
+
+
+def test_pack_to_volumes_terminates_on_cancel(tmp_path):
+    from bot import archive
+    from bot.jobs import JobCancellation
+    import asyncio
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+    dest = tmp_path / "out"
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+    cancellation.event.set()  # already cancelled
+
+    fake_proc = mock.MagicMock()
+    fake_proc.communicate = mock.AsyncMock(return_value=(b"", b""))
+    fake_proc.returncode = 0
+    fake_proc.terminate = mock.MagicMock()
+    fake_proc.kill = mock.MagicMock()
+    fake_proc.wait = mock.AsyncMock(return_value=0)
+    # Empty stdout so _stream_7z_progress exits quickly.
+    fake_proc.stdout = mock.MagicMock()
+    fake_proc.stdout.readline = mock.AsyncMock(return_value=b"")
+
+    async def fake_exec(*args, **kwargs):
+        return fake_proc
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        with pytest.raises(RuntimeError, match="cancelled"):
+            asyncio.run(
+                archive.pack_to_volumes(
+                    [src], dest, volume_size_mb=1, cancellation=cancellation,
+                )
+            )
+
+    fake_proc.terminate.assert_called_once()
+
+
+def test_pack_to_volumes_cleans_partial_volumes_on_cancel(tmp_path):
+    from bot import archive
+    from bot.jobs import JobCancellation
+    import asyncio
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+    dest = tmp_path / "playlist"
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+    cancellation.event.set()
+
+    fake_proc = mock.MagicMock()
+    fake_proc.communicate = mock.AsyncMock(return_value=(b"", b""))
+    fake_proc.returncode = 0
+    fake_proc.terminate = mock.MagicMock()
+    fake_proc.kill = mock.MagicMock()
+    fake_proc.wait = mock.AsyncMock(return_value=0)
+    fake_proc.stdout = mock.MagicMock()
+    fake_proc.stdout.readline = mock.AsyncMock(return_value=b"")
+
+    async def fake_exec(*args, **kwargs):
+        # Pretend two volumes started writing before terminate.
+        (tmp_path / "playlist.7z.001").write_bytes(b"a")
+        (tmp_path / "playlist.7z.002").write_bytes(b"b")
+        return fake_proc
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        with pytest.raises(RuntimeError, match="cancelled"):
+            asyncio.run(
+                archive.pack_to_volumes(
+                    [src], dest, volume_size_mb=1, cancellation=cancellation,
+                )
+            )
+
+    # Partial volumes must be cleaned up.
+    assert not (tmp_path / "playlist.7z.001").exists()
+    assert not (tmp_path / "playlist.7z.002").exists()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -22,6 +22,12 @@ def test_volume_size_for_botapi_returns_botapi_constant():
     assert archive.volume_size_for(use_mtproto=False) == BOTAPI_VOLUME_SIZE_MB
 
 
+def test_volume_size_for_mtproto_larger_than_botapi():
+    from bot.archive import volume_size_for
+
+    assert volume_size_for(use_mtproto=True) > volume_size_for(use_mtproto=False)
+
+
 def test_transliterate_to_ascii_replaces_polish_letters():
     from bot.archive import transliterate_to_ascii
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -65,10 +67,6 @@ def test_is_7z_available_when_absent():
 
     with mock.patch("bot.archive.shutil.which", return_value=None):
         assert archive.is_7z_available() is False
-
-
-import asyncio
-from pathlib import Path
 
 
 def test_pack_to_volumes_raises_on_empty_sources():
@@ -164,6 +162,36 @@ def test_pack_to_volumes_raises_when_7z_exits_nonzero(tmp_path):
             asyncio.run(
                 archive.pack_to_volumes([src], tmp_path / "x", volume_size_mb=1)
             )
+
+
+def test_pack_to_volumes_swallows_progress_callback_exception(tmp_path):
+    """Best-effort progress: a raising callback must not abort packing."""
+    from bot import archive
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+    dest = tmp_path / "out"
+
+    async def fake_exec(*args, **kwargs):
+        process = mock.MagicMock()
+        process.returncode = 0
+        process.communicate = mock.AsyncMock(return_value=(b"", b""))
+        process.stdout = mock.MagicMock()
+        process.stdout.readline = mock.AsyncMock(side_effect=[b""])
+        (tmp_path / "out.7z.001").write_bytes(b"v")
+        return process
+
+    async def raising_callback(_text):
+        raise RuntimeError("boom from callback")
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        result = asyncio.run(
+            archive.pack_to_volumes(
+                [src], dest, volume_size_mb=1, progress_cb=raising_callback,
+            )
+        )
+
+    assert result == [tmp_path / "out.7z.001"]
 
 
 def test_pack_to_volumes_real_7z_small_volumes(tmp_path):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,61 @@
+"""Unit tests for bot.archive low-level helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest import mock
+
+import pytest
+
+
+def test_volume_size_for_mtproto_returns_mtproto_constant():
+    from bot import archive
+    from bot.security_limits import MTPROTO_VOLUME_SIZE_MB
+
+    assert archive.volume_size_for(use_mtproto=True) == MTPROTO_VOLUME_SIZE_MB
+
+
+def test_volume_size_for_botapi_returns_botapi_constant():
+    from bot import archive
+    from bot.security_limits import BOTAPI_VOLUME_SIZE_MB
+
+    assert archive.volume_size_for(use_mtproto=False) == BOTAPI_VOLUME_SIZE_MB
+
+
+def test_transliterate_to_ascii_replaces_polish_letters():
+    from bot.archive import transliterate_to_ascii
+
+    assert transliterate_to_ascii("Pączki ąęłżźćń") == "Paczki aelzzcn"
+
+
+def test_transliterate_to_ascii_preserves_safe_characters():
+    from bot.archive import transliterate_to_ascii
+
+    assert transliterate_to_ascii("Hello world - 2026!") == "Hello world - 2026!"
+
+
+def test_transliterate_to_ascii_handles_uppercase():
+    from bot.archive import transliterate_to_ascii
+
+    assert transliterate_to_ascii("ŻÓŁW") == "ZOLW"
+
+
+def test_compute_archive_basename_format():
+    from bot.archive import compute_archive_basename
+
+    ts = datetime(2026, 5, 2, 14, 5, 33)
+    assert compute_archive_basename("playlist", ts) == "playlist_20260502-140533"
+
+
+def test_is_7z_available_when_present():
+    from bot import archive
+
+    with mock.patch("bot.archive.shutil.which", return_value="/usr/bin/7z"):
+        assert archive.is_7z_available() is True
+
+
+def test_is_7z_available_when_absent():
+    from bot import archive
+
+    with mock.patch("bot.archive.shutil.which", return_value=None):
+        assert archive.is_7z_available() is False

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -65,3 +65,123 @@ def test_is_7z_available_when_absent():
 
     with mock.patch("bot.archive.shutil.which", return_value=None):
         assert archive.is_7z_available() is False
+
+
+import asyncio
+from pathlib import Path
+
+
+def test_pack_to_volumes_raises_on_empty_sources():
+    from bot.archive import pack_to_volumes
+
+    with pytest.raises(ValueError, match="empty sources"):
+        asyncio.run(pack_to_volumes([], Path("/tmp/x"), volume_size_mb=10))
+
+
+def test_pack_to_volumes_invokes_7z_with_correct_args(tmp_path):
+    from bot import archive
+
+    src1 = tmp_path / "a.bin"
+    src1.write_bytes(b"x")
+    src2 = tmp_path / "b.bin"
+    src2.write_bytes(b"y")
+    dest = tmp_path / "out_archive"
+
+    completed = mock.AsyncMock()
+    completed.communicate = mock.AsyncMock(return_value=(b"", b""))
+    completed.returncode = 0
+
+    captured: dict = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["args"] = args
+        # Simulate 7z producing two volumes.
+        (tmp_path / "out_archive.7z.001").write_bytes(b"a")
+        (tmp_path / "out_archive.7z.002").write_bytes(b"b")
+        return completed
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        result = asyncio.run(
+            archive.pack_to_volumes([src1, src2], dest, volume_size_mb=42)
+        )
+
+    assert captured["args"][:6] == (
+        "7z",
+        "a",
+        "-t7z",
+        "-v42m",
+        "-mx0",
+        "-mmt=on",
+    )
+    assert str(dest.with_suffix(".7z")) in captured["args"]
+    assert str(src1) in captured["args"]
+    assert str(src2) in captured["args"]
+    assert result == [tmp_path / "out_archive.7z.001", tmp_path / "out_archive.7z.002"]
+
+
+def test_pack_to_volumes_returns_sorted_volume_paths(tmp_path):
+    from bot import archive
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+    dest = tmp_path / "playlist"
+
+    completed = mock.AsyncMock()
+    completed.communicate = mock.AsyncMock(return_value=(b"", b""))
+    completed.returncode = 0
+
+    async def fake_exec(*args, **kwargs):
+        # Volumes intentionally created out of order on disk.
+        for i in (3, 1, 2):
+            (tmp_path / f"playlist.7z.00{i}").write_bytes(b"z")
+        return completed
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        result = asyncio.run(archive.pack_to_volumes([src], dest, volume_size_mb=10))
+
+    assert [p.name for p in result] == [
+        "playlist.7z.001",
+        "playlist.7z.002",
+        "playlist.7z.003",
+    ]
+
+
+def test_pack_to_volumes_raises_when_7z_exits_nonzero(tmp_path):
+    from bot import archive
+
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"x")
+
+    completed = mock.AsyncMock()
+    completed.communicate = mock.AsyncMock(return_value=(b"", b"E_NO_DISK_SPACE\n"))
+    completed.returncode = 2
+
+    async def fake_exec(*args, **kwargs):
+        return completed
+
+    with mock.patch("bot.archive.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        with pytest.raises(RuntimeError, match="7z failed"):
+            asyncio.run(
+                archive.pack_to_volumes([src], tmp_path / "x", volume_size_mb=1)
+            )
+
+
+def test_pack_to_volumes_real_7z_small_volumes(tmp_path):
+    """Integration test: spawn the real 7z binary on a small file."""
+
+    import shutil as _shutil
+    if _shutil.which("7z") is None:
+        pytest.skip("7z binary not available on this host")
+
+    from bot import archive
+
+    src = tmp_path / "data.bin"
+    # 3 MB content, with -v1m volumes -> at least 3 volumes.
+    src.write_bytes(b"Z" * (3 * 1024 * 1024))
+    dest = tmp_path / "intg"
+
+    result = asyncio.run(archive.pack_to_volumes([src], dest, volume_size_mb=1))
+
+    assert len(result) >= 3
+    assert all(p.exists() for p in result)
+    assert all(p.name.startswith("intg.7z.") for p in result)

--- a/tests/test_archive_service.py
+++ b/tests/test_archive_service.py
@@ -566,6 +566,116 @@ def test_send_volumes_breaks_on_cancel(tmp_path, monkeypatch):
     assert len(sent) == 2  # third volume was not sent
 
 
+def test_execute_playlist_archive_flow_registers_and_unregisters(tmp_path, monkeypatch):
+    import asyncio
+    from bot.services import archive_service
+    from bot.jobs import JobRegistry
+    from bot.session_store import session_store
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    test_registry = JobRegistry()
+    monkeypatch.setattr(archive_service, "job_registry", test_registry)
+
+    job_seen_during_run = {}
+
+    async def fake_download_into(workspace, entries, **kwargs):
+        # Snapshot job listing while the flow is in-flight.
+        job_seen_during_run["count"] = len(test_registry.list_for_chat(99))
+        path = workspace / "a.mp3"
+        path.write_bytes(b"x")
+        return [path], []
+
+    async def fake_pack(sources, dest_basename, volume_size_mb, **kwargs):
+        produced = dest_basename.parent / f"{dest_basename.with_suffix('.7z').name}.001"
+        produced.write_bytes(b"v")
+        return [produced]
+
+    async def fake_send(*a, **kw):
+        return None
+
+    monkeypatch.setattr(archive_service, "download_playlist_into", fake_download_into)
+    monkeypatch.setattr(archive_service, "pack_to_volumes", fake_pack)
+    monkeypatch.setattr(archive_service, "send_volumes", fake_send)
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: None)
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    asyncio.run(
+        archive_service.execute_playlist_archive_flow(
+            update, context, chat_id=99,
+            playlist={"title": "Hits", "entries": [{"url": "u", "title": "a"}]},
+            media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(),
+        )
+    )
+
+    assert job_seen_during_run["count"] == 1
+    # Unregistered after success.
+    assert test_registry.list_for_chat(99) == []
+    session_store.reset()
+
+
+def test_execute_playlist_archive_flow_captures_partial_state_on_cancel(tmp_path, monkeypatch):
+    import asyncio
+    from bot.services import archive_service
+    from bot.jobs import JobRegistry
+    from bot.session_store import partial_archive_workspaces, session_store
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    test_registry = JobRegistry()
+    monkeypatch.setattr(archive_service, "job_registry", test_registry)
+
+    async def fake_download_into(workspace, entries, *, cancellation=None, **kwargs):
+        # Simulate two entries downloaded, then cancellation.
+        p1 = workspace / "a.mp3"; p1.write_bytes(b"x")
+        p2 = workspace / "b.mp3"; p2.write_bytes(b"x")
+        cancellation.event.set()
+        return [p1, p2], ["c (anulowano)"]
+
+    pack_called = mock.AsyncMock()
+    send_called = mock.AsyncMock()
+    monkeypatch.setattr(archive_service, "download_playlist_into", fake_download_into)
+    monkeypatch.setattr(archive_service, "pack_to_volumes", pack_called)
+    monkeypatch.setattr(archive_service, "send_volumes", send_called)
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: None)
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    asyncio.run(
+        archive_service.execute_playlist_archive_flow(
+            update, context, chat_id=99,
+            playlist={"title": "Hits", "entries": [
+                {"url": "u1", "title": "a"},
+                {"url": "u2", "title": "b"},
+                {"url": "u3", "title": "c"},
+            ]},
+            media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(),
+        )
+    )
+
+    # Pack and send must NOT have been called.
+    assert pack_called.await_count == 0
+    assert send_called.await_count == 0
+    # Partial state captured.
+    bucket = partial_archive_workspaces.get(99) or {}
+    assert len(bucket) == 1
+    state = next(iter(bucket.values()))
+    assert len(state.downloaded) == 2
+    assert state.title == "Hits"
+    session_store.reset()
+
+
 def test_execute_single_file_archive_flow_consumes_pending_job(tmp_path, monkeypatch):
     from bot.services import archive_service
     from bot.session_store import (

--- a/tests/test_archive_service.py
+++ b/tests/test_archive_service.py
@@ -218,3 +218,143 @@ def test_download_playlist_into_respects_max_archive_item_size(tmp_path, monkeyp
 
     assert [p.name for p in paths] == ["ok.bin"]
     assert any("huge" in title and "za duzy" in title for title in failed)
+
+
+def test_send_volumes_uses_botapi_for_small_volumes(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    v1 = tmp_path / "out.7z.001"
+    v1.write_bytes(b"x" * (10 * 1024 * 1024))  # 10 MB
+    v2 = tmp_path / "out.7z.002"
+    v2.write_bytes(b"x" * (5 * 1024 * 1024))   # 5 MB
+
+    bot = mock.MagicMock()
+    bot.send_document = mock.AsyncMock()
+
+    mtproto_calls = []
+
+    async def fake_mtproto(*args, **kwargs):
+        mtproto_calls.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr(archive_service, "send_document_mtproto", fake_mtproto)
+
+    import asyncio
+
+    asyncio.run(
+        archive_service.send_volumes(
+            bot,
+            chat_id=42,
+            volumes=[v1, v2],
+            caption_prefix="My playlist (audio mp3)",
+            use_mtproto=False,
+            status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert bot.send_document.await_count == 2
+    assert mtproto_calls == []
+    first_call = bot.send_document.await_args_list[0].kwargs
+    assert first_call["chat_id"] == 42
+    assert first_call["caption"] == "My playlist (audio mp3) [1/2]"
+
+
+def test_send_volumes_uses_mtproto_for_large_volumes(tmp_path, monkeypatch):
+    from bot.security_limits import TELEGRAM_UPLOAD_LIMIT_MB
+    from bot.services import archive_service
+
+    big = tmp_path / "out.7z.001"
+    big.write_bytes(b"x" * int((TELEGRAM_UPLOAD_LIMIT_MB + 5) * 1024 * 1024))
+
+    bot = mock.MagicMock()
+    bot.send_document = mock.AsyncMock()
+
+    mtproto_calls = []
+
+    async def fake_mtproto(chat_id, file_path, caption=None, file_name=None):
+        mtproto_calls.append((chat_id, file_path, caption, file_name))
+        return True
+
+    monkeypatch.setattr(archive_service, "send_document_mtproto", fake_mtproto)
+    monkeypatch.setattr(
+        archive_service, "mtproto_unavailability_reason", lambda: None
+    )
+
+    import asyncio
+
+    asyncio.run(
+        archive_service.send_volumes(
+            bot,
+            chat_id=42,
+            volumes=[big],
+            caption_prefix="X",
+            use_mtproto=True,
+            status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert bot.send_document.await_count == 0
+    assert len(mtproto_calls) == 1
+    assert mtproto_calls[0][0] == 42
+    assert mtproto_calls[0][3] == "out.7z.001"
+
+
+def test_send_volumes_raises_when_volume_too_large_and_no_mtproto(tmp_path, monkeypatch):
+    from bot.security_limits import TELEGRAM_UPLOAD_LIMIT_MB
+    from bot.services import archive_service
+
+    big = tmp_path / "out.7z.001"
+    big.write_bytes(b"x" * int((TELEGRAM_UPLOAD_LIMIT_MB + 5) * 1024 * 1024))
+
+    bot = mock.MagicMock()
+    bot.send_document = mock.AsyncMock()
+
+    monkeypatch.setattr(
+        archive_service, "mtproto_unavailability_reason",
+        lambda: "Skonfiguruj API_ID",
+    )
+
+    import asyncio
+
+    with pytest.raises(RuntimeError, match="MTProto"):
+        asyncio.run(
+            archive_service.send_volumes(
+                bot,
+                chat_id=42,
+                volumes=[big],
+                caption_prefix="X",
+                use_mtproto=False,
+                status_cb=mock.AsyncMock(),
+            )
+        )
+
+
+def test_send_volumes_resumes_from_start_index(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    v1 = tmp_path / "out.7z.001"
+    v1.write_bytes(b"x")
+    v2 = tmp_path / "out.7z.002"
+    v2.write_bytes(b"x")
+    v3 = tmp_path / "out.7z.003"
+    v3.write_bytes(b"x")
+
+    bot = mock.MagicMock()
+    bot.send_document = mock.AsyncMock()
+
+    import asyncio
+
+    asyncio.run(
+        archive_service.send_volumes(
+            bot,
+            chat_id=42,
+            volumes=[v1, v2, v3],
+            caption_prefix="X",
+            use_mtproto=False,
+            start_index=2,
+            status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert bot.send_document.await_count == 1
+    assert bot.send_document.await_args.kwargs["caption"] == "X [3/3]"

--- a/tests/test_archive_service.py
+++ b/tests/test_archive_service.py
@@ -489,6 +489,45 @@ def test_execute_playlist_archive_flow_aborts_when_no_items_succeed(tmp_path, mo
     session_store.reset()
 
 
+def test_download_playlist_into_breaks_on_cancel(tmp_path, monkeypatch):
+    import asyncio
+    from bot.services import archive_service
+    from bot.jobs import JobCancellation
+
+    workspace = tmp_path / "pl_x"
+    workspace.mkdir()
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+    iter_count = {"n": 0}
+
+    async def fake_run(entry, workspace_path, **kwargs):
+        iter_count["n"] += 1
+        if iter_count["n"] == 2:
+            cancellation.event.set()
+        produced = workspace_path / f"{entry['title']}.bin"
+        produced.write_bytes(b"x")
+        return produced, 0.5
+
+    monkeypatch.setattr(archive_service, "_download_one_into_workspace", fake_run)
+
+    entries = [
+        {"url": "u1", "title": "first"},
+        {"url": "u2", "title": "second"},
+        {"url": "u3", "title": "third"},
+    ]
+
+    paths, failed = asyncio.run(
+        archive_service.download_playlist_into(
+            workspace, entries, media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(), status_cb=mock.AsyncMock(),
+            cancellation=cancellation,
+        )
+    )
+
+    assert {p.name for p in paths} == {"first.bin", "second.bin"}
+    assert any("anulowano" in t.lower() for t in failed)
+
+
 def test_execute_single_file_archive_flow_consumes_pending_job(tmp_path, monkeypatch):
     from bot.services import archive_service
     from bot.session_store import (

--- a/tests/test_archive_service.py
+++ b/tests/test_archive_service.py
@@ -1,0 +1,94 @@
+"""Unit tests for bot.services.archive_service workspace + registry helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+def test_prepare_playlist_workspace_creates_pl_prefixed_dir(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+    fixed_ts = datetime(2026, 5, 2, 9, 30, 15)
+    with mock.patch("bot.services.archive_service.datetime") as dt_mock:
+        dt_mock.now.return_value = fixed_ts
+        ws = archive_service.prepare_playlist_workspace(7, "Lista A")
+
+    assert ws.exists() and ws.is_dir()
+    assert ws.parent == tmp_path / "7"
+    assert ws.name.startswith("pl_")
+    assert "Lista_A" in ws.name or "Lista A" in ws.name
+    assert "20260502-093015" in ws.name
+
+
+def test_prepare_playlist_workspace_transliterates_polish_chars(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+    ws = archive_service.prepare_playlist_workspace(9, "Pączki ąęłż")
+
+    assert "Paczki" in ws.name
+    assert "ą" not in ws.name and "ł" not in ws.name
+
+
+def test_prepare_playlist_workspace_uses_big_prefix_when_requested(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+    ws = archive_service.prepare_playlist_workspace(1, "video", prefix="big")
+
+    assert ws.name.startswith("big_")
+
+
+def test_register_pending_archive_job_returns_unique_tokens(tmp_path):
+    from bot.services import archive_service
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+
+    session_store.reset()
+    state = ArchiveJobState(
+        file_path=Path(tmp_path / "x.mp4"),
+        title="t",
+        media_type="video",
+        format_choice="best",
+        file_size_mb=200.0,
+        use_mtproto=False,
+        created_at=datetime(2026, 5, 2),
+    )
+
+    tokens = {archive_service.register_pending_archive_job(99, state) for _ in range(50)}
+
+    assert len(tokens) == 50
+    assert pending_archive_jobs[99].keys() == tokens
+    session_store.reset()
+
+
+def test_register_archived_delivery_stores_state():
+    from bot.services import archive_service
+    from bot.session_store import (
+        ArchivedDeliveryState,
+        archived_deliveries,
+        session_store,
+    )
+
+    session_store.reset()
+    delivery = ArchivedDeliveryState(
+        workspace=Path("/tmp/pl_ws"),
+        volumes=[Path("/tmp/pl_ws/x.7z.001")],
+        caption_prefix="ABC",
+        use_mtproto=True,
+        created_at=datetime(2026, 5, 2),
+    )
+
+    token = archive_service.register_archived_delivery(11, delivery)
+
+    assert token in archived_deliveries[11]
+    assert archived_deliveries[11][token] is delivery
+    session_store.reset()

--- a/tests/test_archive_service.py
+++ b/tests/test_archive_service.py
@@ -393,3 +393,157 @@ def test_send_volumes_raises_when_mtproto_returns_false(tmp_path, monkeypatch):
                 status_cb=mock.AsyncMock(),
             )
         )
+
+
+def test_execute_playlist_archive_flow_happy_path(tmp_path, monkeypatch):
+    """Ensures the end-to-end flow chains workspace → download → pack → send."""
+    from bot.services import archive_service
+    from bot.session_store import session_store
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    async def fake_download_into(workspace, entries, **kwargs):
+        path1 = workspace / "a.mp3"
+        path1.write_bytes(b"a")
+        path2 = workspace / "b.mp3"
+        path2.write_bytes(b"b")
+        return [path1, path2], []
+
+    async def fake_pack(sources, dest_basename, volume_size_mb, **kwargs):
+        produced = dest_basename.parent / f"{dest_basename.with_suffix('.7z').name}.001"
+        produced.write_bytes(b"vol")
+        return [produced]
+
+    sent_volumes = []
+
+    async def fake_send_volumes(bot, chat_id, volumes, caption_prefix, use_mtproto, **kwargs):
+        sent_volumes.extend(volumes)
+
+    monkeypatch.setattr(archive_service, "download_playlist_into", fake_download_into)
+    monkeypatch.setattr(archive_service, "pack_to_volumes", fake_pack)
+    monkeypatch.setattr(archive_service, "send_volumes", fake_send_volumes)
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: None)
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+    context.bot = mock.MagicMock()
+
+    import asyncio
+
+    playlist = {"title": "Hits", "entries": [{"url": "u1", "title": "a"}]}
+
+    asyncio.run(
+        archive_service.execute_playlist_archive_flow(
+            update, context, chat_id=99, playlist=playlist,
+            media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(),
+        )
+    )
+
+    # One volume produced and shipped.
+    assert len(sent_volumes) == 1
+    # Workspace persists for retention.
+    assert any(p.name.startswith("pl_") for p in (tmp_path / "99").iterdir())
+    session_store.reset()
+
+
+def test_execute_playlist_archive_flow_aborts_when_no_items_succeed(tmp_path, monkeypatch):
+    from bot.services import archive_service
+    from bot.session_store import session_store
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    async def fake_download_into(workspace, entries, **kwargs):
+        return [], ["a", "b"]
+
+    pack_called = mock.AsyncMock()
+    monkeypatch.setattr(archive_service, "download_playlist_into", fake_download_into)
+    monkeypatch.setattr(archive_service, "pack_to_volumes", pack_called)
+    monkeypatch.setattr(archive_service, "is_7z_available", lambda: True)
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: None)
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    import asyncio
+
+    playlist = {"title": "Empty", "entries": [{"url": "u", "title": "a"}]}
+    asyncio.run(
+        archive_service.execute_playlist_archive_flow(
+            update, context, chat_id=99, playlist=playlist,
+            media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(),
+        )
+    )
+    assert pack_called.await_count == 0
+    # Workspace removed because everything failed.
+    chat_dir = tmp_path / "99"
+    if chat_dir.exists():
+        assert not any(chat_dir.iterdir())
+    session_store.reset()
+
+
+def test_execute_single_file_archive_flow_consumes_pending_job(tmp_path, monkeypatch):
+    from bot.services import archive_service
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+    monkeypatch.setattr(archive_service, "is_7z_available", lambda: True)
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: None)
+
+    src = tmp_path / "input.mp4"
+    src.write_bytes(b"x")
+    state = ArchiveJobState(
+        file_path=src,
+        title="MyVid",
+        media_type="video",
+        format_choice="best",
+        file_size_mb=10.0,
+        use_mtproto=False,
+        created_at=datetime(2026, 5, 2),
+    )
+    token = archive_service.register_pending_archive_job(33, state)
+
+    async def fake_pack(sources, dest_basename, volume_size_mb, **kwargs):
+        produced = dest_basename.parent / f"{dest_basename.with_suffix('.7z').name}.001"
+        produced.write_bytes(b"v")
+        return [produced]
+
+    sent = []
+
+    async def fake_send_volumes(bot, chat_id, volumes, caption_prefix, use_mtproto, **kwargs):
+        sent.extend(volumes)
+
+    monkeypatch.setattr(archive_service, "pack_to_volumes", fake_pack)
+    monkeypatch.setattr(archive_service, "send_volumes", fake_send_volumes)
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+    context.bot = mock.MagicMock()
+
+    import asyncio
+
+    asyncio.run(
+        archive_service.execute_single_file_archive_flow(
+            update, context, chat_id=33, token=token,
+        )
+    )
+
+    # Pending job consumed.
+    assert pending_archive_jobs.get(33, {}).get(token) is None
+    # File migrated into workspace and a volume produced + sent.
+    assert len(sent) == 1
+    session_store.reset()

--- a/tests/test_archive_service.py
+++ b/tests/test_archive_service.py
@@ -734,3 +734,55 @@ def test_execute_single_file_archive_flow_consumes_pending_job(tmp_path, monkeyp
     # File migrated into workspace and a volume produced + sent.
     assert len(sent) == 1
     session_store.reset()
+
+
+def test_execute_partial_archive_flow_packs_remaining(tmp_path, monkeypatch):
+    import asyncio
+    from datetime import datetime
+    from pathlib import Path
+    from bot.services import archive_service
+    from bot.session_store import (
+        ArchivePartialState,
+        partial_archive_workspaces,
+        session_store,
+    )
+
+    session_store.reset()
+    monkeypatch.setattr(archive_service, "DOWNLOAD_PATH", str(tmp_path))
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    p1 = workspace / "a.mp3"; p1.write_bytes(b"x")
+    p2 = workspace / "b.mp3"; p2.write_bytes(b"x")
+
+    state = ArchivePartialState(
+        workspace=workspace, downloaded=[p1, p2],
+        title="Hits", media_type="audio", format_choice="mp3",
+        use_mtproto=False,
+        created_at=datetime(2026, 5, 3),
+    )
+    partial_archive_workspaces[44] = {"tok": state}
+
+    pack_called = mock.AsyncMock(return_value=[workspace / "out.7z.001"])
+    send_called = mock.AsyncMock()
+    monkeypatch.setattr(archive_service, "pack_to_volumes", pack_called)
+    monkeypatch.setattr(archive_service, "send_volumes", send_called)
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: "n/a")
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+    context.bot = mock.MagicMock()
+
+    asyncio.run(
+        archive_service.execute_partial_archive_flow(
+            update, context, chat_id=44, token="tok",
+        )
+    )
+
+    pack_called.assert_awaited_once()
+    send_called.assert_awaited_once()
+    # Partial state consumed.
+    assert partial_archive_workspaces.get(44, {}).get("tok") is None
+    session_store.reset()

--- a/tests/test_archive_service.py
+++ b/tests/test_archive_service.py
@@ -92,3 +92,129 @@ def test_register_archived_delivery_stores_state():
     assert token in archived_deliveries[11]
     assert archived_deliveries[11][token] is delivery
     session_store.reset()
+
+
+def test_download_playlist_into_keeps_files_after_download(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    workspace = tmp_path / "pl_x"
+    workspace.mkdir()
+
+    async def fake_run(entry, workspace_path, *, media_type, format_choice, executor):
+        produced = workspace_path / f"{entry['title']}.bin"
+        produced.write_bytes(b"data")
+        return produced, 1.5  # path, size_mb
+
+    monkeypatch.setattr(archive_service, "_download_one_into_workspace", fake_run)
+
+    entries = [{"url": "u1", "title": "first"}, {"url": "u2", "title": "second"}]
+    import asyncio
+
+    paths, failed = asyncio.run(
+        archive_service.download_playlist_into(
+            workspace,
+            entries,
+            media_type="audio",
+            format_choice="mp3",
+            executor=mock.MagicMock(),
+            status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert {p.name for p in paths} == {"first.bin", "second.bin"}
+    assert failed == []
+    assert (workspace / "first.bin").exists()
+    assert (workspace / "second.bin").exists()
+
+
+def test_download_playlist_into_returns_empty_when_all_fail(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    workspace = tmp_path / "pl_x"
+    workspace.mkdir()
+
+    async def fake_run(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(archive_service, "_download_one_into_workspace", fake_run)
+
+    entries = [{"url": "u1", "title": "a"}, {"url": "u2", "title": "b"}]
+    import asyncio
+
+    paths, failed = asyncio.run(
+        archive_service.download_playlist_into(
+            workspace, entries, media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(), status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert paths == []
+    assert failed == ["a", "b"]
+
+
+def test_download_playlist_into_returns_failed_titles_on_partial(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    workspace = tmp_path / "pl_x"
+    workspace.mkdir()
+    call_count = {"n": 0}
+
+    async def fake_run(entry, workspace_path, **kwargs):
+        call_count["n"] += 1
+        if entry["title"] == "bad":
+            raise RuntimeError("fail")
+        produced = workspace_path / f"{entry['title']}.bin"
+        produced.write_bytes(b"x")
+        return produced, 0.5
+
+    monkeypatch.setattr(archive_service, "_download_one_into_workspace", fake_run)
+
+    entries = [
+        {"url": "u1", "title": "good1"},
+        {"url": "u2", "title": "bad"},
+        {"url": "u3", "title": "good2"},
+    ]
+    import asyncio
+
+    paths, failed = asyncio.run(
+        archive_service.download_playlist_into(
+            workspace, entries, media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(), status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert {p.name for p in paths} == {"good1.bin", "good2.bin"}
+    assert failed == ["bad"]
+
+
+def test_download_playlist_into_respects_max_archive_item_size(tmp_path, monkeypatch):
+    from bot.services import archive_service
+
+    workspace = tmp_path / "pl_x"
+    workspace.mkdir()
+
+    async def fake_run(entry, workspace_path, **kwargs):
+        # Pretend the second entry is huge.
+        if entry["title"] == "huge":
+            return None, 99999.0  # too big
+        produced = workspace_path / f"{entry['title']}.bin"
+        produced.write_bytes(b"x")
+        return produced, 1.0
+
+    monkeypatch.setattr(archive_service, "_download_one_into_workspace", fake_run)
+
+    entries = [
+        {"url": "u1", "title": "ok"},
+        {"url": "u2", "title": "huge"},
+    ]
+    import asyncio
+
+    paths, failed = asyncio.run(
+        archive_service.download_playlist_into(
+            workspace, entries, media_type="audio", format_choice="mp3",
+            executor=mock.MagicMock(), status_cb=mock.AsyncMock(),
+        )
+    )
+
+    assert [p.name for p in paths] == ["ok.bin"]
+    assert any("huge" in title for title in failed)

--- a/tests/test_archive_service.py
+++ b/tests/test_archive_service.py
@@ -217,4 +217,4 @@ def test_download_playlist_into_respects_max_archive_item_size(tmp_path, monkeyp
     )
 
     assert [p.name for p in paths] == ["ok.bin"]
-    assert any("huge" in title for title in failed)
+    assert any("huge" in title and "za duzy" in title for title in failed)

--- a/tests/test_archive_service.py
+++ b/tests/test_archive_service.py
@@ -528,6 +528,44 @@ def test_download_playlist_into_breaks_on_cancel(tmp_path, monkeypatch):
     assert any("anulowano" in t.lower() for t in failed)
 
 
+def test_send_volumes_breaks_on_cancel(tmp_path, monkeypatch):
+    import asyncio
+    from bot.services import archive_service
+    from bot.jobs import JobCancellation
+
+    volumes = []
+    for i in range(1, 6):
+        v = tmp_path / f"out.7z.00{i}"
+        v.write_bytes(b"x")
+        volumes.append(v)
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+
+    bot = mock.MagicMock()
+    sent = []
+
+    async def fake_send(**kwargs):
+        sent.append(kwargs["caption"])
+        if len(sent) == 2:
+            cancellation.event.set()
+
+    bot.send_document = fake_send
+
+    monkeypatch.setattr(
+        archive_service, "mtproto_unavailability_reason", lambda: "n/a",
+    )
+
+    asyncio.run(
+        archive_service.send_volumes(
+            bot, chat_id=1, volumes=volumes, caption_prefix="X",
+            use_mtproto=False, status_cb=mock.AsyncMock(),
+            cancellation=cancellation,
+        )
+    )
+
+    assert len(sent) == 2  # third volume was not sent
+
+
 def test_execute_single_file_archive_flow_consumes_pending_job(tmp_path, monkeypatch):
     from bot.services import archive_service
     from bot.session_store import (

--- a/tests/test_archive_service.py
+++ b/tests/test_archive_service.py
@@ -238,6 +238,10 @@ def test_send_volumes_uses_botapi_for_small_volumes(tmp_path, monkeypatch):
         return True
 
     monkeypatch.setattr(archive_service, "send_document_mtproto", fake_mtproto)
+    monkeypatch.setattr(
+        archive_service, "mtproto_unavailability_reason",
+        lambda: "n/a in this test",
+    )
 
     import asyncio
 
@@ -358,3 +362,34 @@ def test_send_volumes_resumes_from_start_index(tmp_path, monkeypatch):
 
     assert bot.send_document.await_count == 1
     assert bot.send_document.await_args.kwargs["caption"] == "X [3/3]"
+
+
+def test_send_volumes_raises_when_mtproto_returns_false(tmp_path, monkeypatch):
+    from bot.security_limits import TELEGRAM_UPLOAD_LIMIT_MB
+    from bot.services import archive_service
+
+    big = tmp_path / "out.7z.001"
+    big.write_bytes(b"x" * int((TELEGRAM_UPLOAD_LIMIT_MB + 5) * 1024 * 1024))
+
+    monkeypatch.setattr(archive_service, "mtproto_unavailability_reason", lambda: None)
+    monkeypatch.setattr(
+        archive_service, "send_document_mtproto",
+        mock.AsyncMock(return_value=False),
+    )
+
+    bot = mock.MagicMock()
+    bot.send_document = mock.AsyncMock()
+
+    import asyncio
+
+    with pytest.raises(RuntimeError, match="nie powiodła się"):
+        asyncio.run(
+            archive_service.send_volumes(
+                bot,
+                chat_id=42,
+                volumes=[big],
+                caption_prefix="X",
+                use_mtproto=True,
+                status_cb=mock.AsyncMock(),
+            )
+        )

--- a/tests/test_callback_download_handlers.py
+++ b/tests/test_callback_download_handlers.py
@@ -1,6 +1,7 @@
 """Download- and routing-oriented tests for Telegram callbacks."""
 
 import asyncio
+from unittest import mock
 
 import pytest
 
@@ -193,3 +194,202 @@ def test_handle_callback_time_range_options_and_clear():
     assert shown["time_range_url"] == "https://www.youtube.com/watch?v=abc"
     assert back_called["url"] == "https://www.youtube.com/watch?v=abc"
     assert 888 not in tc.user_time_ranges
+
+
+def test_oversized_single_file_offers_archive_choice(tmp_path, monkeypatch):
+    """File too big after download → user gets [Wyślij jako 7z][Anuluj]."""
+    from bot.handlers import download_callbacks
+    from bot.session_store import pending_archive_jobs, session_store
+
+    session_store.reset()
+    pretend = tmp_path / "big.mp4"
+    pretend.write_bytes(b"x")
+
+    captured = {}
+
+    async def fake_offer_archive(update, context, *, chat_id, file_path, title, media_type, format_choice, file_size_mb):
+        captured["called"] = True
+
+    monkeypatch.setattr(
+        download_callbacks, "_offer_archive_or_cancel", fake_offer_archive
+    )
+
+    import asyncio
+    asyncio.run(
+        download_callbacks._offer_archive_or_cancel(
+            mock.MagicMock(),
+            mock.MagicMock(),
+            chat_id=1,
+            file_path=str(pretend),
+            title="t",
+            media_type="video",
+            format_choice="best",
+            file_size_mb=999.0,
+        )
+    )
+    assert captured["called"] is True
+    session_store.reset()
+
+
+def test_arc_cancel_removes_file_immediately(tmp_path, monkeypatch):
+    from bot.handlers import download_callbacks
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+    from datetime import datetime
+    from pathlib import Path
+
+    session_store.reset()
+    src = tmp_path / "to_cancel.mp4"
+    src.write_bytes(b"x")
+    state = ArchiveJobState(
+        file_path=src,
+        title="x", media_type="video", format_choice="best",
+        file_size_mb=200.0, use_mtproto=False,
+        created_at=datetime(2026, 5, 2),
+    )
+    pending_archive_jobs[7] = {"tok": state}
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 7
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    import asyncio
+    asyncio.run(
+        download_callbacks.handle_archive_callback(
+            update, context, "arc_cancel_tok"
+        )
+    )
+
+    assert not src.exists()
+    assert pending_archive_jobs.get(7, {}).get("tok") is None
+    session_store.reset()
+
+
+def test_arc_split_dispatches_to_archive_service(tmp_path, monkeypatch):
+    from bot.handlers import download_callbacks
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+    from datetime import datetime
+
+    session_store.reset()
+    src = tmp_path / "x.mp4"
+    src.write_bytes(b"x")
+    pending_archive_jobs[7] = {"tok2": ArchiveJobState(
+        file_path=src, title="x", media_type="video", format_choice="best",
+        file_size_mb=200.0, use_mtproto=False,
+        created_at=datetime(2026, 5, 2),
+    )}
+
+    fake_flow = mock.AsyncMock()
+    monkeypatch.setattr(
+        download_callbacks, "execute_single_file_archive_flow", fake_flow
+    )
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 7
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    import asyncio
+    asyncio.run(
+        download_callbacks.handle_archive_callback(
+            update, context, "arc_split_tok2"
+        )
+    )
+
+    assert fake_flow.await_count == 1
+    kwargs = fake_flow.await_args.kwargs
+    assert kwargs["chat_id"] == 7
+    assert kwargs["token"] == "tok2"
+    session_store.reset()
+
+
+def test_arc_resend_calls_send_volumes_with_index(tmp_path, monkeypatch):
+    from bot.handlers import download_callbacks
+    from bot.session_store import (
+        ArchivedDeliveryState,
+        archived_deliveries,
+        session_store,
+    )
+    from datetime import datetime
+    from pathlib import Path
+
+    session_store.reset()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    v1 = workspace / "x.7z.001"
+    v1.write_bytes(b"a")
+    v2 = workspace / "x.7z.002"
+    v2.write_bytes(b"a")
+    archived_deliveries[5] = {"tk": ArchivedDeliveryState(
+        workspace=workspace, volumes=[v1, v2],
+        caption_prefix="X", use_mtproto=True,
+        created_at=datetime(2026, 5, 2),
+    )}
+
+    sent = mock.AsyncMock()
+    monkeypatch.setattr(download_callbacks, "send_volumes", sent)
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 5
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+    context.bot = mock.MagicMock()
+
+    import asyncio
+    asyncio.run(
+        download_callbacks.handle_archive_callback(
+            update, context, "arc_resend_tk_1"
+        )
+    )
+
+    assert sent.await_count == 1
+    assert sent.await_args.kwargs["start_index"] == 1
+    session_store.reset()
+
+
+def test_arc_purge_removes_workspace(tmp_path, monkeypatch):
+    from bot.handlers import download_callbacks
+    from bot.session_store import (
+        ArchivedDeliveryState,
+        archived_deliveries,
+        session_store,
+    )
+    from datetime import datetime
+
+    session_store.reset()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "x.7z.001").write_bytes(b"a")
+    archived_deliveries[5] = {"tk2": ArchivedDeliveryState(
+        workspace=workspace, volumes=[workspace / "x.7z.001"],
+        caption_prefix="X", use_mtproto=True,
+        created_at=datetime(2026, 5, 2),
+    )}
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 5
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    import asyncio
+    asyncio.run(
+        download_callbacks.handle_archive_callback(
+            update, context, "arc_purge_tk2"
+        )
+    )
+
+    assert not workspace.exists()
+    assert archived_deliveries.get(5, {}).get("tk2") is None
+    session_store.reset()

--- a/tests/test_callback_download_handlers.py
+++ b/tests/test_callback_download_handlers.py
@@ -196,8 +196,8 @@ def test_handle_callback_time_range_options_and_clear():
     assert 888 not in tc.user_time_ranges
 
 
-def test_oversized_single_file_offers_archive_choice(tmp_path, monkeypatch):
-    """File too big after download → user gets [Wyślij jako 7z][Anuluj]."""
+def test_offer_archive_or_cancel_registers_pending_job(tmp_path, monkeypatch):
+    """_offer_archive_or_cancel registers state and shows two-button keyboard."""
     from bot.handlers import download_callbacks
     from bot.session_store import pending_archive_jobs, session_store
 
@@ -205,29 +205,44 @@ def test_oversized_single_file_offers_archive_choice(tmp_path, monkeypatch):
     pretend = tmp_path / "big.mp4"
     pretend.write_bytes(b"x")
 
-    captured = {}
-
-    async def fake_offer_archive(update, context, *, chat_id, file_path, title, media_type, format_choice, file_size_mb):
-        captured["called"] = True
-
     monkeypatch.setattr(
-        download_callbacks, "_offer_archive_or_cancel", fake_offer_archive
+        download_callbacks, "_mtproto_unavailability_reason", lambda: None
     )
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
 
     import asyncio
     asyncio.run(
         download_callbacks._offer_archive_or_cancel(
-            mock.MagicMock(),
-            mock.MagicMock(),
-            chat_id=1,
+            update,
+            context,
+            chat_id=99,
             file_path=str(pretend),
-            title="t",
+            title="big-file",
             media_type="video",
             format_choice="best",
-            file_size_mb=999.0,
+            file_size_mb=1500.0,
         )
     )
-    assert captured["called"] is True
+
+    # State registered.
+    bucket = pending_archive_jobs.get(99) or {}
+    assert len(bucket) == 1
+    state = next(iter(bucket.values()))
+    assert state.title == "big-file"
+    assert state.file_size_mb == 1500.0
+
+    # Two buttons shown.
+    update.callback_query.edit_message_text.assert_awaited_once()
+    sent_text, sent_kwargs = update.callback_query.edit_message_text.await_args.args, update.callback_query.edit_message_text.await_args.kwargs
+    keyboard = sent_kwargs["reply_markup"]
+    callback_data = [btn.callback_data for row in keyboard.inline_keyboard for btn in row]
+    assert any(cb.startswith("arc_split_") for cb in callback_data)
+    assert any(cb.startswith("arc_cancel_") for cb in callback_data)
+
     session_store.reset()
 
 

--- a/tests/test_callback_download_handlers.py
+++ b/tests/test_callback_download_handlers.py
@@ -408,3 +408,36 @@ def test_arc_purge_removes_workspace(tmp_path, monkeypatch):
     assert not workspace.exists()
     assert archived_deliveries.get(5, {}).get("tk2") is None
     session_store.reset()
+
+
+def test_download_file_registers_and_unregisters_job(tmp_path, monkeypatch):
+    import asyncio
+    from bot.handlers import download_callbacks
+    from bot.jobs import JobRegistry
+    from bot.session_store import session_store
+
+    session_store.reset()
+    test_registry = JobRegistry()
+    monkeypatch.setattr(download_callbacks, "job_registry", test_registry)
+
+    # Patch prepare_download_plan to short-circuit by returning None.
+    monkeypatch.setattr(
+        download_callbacks, "prepare_download_plan", lambda **kw: None,
+    )
+
+    update = mock.MagicMock()
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    update.effective_chat.id = 7
+    context = mock.MagicMock()
+
+    asyncio.run(
+        download_callbacks.download_file(
+            update, context,
+            type="video", format="best", url="https://x",
+        )
+    )
+
+    # Even on early-exit path the job should register and unregister.
+    assert test_registry.list_for_chat(7) == []
+    session_store.reset()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -237,3 +237,29 @@ def test_purge_pending_archive_jobs_removes_old_jobs(tmp_path):
     assert pending_archive_jobs.get(1, {}).get("old") is None
     assert not src.exists()
     session_store.reset()
+
+
+def test_purge_archived_deliveries_removes_old_entries(tmp_path):
+    from bot import cleanup
+    from bot.session_store import (
+        ArchivedDeliveryState,
+        archived_deliveries,
+        session_store,
+    )
+
+    session_store.reset()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    old_state = ArchivedDeliveryState(
+        workspace=workspace,
+        volumes=[workspace / "x.7z.001"],
+        caption_prefix="X",
+        use_mtproto=True,
+        created_at=datetime.now() - timedelta(hours=2),
+    )
+    archived_deliveries[1] = {"old": old_state}
+
+    cleanup._purge_archived_deliveries(retention_min=60)
+
+    assert archived_deliveries.get(1, {}).get("old") is None
+    session_store.reset()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -4,8 +4,9 @@ Unit tests for cleanup helpers.
 
 import os
 import time
-from types import SimpleNamespace
+from datetime import datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from bot.cleanup import cleanup_old_files, get_disk_usage, monitor_disk_space
@@ -119,12 +120,6 @@ def test_monitor_disk_space_runs_cleanup_below_warning_threshold(monkeypatch):
     assert calls == [(cleanup_module.DOWNLOAD_PATH, 6)]
 
 
-import os
-import time
-from datetime import datetime, timedelta
-from pathlib import Path
-
-
 def test_purge_archive_workspaces_removes_old_pl_dirs(tmp_path, monkeypatch):
     from bot import cleanup
 
@@ -154,7 +149,7 @@ def test_purge_archive_workspaces_keeps_recent_dirs(tmp_path):
     assert fresh_ws.exists()
 
 
-def test_purge_archive_workspaces_respects_lock_when_recent(tmp_path):
+def test_purge_archive_workspaces_keeps_dirs_under_threshold(tmp_path):
     from bot import cleanup
 
     chat_dir = tmp_path / "333"
@@ -169,6 +164,40 @@ def test_purge_archive_workspaces_respects_lock_when_recent(tmp_path):
     cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
 
     assert ws.exists()
+
+
+def test_purge_archive_workspaces_keeps_locked_dir_within_safety_net(tmp_path):
+    """Lock blocks deletion when age > retention but <= 24h."""
+    chat_dir = tmp_path / "555"
+    chat_dir.mkdir()
+    ws = chat_dir / "pl_locked_old_20260502-080000"
+    ws.mkdir()
+    (ws / ".lock").touch()
+    # 90 min old: past 60 min retention, well below 24h safety net.
+    age = time.time() - 90 * 60
+    os.utime(ws, (age, age))
+
+    from bot import cleanup
+    cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
+
+    assert ws.exists()
+
+
+def test_purge_archive_workspaces_safety_net_deletes_lock_after_24h(tmp_path):
+    """Lock must not save a workspace older than the 24h safety net."""
+    chat_dir = tmp_path / "666"
+    chat_dir.mkdir()
+    ws = chat_dir / "pl_orphan_lock_20260502-080000"
+    ws.mkdir()
+    (ws / ".lock").touch()
+    # 25 h old: past safety net.
+    age = time.time() - 25 * 3600
+    os.utime(ws, (age, age))
+
+    from bot import cleanup
+    cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
+
+    assert not ws.exists()
 
 
 def test_purge_archive_workspaces_ignores_non_archive_dirs(tmp_path):

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -263,3 +263,52 @@ def test_purge_archived_deliveries_removes_old_entries(tmp_path):
 
     assert archived_deliveries.get(1, {}).get("old") is None
     session_store.reset()
+
+
+def test_purge_dead_jobs_called_in_periodic_cleanup(monkeypatch):
+    """periodic_cleanup invokes job_registry.purge_dead with 6h threshold."""
+
+    from datetime import timedelta
+    from bot import cleanup
+    from bot.jobs import JobRegistry
+
+    test_registry = JobRegistry()
+    monkeypatch.setattr(cleanup, "job_registry", test_registry)
+    captured = {}
+
+    def fake_purge(threshold):
+        captured["threshold"] = threshold
+        return 0
+
+    monkeypatch.setattr(test_registry, "purge_dead", fake_purge)
+
+    # Drive one iteration of the loop body without sleeping for an hour.
+    cleanup._purge_dead_jobs(retention_hours=6)
+
+    assert captured["threshold"] == timedelta(hours=6)
+
+
+def test_purge_partial_archive_workspaces_removes_old(tmp_path, monkeypatch):
+    from datetime import datetime, timedelta
+    from pathlib import Path
+    from bot import cleanup
+    from bot.session_store import (
+        ArchivePartialState,
+        partial_archive_workspaces,
+        session_store,
+    )
+
+    session_store.reset()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    state = ArchivePartialState(
+        workspace=workspace, downloaded=[], title="x",
+        media_type="audio", format_choice="mp3", use_mtproto=False,
+        created_at=datetime.now() - timedelta(hours=2),
+    )
+    partial_archive_workspaces[1] = {"old": state}
+
+    cleanup._purge_partial_archive_workspaces(retention_min=60)
+
+    assert partial_archive_workspaces.get(1, {}).get("old") is None
+    session_store.reset()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -117,3 +117,94 @@ def test_monitor_disk_space_runs_cleanup_below_warning_threshold(monkeypatch):
 
     monitor_disk_space()
     assert calls == [(cleanup_module.DOWNLOAD_PATH, 6)]
+
+
+import os
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+def test_purge_archive_workspaces_removes_old_pl_dirs(tmp_path, monkeypatch):
+    from bot import cleanup
+
+    chat_dir = tmp_path / "111"
+    chat_dir.mkdir()
+    old_ws = chat_dir / "pl_oldslug_20260102-080000"
+    old_ws.mkdir()
+    (old_ws / "x.7z.001").write_bytes(b"x")
+    # Set mtime to 2 hours ago.
+    old_time = time.time() - 2 * 3600
+    os.utime(old_ws, (old_time, old_time))
+
+    cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
+
+    assert not old_ws.exists()
+
+
+def test_purge_archive_workspaces_keeps_recent_dirs(tmp_path):
+    from bot import cleanup
+
+    chat_dir = tmp_path / "222"
+    chat_dir.mkdir()
+    fresh_ws = chat_dir / "pl_fresh_20260502-080000"
+    fresh_ws.mkdir()
+    # Default mtime is "now", which is well under 60 min.
+    cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
+    assert fresh_ws.exists()
+
+
+def test_purge_archive_workspaces_respects_lock_when_recent(tmp_path):
+    from bot import cleanup
+
+    chat_dir = tmp_path / "333"
+    chat_dir.mkdir()
+    ws = chat_dir / "pl_locked_20260502-080000"
+    ws.mkdir()
+    (ws / ".lock").touch()
+    # Make the workspace look 30 min old (under the 60 min retention).
+    age = time.time() - 30 * 60
+    os.utime(ws, (age, age))
+
+    cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
+
+    assert ws.exists()
+
+
+def test_purge_archive_workspaces_ignores_non_archive_dirs(tmp_path):
+    from bot import cleanup
+
+    chat_dir = tmp_path / "444"
+    chat_dir.mkdir()
+    other = chat_dir / "downloads_subfolder"
+    other.mkdir()
+    age = time.time() - 7200
+    os.utime(other, (age, age))
+
+    cleanup._purge_archive_workspaces(chat_dir, retention_min=60)
+    assert other.exists()
+
+
+def test_purge_pending_archive_jobs_removes_old_jobs(tmp_path):
+    from bot import cleanup
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+
+    session_store.reset()
+    src = tmp_path / "x.mp4"
+    src.write_bytes(b"x")
+    old_state = ArchiveJobState(
+        file_path=src, title="x", media_type="video", format_choice="best",
+        file_size_mb=1.0, use_mtproto=False,
+        created_at=datetime.now() - timedelta(hours=2),
+    )
+    pending_archive_jobs[1] = {"old": old_state}
+
+    cleanup._purge_pending_archive_jobs(retention_min=60)
+
+    assert pending_archive_jobs.get(1, {}).get("old") is None
+    assert not src.exists()
+    session_store.reset()

--- a/tests/test_download_service.py
+++ b/tests/test_download_service.py
@@ -449,3 +449,31 @@ def test_execute_download_async_raises_when_no_file(monkeypatch, tmp_path):
     with pytest.raises(FileNotFoundError):
         asyncio.run(run())
     executor.shutdown(wait=False)
+
+
+def test_execute_download_progress_hook_raises_on_cancel():
+    """When cancellation.event is set, the wrapped hook raises DownloadError."""
+    import yt_dlp
+
+    from bot.jobs import JobCancellation
+    from bot.services.download_service import _build_cancellable_progress_hook
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+    base_called = {"n": 0}
+
+    def base(d):
+        base_called["n"] += 1
+
+    hook = _build_cancellable_progress_hook(base, cancellation)
+
+    # Without cancellation — base hook should be called normally.
+    hook({"status": "downloading"})
+    assert base_called["n"] == 1
+
+    # With cancellation set — DownloadError must be raised before calling base.
+    cancellation.event.set()
+    with pytest.raises(yt_dlp.utils.DownloadError, match="cancelled"):
+        hook({"status": "downloading"})
+
+    # Base hook must not have been called after cancellation.
+    assert base_called["n"] == 1

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -121,3 +121,106 @@ def test_global_singleton_is_jobregistry():
     from bot.jobs import JobRegistry, job_registry
 
     assert isinstance(job_registry, JobRegistry)
+
+
+def test_cancel_sets_event_and_returns_true():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    result = registry.cancel(c.job_id, reason="test")
+
+    assert result is True
+    assert c.event.is_set() is True
+    assert c.cancelled_reason == "test"
+
+
+def test_cancel_unknown_returns_false():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    result = registry.cancel("nonexistent")
+
+    assert result is False
+
+
+def test_cancel_terminates_attached_subprocess(monkeypatch):
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    fake_process = mock.MagicMock()
+    fake_process.terminate = mock.MagicMock()
+    fake_process.wait = mock.AsyncMock(return_value=0)
+    fake_process.returncode = None
+    fake_process.kill = mock.MagicMock()
+    c.process = fake_process
+
+    asyncio.run(registry.cancel_async(c.job_id, reason="t"))
+
+    fake_process.terminate.assert_called_once()
+    fake_process.kill.assert_not_called()
+
+
+def test_cancel_kills_subprocess_when_terminate_times_out():
+    from bot.jobs import JobRegistry
+    from bot.security_limits import JOB_TERMINATE_GRACE_SEC
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    fake_process = mock.MagicMock()
+    fake_process.terminate = mock.MagicMock()
+    fake_process.wait = mock.AsyncMock(side_effect=asyncio.TimeoutError())
+    fake_process.kill = mock.MagicMock()
+    c.process = fake_process
+
+    asyncio.run(registry.cancel_async(c.job_id, reason="t"))
+
+    fake_process.terminate.assert_called_once()
+    fake_process.kill.assert_called_once()
+
+
+def test_cancel_cancels_attached_pyrogram_task():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    fake_task = mock.MagicMock()
+    fake_task.done = mock.MagicMock(return_value=False)
+    fake_task.cancel = mock.MagicMock()
+    c.pyrogram_task = fake_task
+
+    asyncio.run(registry.cancel_async(c.job_id, reason="t"))
+
+    fake_task.cancel.assert_called_once()
+
+
+def test_cancel_skips_already_done_pyrogram_task():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    fake_task = mock.MagicMock()
+    fake_task.done = mock.MagicMock(return_value=True)
+    fake_task.cancel = mock.MagicMock()
+    c.pyrogram_task = fake_task
+
+    asyncio.run(registry.cancel_async(c.job_id, reason="t"))
+
+    fake_task.cancel.assert_not_called()
+
+
+def test_cancelled_reason_propagates():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    registry.cancel(c.job_id, reason="user via /stop")
+
+    assert c.cancelled_reason == "user via /stop"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,123 @@
+"""Unit tests for bot.jobs registry."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from unittest import mock
+
+import pytest
+
+
+def _descriptor(chat_id=42, kind="single_dl", label="t"):
+    from bot.jobs import JobDescriptor
+    return JobDescriptor(
+        job_id="",  # will be set by registry
+        chat_id=chat_id,
+        kind=kind,
+        label=label,
+        started_at=datetime.now(),
+    )
+
+
+def test_register_returns_unique_job_id():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c1 = registry.register(1, _descriptor())
+    c2 = registry.register(1, _descriptor())
+
+    assert c1.job_id != c2.job_id
+    assert len(c1.job_id) >= 8
+
+
+def test_register_creates_unset_event():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    cancellation = registry.register(1, _descriptor())
+
+    assert isinstance(cancellation.event, asyncio.Event)
+    assert cancellation.event.is_set() is False
+    assert cancellation.process is None
+    assert cancellation.pyrogram_task is None
+    assert cancellation.cancelled_reason is None
+
+
+def test_get_returns_registered_cancellation():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c1 = registry.register(1, _descriptor())
+
+    assert registry.get(c1.job_id) is c1
+    assert registry.get("nonexistent") is None
+
+
+def test_list_for_chat_returns_descriptors():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c1 = registry.register(7, _descriptor(chat_id=7, label="A"))
+    c2 = registry.register(7, _descriptor(chat_id=7, label="B"))
+
+    descriptors = registry.list_for_chat(7)
+    labels = [d.label for d in descriptors]
+
+    assert sorted(labels) == ["A", "B"]
+    assert all(d.chat_id == 7 for d in descriptors)
+
+
+def test_list_for_chat_excludes_other_chats():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    registry.register(1, _descriptor(chat_id=1, label="A"))
+    registry.register(2, _descriptor(chat_id=2, label="B"))
+
+    assert [d.label for d in registry.list_for_chat(1)] == ["A"]
+    assert [d.label for d in registry.list_for_chat(2)] == ["B"]
+
+
+def test_update_label_changes_descriptor():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor(label="initial"))
+
+    registry.update_label(c.job_id, "updated [3/5]")
+    descriptors = registry.list_for_chat(1)
+
+    assert descriptors[0].label == "updated [3/5]"
+
+
+def test_update_label_silently_ignores_unknown_job():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    registry.update_label("nonexistent", "x")  # must not raise
+
+
+def test_unregister_removes_descriptor():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    c = registry.register(1, _descriptor())
+
+    registry.unregister(c.job_id)
+
+    assert registry.get(c.job_id) is None
+    assert registry.list_for_chat(1) == []
+
+
+def test_unregister_unknown_is_noop():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    registry.unregister("nonexistent")  # must not raise
+
+
+def test_global_singleton_is_jobregistry():
+    from bot.jobs import JobRegistry, job_registry
+
+    assert isinstance(job_registry, JobRegistry)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -224,3 +224,33 @@ def test_cancelled_reason_propagates():
     registry.cancel(c.job_id, reason="user via /stop")
 
     assert c.cancelled_reason == "user via /stop"
+
+
+def test_purge_dead_removes_old_entries():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    old = _descriptor(label="old")
+    old.started_at = datetime.now() - timedelta(hours=7)
+    registry.register(1, old)
+    fresh = _descriptor(label="fresh")
+    registry.register(1, fresh)
+
+    removed = registry.purge_dead(threshold=timedelta(hours=6))
+
+    assert removed == 1
+    labels = [d.label for d in registry.list_for_chat(1)]
+    assert labels == ["fresh"]
+
+
+def test_purge_dead_returns_zero_when_all_fresh():
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    registry.register(1, _descriptor(label="A"))
+    registry.register(1, _descriptor(label="B"))
+
+    removed = registry.purge_dead(threshold=timedelta(hours=6))
+
+    assert removed == 0
+    assert len(registry.list_for_chat(1)) == 2

--- a/tests/test_mtproto.py
+++ b/tests/test_mtproto.py
@@ -15,6 +15,17 @@ from bot.mtproto import (
 )
 
 
+def _make_blocked_import(blocked: str):
+    real_import = __import__
+
+    def fake(name, *args, **kwargs):
+        if name == blocked or name.startswith(f"{blocked}."):
+            raise ImportError(f"blocked: {name}")
+        return real_import(name, *args, **kwargs)
+
+    return fake
+
+
 class TestIsMtprotoAvailable:
     """Tests for is_mtproto_available() configuration check."""
 
@@ -291,3 +302,95 @@ class TestSendVideoMtproto:
         with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
             result = asyncio.run(send_video_mtproto(123, str(video_file)))
             assert result is False
+
+
+def test_send_document_mtproto_returns_false_without_pyrogram(monkeypatch):
+    from bot import mtproto
+
+    monkeypatch.setattr(
+        "builtins.__import__",
+        _make_blocked_import("pyrogram"),
+    )
+    result = asyncio.run(
+        mtproto.send_document_mtproto(123, "/tmp/x.bin", caption="x")
+    )
+    assert result is False
+
+
+def test_send_document_mtproto_returns_false_without_credentials(monkeypatch):
+    from bot import mtproto
+
+    monkeypatch.setattr(
+        mtproto, "get_runtime_value",
+        lambda key, default="": "",
+    )
+    result = asyncio.run(
+        mtproto.send_document_mtproto(123, "/tmp/x.bin", caption="x")
+    )
+    assert result is False
+
+
+def test_send_document_mtproto_returns_false_on_invalid_api_id(monkeypatch):
+    from bot import mtproto
+
+    values = {"TELEGRAM_API_ID": "not-a-number", "TELEGRAM_API_HASH": "abc"}
+    monkeypatch.setattr(
+        mtproto, "get_runtime_value",
+        lambda key, default="": values.get(key, default),
+    )
+    result = asyncio.run(
+        mtproto.send_document_mtproto(123, "/tmp/x.bin", caption="x")
+    )
+    assert result is False
+
+
+def test_send_document_mtproto_invokes_send_document(tmp_path, monkeypatch):
+    from bot import mtproto
+    from unittest.mock import MagicMock
+
+    src = tmp_path / "vol.7z.001"
+    src.write_bytes(b"x" * 1024)
+
+    values = {
+        "TELEGRAM_API_ID": "12345",
+        "TELEGRAM_API_HASH": "abc",
+        "TELEGRAM_BOT_TOKEN": "token",
+    }
+    monkeypatch.setattr(
+        mtproto, "get_runtime_value",
+        lambda key, default="": values.get(key, default),
+    )
+
+    captured: dict = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def send_document(self, **kwargs):
+            captured["send_kwargs"] = kwargs
+
+    monkeypatch.setattr(mtproto, "_build_client", lambda *a, **kw: FakeClient())
+
+    mock_pyrogram = MagicMock()
+    with patch.dict('sys.modules', {'pyrogram': mock_pyrogram}):
+        result = asyncio.run(
+            mtproto.send_document_mtproto(
+                chat_id=42,
+                file_path=str(src),
+                caption="part 1",
+                file_name="playlist.7z.001",
+            )
+        )
+
+    assert result is True
+    assert captured["send_kwargs"]["chat_id"] == 42
+    assert captured["send_kwargs"]["document"] == str(src)
+    assert captured["send_kwargs"]["caption"] == "part 1"
+    assert captured["send_kwargs"]["file_name"] == "playlist.7z.001"

--- a/tests/test_mtproto.py
+++ b/tests/test_mtproto.py
@@ -4,6 +4,7 @@ Unit tests for bot.mtproto — MTProto large file transfer module.
 
 import asyncio
 import os
+from unittest import mock
 from unittest.mock import patch, AsyncMock, MagicMock
 
 from bot.mtproto import (
@@ -394,3 +395,47 @@ def test_send_document_mtproto_invokes_send_document(tmp_path, monkeypatch):
     assert captured["send_kwargs"]["document"] == str(src)
     assert captured["send_kwargs"]["caption"] == "part 1"
     assert captured["send_kwargs"]["file_name"] == "playlist.7z.001"
+
+
+def test_send_video_mtproto_attaches_task_to_cancellation(tmp_path, monkeypatch):
+    import asyncio
+    import sys
+    from bot import mtproto
+    from bot.jobs import JobCancellation
+
+    src = tmp_path / "vid.mp4"
+    src.write_bytes(b"x" * 1024)
+
+    values = {
+        "TELEGRAM_API_ID": "12345",
+        "TELEGRAM_API_HASH": "abc",
+        "TELEGRAM_BOT_TOKEN": "token",
+    }
+    monkeypatch.setattr(
+        mtproto, "get_runtime_value",
+        lambda key, default="": values.get(key, default),
+    )
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+    captured = {}
+
+    class FakeClient:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def send_video(self, **kwargs):
+            # Snapshot cancellation.pyrogram_task during upload.
+            captured["task"] = cancellation.pyrogram_task
+
+    monkeypatch.setattr(mtproto, "_build_client", lambda *a, **kw: FakeClient())
+    # Stub pyrogram import so the guard passes.
+    monkeypatch.setitem(sys.modules, "pyrogram", mock.MagicMock())
+
+    asyncio.run(
+        mtproto.send_video_mtproto(
+            chat_id=42, file_path=str(src), caption="x",
+            cancellation=cancellation,
+        )
+    )
+
+    assert captured["task"] is not None
+    assert isinstance(captured["task"], asyncio.Task)

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -3,6 +3,7 @@ Unit tests for playlist support.
 """
 
 import asyncio
+from unittest import mock
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 
 from bot.downloader import (
@@ -490,4 +491,55 @@ def test_handle_playlist_callback_pl_zip_dl_dispatches_to_archive_flow():
     assert kwargs["chat_id"] == 42
     assert kwargs["media_type"] == "audio"
     assert kwargs["format_choice"] == "mp3"
+    session_store.reset()
+
+
+def test_legacy_download_playlist_breaks_on_cancel(monkeypatch):
+    import asyncio
+    from bot.handlers import playlist_callbacks
+    from bot.jobs import JobRegistry
+    from bot.session_store import session_store, user_playlist_data
+
+    session_store.reset()
+    user_playlist_data[42] = {
+        "title": "Pl",
+        "entries": [
+            {"url": "u1", "title": "a"},
+            {"url": "u2", "title": "b"},
+            {"url": "u3", "title": "c"},
+        ],
+    }
+    test_registry = JobRegistry()
+    monkeypatch.setattr(playlist_callbacks, "job_registry", test_registry)
+
+    iter_count = {"n": 0}
+
+    async def fake_dl(*args, **kwargs):
+        iter_count["n"] += 1
+        if iter_count["n"] == 2:
+            # Cancel after 2nd iteration starts.
+            jobs = test_registry.list_for_chat(42)
+            test_registry.cancel(jobs[0].job_id, reason="t")
+
+    monkeypatch.setattr(
+        playlist_callbacks, "_download_single_playlist_item", fake_dl,
+    )
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 42
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+    context.bot.send_message = mock.AsyncMock()
+
+    asyncio.run(
+        playlist_callbacks.download_playlist(
+            update, context, "pl_dl_audio_mp3",
+        )
+    )
+
+    # Job unregistered.
+    assert test_registry.list_for_chat(42) == []
+    # Loop broke after 2nd iteration; 3rd not invoked.
+    assert iter_count["n"] == 2
     session_store.reset()

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -455,3 +455,39 @@ class TestProcessPlaylistLink:
         progress_msg.edit_text.assert_awaited_with(
             "Nie udało się pobrać informacji o playliście."
         )
+
+
+def test_handle_playlist_callback_pl_zip_dl_dispatches_to_archive_flow():
+    import asyncio
+    from unittest import mock
+    from bot.handlers import playlist_callbacks
+    from bot.session_store import session_store, user_playlist_data
+
+    session_store.reset()
+    user_playlist_data[42] = {
+        "title": "Pl",
+        "entries": [{"url": "u", "title": "a"}],
+    }
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 42
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    fake_flow = mock.AsyncMock()
+    with mock.patch(
+        "bot.handlers.playlist_callbacks.execute_playlist_archive_flow", fake_flow
+    ):
+        asyncio.run(
+            playlist_callbacks.handle_playlist_callback(
+                update, context, "pl_zip_dl_audio_mp3"
+            )
+        )
+
+    assert fake_flow.await_count == 1
+    kwargs = fake_flow.await_args.kwargs
+    assert kwargs["chat_id"] == 42
+    assert kwargs["media_type"] == "audio"
+    assert kwargs["format_choice"] == "mp3"
+    session_store.reset()

--- a/tests/test_playlist_service.py
+++ b/tests/test_playlist_service.py
@@ -42,3 +42,50 @@ def test_parse_playlist_download_choice_video():
 
     assert choice.media_type == "video"
     assert choice.format_choice == "720p"
+
+
+def test_parse_playlist_download_choice_recognizes_zip_prefix():
+    from bot.services.playlist_service import parse_playlist_download_choice
+
+    choice = parse_playlist_download_choice("pl_zip_dl_audio_mp3")
+
+    assert choice.media_type == "audio"
+    assert choice.format_choice == "mp3"
+    assert choice.as_archive is True
+
+
+def test_parse_playlist_download_choice_legacy_prefix_unchanged():
+    from bot.services.playlist_service import parse_playlist_download_choice
+
+    choice = parse_playlist_download_choice("pl_dl_audio_mp3")
+
+    assert choice.media_type == "audio"
+    assert choice.format_choice == "mp3"
+    assert choice.as_archive is False
+
+
+def test_build_playlist_message_includes_zip_buttons_when_archive_available():
+    from bot.services.playlist_service import build_playlist_message
+
+    msg, kb = build_playlist_message(
+        {"title": "X", "entries": [{"title": "a", "duration": 60}], "playlist_count": 1},
+        archive_available=True,
+    )
+
+    callback_data = [btn.callback_data for row in kb.inline_keyboard for btn in row]
+    assert "pl_dl_audio_mp3" in callback_data
+    assert "pl_zip_dl_audio_mp3" in callback_data
+    assert "pl_zip_dl_video_720p" in callback_data
+
+
+def test_build_playlist_message_hides_zip_buttons_when_archive_unavailable():
+    from bot.services.playlist_service import build_playlist_message
+
+    msg, kb = build_playlist_message(
+        {"title": "X", "entries": [{"title": "a", "duration": 60}], "playlist_count": 1},
+        archive_available=False,
+    )
+
+    callback_data = [btn.callback_data for row in kb.inline_keyboard for btn in row]
+    assert "pl_dl_audio_mp3" in callback_data
+    assert not any(cd.startswith("pl_zip_dl_") for cd in callback_data)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -48,3 +48,15 @@ def test_runtime_config_helpers_use_attached_runtime():
     assert get_config_for(context) is runtime.config
     assert get_config_value_for(context, "TELEGRAM_BOT_TOKEN") == "runtime-token"
     assert get_config_value_for(context, "MISSING", "fallback") == "fallback"
+
+
+def test_app_runtime_includes_archive_available_flag(monkeypatch):
+    from bot import runtime as runtime_module
+
+    monkeypatch.setattr("bot.archive.is_7z_available", lambda: True)
+    rt = runtime_module.build_app_runtime()
+    assert rt.archive_available is True
+
+    monkeypatch.setattr("bot.archive.is_7z_available", lambda: False)
+    rt = runtime_module.build_app_runtime()
+    assert rt.archive_available is False

--- a/tests/test_security_unit.py
+++ b/tests/test_security_unit.py
@@ -411,3 +411,17 @@ def test_playlist_archive_retention_defined():
     # Retention must expire before the 24h cleanup safety net so workspaces
     # eligible for retry never collide with the daily eviction.
     assert security_limits.PLAYLIST_ARCHIVE_RETENTION_MIN < 24 * 60
+
+
+def test_job_dead_age_constant_defined():
+    from bot import security_limits
+
+    assert security_limits.JOB_DEAD_AGE_HOURS == 6
+    assert security_limits.JOB_DEAD_AGE_HOURS > 0
+
+
+def test_job_terminate_grace_constant_defined():
+    from bot import security_limits
+
+    assert security_limits.JOB_TERMINATE_GRACE_SEC == 1.0
+    assert 0 < security_limits.JOB_TERMINATE_GRACE_SEC <= 5.0

--- a/tests/test_security_unit.py
+++ b/tests/test_security_unit.py
@@ -387,3 +387,24 @@ def test_register_pin_failure_returns_actual_attempt_after_reblock():
     )
     assert remaining == 0
     assert actual == 3  # Real attempt count, not capped at max_attempts
+
+
+def test_archive_volume_size_constants_defined():
+    from bot import security_limits
+
+    assert security_limits.MTPROTO_VOLUME_SIZE_MB == 1900
+    assert security_limits.BOTAPI_VOLUME_SIZE_MB == 49
+    assert security_limits.BOTAPI_VOLUME_SIZE_MB < security_limits.TELEGRAM_UPLOAD_LIMIT_MB
+
+
+def test_archive_item_size_limit_defined():
+    from bot import security_limits
+
+    assert security_limits.MAX_ARCHIVE_ITEM_SIZE_MB == 10240
+    assert security_limits.MAX_ARCHIVE_ITEM_SIZE_MB > security_limits.MAX_FILE_SIZE_MB
+
+
+def test_playlist_archive_retention_defined():
+    from bot import security_limits
+
+    assert security_limits.PLAYLIST_ARCHIVE_RETENTION_MIN == 60

--- a/tests/test_security_unit.py
+++ b/tests/test_security_unit.py
@@ -408,3 +408,6 @@ def test_playlist_archive_retention_defined():
     from bot import security_limits
 
     assert security_limits.PLAYLIST_ARCHIVE_RETENTION_MIN == 60
+    # Retention must expire before the 24h cleanup safety net so workspaces
+    # eligible for retry never collide with the daily eviction.
+    assert security_limits.PLAYLIST_ARCHIVE_RETENTION_MIN < 24 * 60

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -174,3 +174,63 @@ def test_session_context_value_with_runtime_ignores_legacy_user_data():
     )
 
     assert value is None
+
+
+def test_pending_archive_jobs_field_is_independent_per_chat():
+    from bot.session_store import (
+        ArchiveJobState,
+        pending_archive_jobs,
+        session_store,
+    )
+    from datetime import datetime
+    from pathlib import Path
+
+    session_store.reset()
+    state_a = ArchiveJobState(
+        file_path=Path("/tmp/a.mp4"),
+        title="A",
+        media_type="video",
+        format_choice="best",
+        file_size_mb=12.0,
+        use_mtproto=False,
+        created_at=datetime(2026, 5, 2, 12, 0, 0),
+    )
+    pending_archive_jobs[111] = {"tok-a": state_a}
+
+    state_b = ArchiveJobState(
+        file_path=Path("/tmp/b.mp4"),
+        title="B",
+        media_type="video",
+        format_choice="best",
+        file_size_mb=15.0,
+        use_mtproto=False,
+        created_at=datetime(2026, 5, 2, 12, 1, 0),
+    )
+    pending_archive_jobs[222] = {"tok-b": state_b}
+
+    assert pending_archive_jobs[111] == {"tok-a": state_a}
+    assert pending_archive_jobs[222] == {"tok-b": state_b}
+    session_store.reset()
+
+
+def test_archived_deliveries_field_holds_volume_state():
+    from bot.session_store import (
+        ArchivedDeliveryState,
+        archived_deliveries,
+        session_store,
+    )
+    from datetime import datetime
+    from pathlib import Path
+
+    session_store.reset()
+    delivery = ArchivedDeliveryState(
+        workspace=Path("/tmp/pl_ws"),
+        volumes=[Path("/tmp/pl_ws/x.7z.001"), Path("/tmp/pl_ws/x.7z.002")],
+        caption_prefix="My playlist",
+        use_mtproto=True,
+        created_at=datetime(2026, 5, 2, 12, 30, 0),
+    )
+    archived_deliveries[42] = {"tok-z": delivery}
+
+    assert archived_deliveries[42] == {"tok-z": delivery}
+    session_store.reset()

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -234,3 +234,28 @@ def test_archived_deliveries_field_holds_volume_state():
 
     assert archived_deliveries[42] == {"tok-z": delivery}
     session_store.reset()
+
+
+def test_partial_archive_workspaces_field_holds_state():
+    from bot.session_store import (
+        ArchivePartialState,
+        partial_archive_workspaces,
+        session_store,
+    )
+    from datetime import datetime
+    from pathlib import Path
+
+    session_store.reset()
+    state = ArchivePartialState(
+        workspace=Path("/tmp/ws"),
+        downloaded=[Path("/tmp/ws/a.mp3"), Path("/tmp/ws/b.mp3")],
+        title="My playlist",
+        media_type="audio",
+        format_choice="mp3",
+        use_mtproto=True,
+        created_at=datetime(2026, 5, 3, 10, 0, 0),
+    )
+    partial_archive_workspaces[55] = {"tok-1": state}
+
+    assert partial_archive_workspaces[55] == {"tok-1": state}
+    session_store.reset()

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -11,10 +11,12 @@ def test_stop_command_returns_empty_message_when_no_jobs():
     registry = JobRegistry()
     update = mock.MagicMock()
     update.effective_chat.id = 1
+    update.effective_user.id = 1
     update.effective_message.reply_text = mock.AsyncMock()
     context = mock.MagicMock()
 
-    with mock.patch("bot.telegram_commands.job_registry", registry):
+    with mock.patch("bot.telegram_commands.job_registry", registry), \
+         mock.patch("bot.telegram_commands._is_authorized", return_value=True):
         asyncio.run(telegram_commands.stop_command(update, context))
 
     update.effective_message.reply_text.assert_awaited_once()
@@ -42,10 +44,12 @@ def test_stop_command_lists_active_jobs():
 
     update = mock.MagicMock()
     update.effective_chat.id = 7
+    update.effective_user.id = 7
     update.effective_message.reply_text = mock.AsyncMock()
     context = mock.MagicMock()
 
-    with mock.patch("bot.telegram_commands.job_registry", registry):
+    with mock.patch("bot.telegram_commands.job_registry", registry), \
+         mock.patch("bot.telegram_commands._is_authorized", return_value=True):
         asyncio.run(telegram_commands.stop_command(update, context))
 
     text = update.effective_message.reply_text.await_args.args[0]

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -1,0 +1,113 @@
+"""Tests for /stop command handler and stop_* callback dispatcher."""
+
+from unittest import mock
+
+
+def test_stop_command_returns_empty_message_when_no_jobs():
+    import asyncio
+    from bot import telegram_commands
+    from bot.jobs import JobRegistry
+
+    registry = JobRegistry()
+    update = mock.MagicMock()
+    update.effective_chat.id = 1
+    update.effective_message.reply_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    with mock.patch("bot.telegram_commands.job_registry", registry):
+        asyncio.run(telegram_commands.stop_command(update, context))
+
+    update.effective_message.reply_text.assert_awaited_once()
+    text = update.effective_message.reply_text.await_args.args[0]
+    assert "Brak aktywnych operacji" in text
+
+
+def test_stop_command_lists_active_jobs():
+    import asyncio
+    from datetime import datetime
+    from bot import telegram_commands
+    from bot.jobs import JobDescriptor, JobRegistry
+
+    registry = JobRegistry()
+    registry.register(7, JobDescriptor(
+        job_id="", chat_id=7, kind="playlist_zip",
+        label="Playlist 7z (mp3) — [12/30]",
+        started_at=datetime.now(),
+    ))
+    registry.register(7, JobDescriptor(
+        job_id="", chat_id=7, kind="single_dl",
+        label="Pojedynczy plik (best)",
+        started_at=datetime.now(),
+    ))
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 7
+    update.effective_message.reply_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    with mock.patch("bot.telegram_commands.job_registry", registry):
+        asyncio.run(telegram_commands.stop_command(update, context))
+
+    text = update.effective_message.reply_text.await_args.args[0]
+    assert "Aktywne operacje (2)" in text
+    assert "Playlist 7z" in text
+    assert "Pojedynczy plik" in text
+    keyboard = update.effective_message.reply_text.await_args.kwargs["reply_markup"]
+    callback_data = [
+        btn.callback_data for row in keyboard.inline_keyboard for btn in row
+    ]
+    assert any(cb.startswith("stop_") for cb in callback_data)
+    assert "stop_all" in callback_data
+
+
+def test_stop_callback_cancels_specific_job():
+    import asyncio
+    from datetime import datetime
+    from bot.jobs import JobDescriptor, JobRegistry
+
+    registry = JobRegistry()
+    cancellation = registry.register(5, JobDescriptor(
+        job_id="", chat_id=5, kind="single_dl",
+        label="x", started_at=datetime.now(),
+    ))
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 5
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    with mock.patch("bot.telegram_commands.job_registry", registry):
+        from bot.telegram_commands import handle_stop_callback
+        asyncio.run(handle_stop_callback(update, context, f"stop_{cancellation.job_id}"))
+
+    assert cancellation.event.is_set()
+
+
+def test_stop_all_callback_cancels_every_job_in_chat():
+    import asyncio
+    from datetime import datetime
+    from bot.jobs import JobDescriptor, JobRegistry
+
+    registry = JobRegistry()
+    c1 = registry.register(8, JobDescriptor(
+        job_id="", chat_id=8, kind="single_dl",
+        label="A", started_at=datetime.now(),
+    ))
+    c2 = registry.register(8, JobDescriptor(
+        job_id="", chat_id=8, kind="playlist_zip",
+        label="B", started_at=datetime.now(),
+    ))
+
+    update = mock.MagicMock()
+    update.effective_chat.id = 8
+    update.callback_query = mock.MagicMock()
+    update.callback_query.edit_message_text = mock.AsyncMock()
+    context = mock.MagicMock()
+
+    with mock.patch("bot.telegram_commands.job_registry", registry):
+        from bot.telegram_commands import handle_stop_callback
+        asyncio.run(handle_stop_callback(update, context, "stop_all"))
+
+    assert c1.event.is_set()
+    assert c2.event.is_set()

--- a/tests/test_transcription_pipeline.py
+++ b/tests/test_transcription_pipeline.py
@@ -198,3 +198,45 @@ def test_api_timeout_during_post_processing_uses_raw_transcript(tmp_path):
             is_text_too_long_for_correction_fn=lambda _text: False,
             rmtree_fn=lambda _path: None,
         )
+
+
+def test_transcribe_mp3_file_breaks_on_cancel(tmp_path):
+    """When cancellation event is set before chunks start, no API calls are made."""
+
+    import asyncio
+    from bot.jobs import JobCancellation
+
+    cancellation = JobCancellation(job_id="t", event=asyncio.Event())
+    cancellation.event.set()
+
+    part = tmp_path / "audio_part1.mp3"
+    part.write_bytes(b"x")
+
+    source = tmp_path / "audio.mp3"
+    source.write_bytes(b"x" * 100)
+
+    api_called = {"n": 0}
+
+    def fake_transcribe(_path, _key, language=None, prompt=None):
+        api_called["n"] += 1
+        return "should not be called"
+
+    result = pipeline.transcribe_mp3_file(
+        str(source),
+        str(tmp_path),
+        cancellation=cancellation,
+        get_api_key_fn=lambda: "groq",
+        get_claude_api_key_fn=lambda: "",
+        split_mp3_fn=lambda *_args, **_kwargs: [str(part)],
+        get_part_number_fn=lambda _filename: 1,
+        transcribe_audio_fn=fake_transcribe,
+        post_process_transcript_fn=lambda text, api_key=None: None,
+        estimate_token_count_fn=lambda text: len(text),
+        is_text_too_long_for_correction_fn=lambda _text: False,
+        rmtree_fn=lambda _path: None,
+    )
+
+    # API must NOT be called for any chunk when cancellation is already set.
+    assert api_called["n"] == 0
+    # Result must indicate cancel (None or "cancelled"/"anulowano" string).
+    assert result is None or "anulowano" in str(result).lower() or "cancelled" in str(result).lower()

--- a/tests/test_transcription_service.py
+++ b/tests/test_transcription_service.py
@@ -33,7 +33,7 @@ def test_run_transcription_with_progress_returns_transcript_path(monkeypatch, tm
     monkeypatch.setattr(
         ts,
         "transcribe_mp3_file",
-        lambda source_path, output_dir, progress_callback, language=None: (
+        lambda source_path, output_dir, progress_callback, language=None, cancellation=None: (
             progress_callback("step 1"),
             str(tmp_path / "audio_transcript.md"),
         )[1],


### PR DESCRIPTION
## Summary

Two new features for the YouTube/Telegram bot:

### 1. `/stop` cancel-operations command
List active long-running operations per chat and cancel them — individually or all at once. Works for: playlist downloads (legacy + 7z), single-file downloads, 7z packing, MTProto volume sending, transcription, summaries. Mechanism: a single shared `JobCancellation` (`asyncio.Event` + optional subprocess + optional pyrogram task) consumed natively by each layer. After cancel during a playlist 7z flow, downloaded files are preserved for the existing 60-min retention; status message gets `[Spakuj co mam]` + `[Usuń teraz]` recovery buttons.

### 2. 7z multi-volume archive download mode
New "… jako 7z" buttons in the playlist menu. The bot keeps downloaded items, packs them into 7z multi-volume archives sized for the active Telegram transport (~1900 MB with MTProto, ~49 MB without), and ships only the volumes. Same mechanism is a fallback when a single file exceeds the active limit ("Cancel / Send as 7z" choice instead of a hard error). Workspaces preserved for 60-min retention; recovery buttons let the user retry or purge without re-downloading.

Plus an upstream merge bringing in the platform registry refactor and X (Twitter) support from a parallel development line.

## Test plan
- [ ] Run pytest: `source /home/pi/venv/bin/activate && pytest tests/` — expect 745 pass + 1 pre-existing fail (`test_no_legacy_node_manifests_in_project_root`, unrelated to this PR)
- [ ] `/stop` with no active operations → "Brak aktywnych operacji."
- [ ] Cancel playlist 7z mid-download → `[Spakuj co mam]` button packs the downloaded subset
- [ ] Cancel 7z packing → status `⏹`, no `.7z.001` files left in workspace
- [ ] Cancel MTProto upload after 3/8 volumes → 3 volumes in chat, `[Wznów od 4]` resumes from index
- [ ] Cancel transcription mid-chunks → status `⏹`, audio source kept until 24h cleanup
- [ ] Two parallel jobs + `Zatrzymaj wszystkie` → both stopped
- [ ] Zombie cleanup after 7h → entry disappears + warning logged
- [ ] Playlist 7z happy path: 5×audio_mp3 → 1 volume, opens in 7-Zip on Windows
- [ ] Playlist 7z with 30×video_720p → multi-volume archive, sumarycznie > 1900 MB
- [ ] Single-file > limit fallback → `[Wyślij jako 7z] [Anuluj]` buttons